### PR TITLE
Define conversion and promotion for CartesianIndex

### DIFF
--- a/src/SVector.jl
+++ b/src/SVector.jl
@@ -53,6 +53,12 @@ end
     Base.unsafe_convert(Ptr{T}, Base.data_pointer_from_objref(v))
 end
 
+# Converting a CartesianIndex to an SVector
+convert(::Type{SVector}, I::CartesianIndex) = SVector(I.I)
+convert{N}(::Type{SVector{N}}, I::CartesianIndex{N}) = SVector{N}(I.I)
+convert{N,T}(::Type{SVector{N,T}}, I::CartesianIndex{N}) = SVector{N,T}(I.I)
+
+Base.promote_rule{N,T}(::Type{SVector{N,T}}, ::Type{CartesianIndex{N}}) = SVector{N,promote_type(T,Int)}
 
 macro SVector(ex)
     if isa(ex, Expr) && ex.head == :vect

--- a/test/SVector.jl
+++ b/test/SVector.jl
@@ -59,4 +59,11 @@
 
         @test_throws Exception v[1] = 1
     end
+
+    @testset "CartesianIndex" begin
+        a, b = SVector(0x01, 0x02), SVector(1.0f0, 1.2f0)
+        c = CartesianIndex((1,2))
+        @test @inferred(eltype([a,c])) == SVector{2,Int}
+        @test @inferred(eltype([b,c])) == SVector{2,Float32}
+    end
 end


### PR DESCRIPTION
This is an alternative---more minimalist---version of #47. It's not quite as convenient for the user, but it has one big advantage: this approach prevents "mission creep" in needing to define more and more methods for `CartesianIndex`. On balance I slightly favor this approach, but it's a close thing.