### PR TITLE
Added a `Scalar` type for 0-dimensional array

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,18 @@ easier to define the types without the extra tuple characters (compare
 because it is so easy to define new `StaticArray` subtypes, and they naturally
 work together.
 
+### `Scalar`
+
+Sometimes you want to broadcast an operation, but not over one of your inputs.
+A classic example is attempting to displace a collection of vectors by the
+same vector. We can now do this with the `Scalar` type:
+
+```julia
+[[1,2,3], [4,5,6]] .+ Scalar([1,0,-1]) # [[2,2,2], [5,5,5]]
+```
+
+`Scalar` is simply an implementation of an immutable, 0-dimensional `StaticArray`.
+
 ### Mutable arrays: `MVector`, `MMatrix` and `MArray`
 
 These statically sized arrays are identical to the above, but are defined as

--- a/src/Scalar.jl
+++ b/src/Scalar.jl
@@ -1,0 +1,20 @@
+"""
+    Scalar{T}(x::T)
+
+Construct a statically-sized 0-dimensional array that contains a single element,
+`x`. This type is particularly useful for influencing broadcasting operations.
+"""
+immutable Scalar{T} <: StaticArray{T,0}
+    data::T
+end
+
+@inline (::Type{Scalar}){T}(x::Tuple{T}) = Scalar{T}(x[1])
+
+@pure size(::Type{Scalar}) = ()
+@pure size{T}(::Type{Scalar{T}}) = ()
+
+@inline function getindex(v::Scalar)
+    v.data
+end
+
+@inline Tuple(v::Scalar) = (v.data,)

--- a/src/Scalar.jl
+++ b/src/Scalar.jl
@@ -8,13 +8,20 @@ immutable Scalar{T} <: StaticArray{T,0}
     data::T
 end
 
-@inline (::Type{Scalar}){T}(x::Tuple{T}) = Scalar{T}(x[1])
+@inline (::Type{Scalar{T}}){T}(x::Tuple{T}) = Scalar{T}(x[1])
 
 @pure size(::Type{Scalar}) = ()
 @pure size{T}(::Type{Scalar{T}}) = ()
 
-@inline function getindex(v::Scalar)
+getindex(v::Scalar) = v.data
+@inline function getindex(v::Scalar, i::Int)
+    @boundscheck if i != 1
+        error("Attempt to index Scalar at index $i")
+    end
     v.data
 end
 
 @inline Tuple(v::Scalar) = (v.data,)
+
+# A lot more compact than the default array show
+Base.show{T}(io::IO, ::MIME"text/plain", x::Scalar{T}) = print(io, "Scalar{$T}(", x.data, ")")

--- a/src/StaticArrays.jl
+++ b/src/StaticArrays.jl
@@ -8,8 +8,8 @@ import Base: @pure, @propagate_inbounds, getindex, setindex!, size, similar,
              ones, zeros, eye, cross, vecdot, reshape, fill, fill!, det, inv,
              eig, trace, vecnorm, dot
 
-export StaticArray, StaticVector, StaticMatrix
-export SArray, SVector, SMatrix
+export StaticScalar, StaticArray, StaticVector, StaticMatrix
+export Scalar, SArray, SVector, SMatrix
 export MArray, MVector, MMatrix
 export FieldVector, MutableFieldVector
 
@@ -21,6 +21,7 @@ export similar_type
 include("util.jl")
 
 include("core.jl")
+include("Scalar.jl")
 include("SVector.jl")
 include("FieldVector.jl")
 include("SMatrix.jl")

--- a/src/abstractarray.jl
+++ b/src/abstractarray.jl
@@ -1,4 +1,7 @@
+typealias StaticScalar{T} StaticArray{T,0}
+
 @pure length{T<:StaticArray}(a::Union{T,Type{T}}) = prod(size(a))
+@pure length{T<:StaticScalar}(a::Union{T,Type{T}}) = 1
 
 @pure function size{T<:StaticArray}(a::Union{T,Type{T}}, d::Integer)
     s = size(a)

--- a/src/abstractarray.jl
+++ b/src/abstractarray.jl
@@ -107,6 +107,7 @@ end
 
 # Some fallbacks
 
+@pure similar_type{SA<:StaticArray}(::Union{SA,Type{SA}}, size::Tuple{}) = Scalar{eltype(SA)} # No mutable fallback here...
 @pure similar_type{SA<:StaticArray}(::Union{SA,Type{SA}}, size::Int) = SVector{size, eltype(SA)}
 @pure similar_type{SA<:StaticArray}(::Union{SA,Type{SA}}, sizes::Tuple{Int}) = SVector{sizes[1], eltype(SA)}
 

--- a/test/Scalar.jl
+++ b/test/Scalar.jl
@@ -1,0 +1,4 @@
+@testset "Scalar" begin
+    @test Scalar(2) .* [1, 2, 3] == [2, 4, 6]
+    @test Scalar([1 2; 3 4]) .+ [[1 1; 1 1], [2 2; 2 2]] == [[2 3; 4 5], [3 4; 5 6]]
+end

--- a/test/Scalar.jl
+++ b/test/Scalar.jl
@@ -1,4 +1,5 @@
 @testset "Scalar" begin
     @test Scalar(2) .* [1, 2, 3] == [2, 4, 6]
     @test Scalar([1 2; 3 4]) .+ [[1 1; 1 1], [2 2; 2 2]] == [[2 3; 4 5], [3 4; 5 6]]
+    @test (Scalar(1) + Scalar(1.0))::Scalar{Float64} ≈ Scalar(2.0)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,7 @@ using Base.Test
     include("SArray.jl")
     include("MArray.jl")
     include("FieldVector.jl")
+    include("Scalar.jl")
 
     include("core.jl")
     include("abstractarray.jl")


### PR DESCRIPTION
Better than `Array{T,0}` and `Ref` as scalar containers since this is immutable. It's useful for controlling broadcasting. Here is an example:

```
julia> using StaticArrays

julia> s = Scalar(SVector(1,2,3))
0-dimensional StaticArrays.Scalar{StaticArrays.SVector{3,Int64}}:
[1,2,3]

julia> v = [SVector(1,2,3), SVector(0,0,0), SVector(10,10,10)]
3-element Array{StaticArrays.SVector{3,Int64},1}:
 [1,2,3]   
 [0,0,0]   
 [10,10,10]

julia> v .+ s
3-element Array{StaticArrays.SVector{3,Int64},1}:
 [2,4,6]   
 [1,2,3]   
 [11,12,13]
```

See some relevant discussions at:

https://github.com/JuliaArrays/StaticArrays.jl/issues/45#issuecomment-252975952
https://github.com/JuliaLang/julia/issues/18379
https://github.com/JuliaLang/julia/pull/18766#issuecomment-253031994