### PR TITLE
inv(::StaticMatrix) should always return StaticMatrix

### DIFF
--- a/src/inv.jl
+++ b/src/inv.jl
@@ -40,7 +40,7 @@
             else
                 Ai = inv(lufact(AA))
             end
-            return convert(typeof(parent(Ai)), Ai)
+            return convert($newtype, Ai)
         end
     end
 end


### PR DESCRIPTION
Currently, `inv(SMatrix{4, 4}(rand(Float32, 4, 4)))` returns an `Array{Float32, 2}`.

I think it should return a `SMatrix{4, 4}`.
