### PR TITLE
`Size` traits

### DIFF
--- a/src/StaticArrays.jl
+++ b/src/StaticArrays.jl
@@ -13,6 +13,8 @@ export Scalar, SArray, SVector, SMatrix
 export MArray, MVector, MMatrix
 export FieldVector, MutableFieldVector
 
+export Size, SizeOf
+
 export @SVector, @SMatrix, @SArray
 export @MVector, @MMatrix, @MArray
 
@@ -21,6 +23,7 @@ export similar_type
 include("util.jl")
 
 include("core.jl")
+include("traits.jl")
 include("Scalar.jl")
 include("SVector.jl")
 include("FieldVector.jl")
@@ -29,7 +32,6 @@ include("SArray.jl")
 include("MVector.jl")
 include("MMatrix.jl")
 include("MArray.jl")
-
 
 include("indexing.jl")
 include("abstractarray.jl")

--- a/src/StaticArrays.jl
+++ b/src/StaticArrays.jl
@@ -13,7 +13,7 @@ export Scalar, SArray, SVector, SMatrix
 export MArray, MVector, MMatrix
 export FieldVector, MutableFieldVector
 
-export Size, SizeOf
+export Size
 
 export @SVector, @SMatrix, @SArray
 export @MVector, @MMatrix, @MArray

--- a/src/det.jl
+++ b/src/det.jl
@@ -1,4 +1,4 @@
-@inline det(A::StaticMatrix) = det(SizeOf(A), A)
+@inline det(A::StaticMatrix) = _det(Size(A), A)
 
 """
     det(Size(m,m), mat)
@@ -6,20 +6,20 @@
 Calculate the matrix determinate using an algorithm specialized on the size of
 the `m`×`m` matrix `mat`, which is much faster for small matrices.
 """
-@inline det(::Type{Size{(1,1)}}, A::AbstractMatrix) = @inbounds return A[1]
+@inline _det(::Size{(1,1)}, A::AbstractMatrix) = @inbounds return A[1]
 
-@inline function det(::Type{Size{(2,2)}}, A::AbstractMatrix)
+@inline function _det(::Size{(2,2)}, A::AbstractMatrix)
     @inbounds return A[1]*A[4] - A[3]*A[2]
 end
 
-@inline function det(::Type{Size{(3,3)}}, A::AbstractMatrix)
+@inline function _det(::Size{(3,3)}, A::AbstractMatrix)
     @inbounds x0 = SVector(A[1], A[2], A[3])
     @inbounds x1 = SVector(A[4], A[5], A[6])
     @inbounds x2 = SVector(A[7], A[8], A[9])
     return vecdot(x0, cross(x1, x2))
 end
 
-@generated function det{S,T}(::Type{Size{S}}, A::AbstractMatrix{T})
+@generated function _det{S,T}(::Size{S}, A::AbstractMatrix{T})
     if S[1] != S[2]
         throw(DimensionMismatch("matrix is not square"))
     end

--- a/src/det.jl
+++ b/src/det.jl
@@ -1,36 +1,34 @@
+@inline det(A::StaticMatrix) = det(SizeOf(A), A)
 
-@generated function det{T}(A::StaticMatrix{T})
-    if size(A) == (1,1)
-        return quote
-            $(Expr(:meta, :inline))
-            @inbounds return A[1]
-        end
-    elseif size(A) == (2,2)
-        return quote
-            $(Expr(:meta, :inline))
-            @inbounds return A[1]*A[4] - A[3]*A[2]
-        end
-    elseif size(A) == (3,3)
-        return quote
-            $(Expr(:meta, :inline))
-            #@inbounds a = A[5]*A[9] - A[8]*A[6]
-            #@inbounds b = A[8]*A[3] - A[2]*A[9]
-            #@inbounds c = A[2]*A[6] - A[5]*A[3]
-            #@inbounds return A[1]*a + A[4]*b + A[7]*c
+"""
+    det(Size(m,m), mat)
 
-            @inbounds x0 = SVector(A[1], A[2], A[3])
-            @inbounds x1 = SVector(A[4], A[5], A[6])
-            @inbounds x2 = SVector(A[7], A[8], A[9])
-            return vecdot(x0, cross(x1, x2))
+Calculate the matrix determinate using an algorithm specialized on the size of
+the `m`×`m` matrix `mat`, which is much faster for small matrices.
+"""
+@inline det(::Type{Size{(1,1)}}, A::AbstractMatrix) = @inbounds return A[1]
+
+@inline function det(::Type{Size{(2,2)}}, A::AbstractMatrix)
+    @inbounds return A[1]*A[4] - A[3]*A[2]
+end
+
+@inline function det(::Type{Size{(3,3)}}, A::AbstractMatrix)
+    @inbounds x0 = SVector(A[1], A[2], A[3])
+    @inbounds x1 = SVector(A[4], A[5], A[6])
+    @inbounds x2 = SVector(A[7], A[8], A[9])
+    return vecdot(x0, cross(x1, x2))
+end
+
+@generated function det{S,T}(::Type{Size{S}}, A::AbstractMatrix{T})
+    if S[1] != S[2]
+        throw(DimensionMismatch("matrix is not square"))
+    end
+    T2 = typeof((one(T)*zero(T) + zero(T))/one(T))
+    return quote # Implementation from Base
+        if istriu(A) || istril(A)
+            return convert($T2, det(UpperTriangular(A)))::$T2 # Is this a Julia bug that a convert is not type stable??
         end
-    else
-        S = typeof((one(T)*zero(T) + zero(T))/one(T))
-        return quote # Implementation from Base
-            if istriu(A) || istril(A)
-                return convert($S, det(UpperTriangular(A)))::$S # Is this a Julia bug that a convert is not type stable??
-            end
-            AA = convert(Array{$S}, A)
-            return det(lufact(AA))
-        end
+        AA = convert(Array{$T2}, A)
+        return det(lufact(AA))
     end
 end

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -1,70 +1,48 @@
 """
-    SizeOf(static_array)
-
-Returns the size of a static array, wrapped in a `Size` trait such as
-`Size{(2,3)}` for a 2×3 matrix.
-
-`SizeOf` implements the "traitor" paradigm for traits, whereby an abstract trait
-class `SizeOf` returns a direct subtype, in this case `Size`.
-
-For example,
-```
-det(x::StaticMatrix) = det(SizeOf(x), x)
-det(::Type{Size{1,1}}, x::AbstractMatrix) = x[1,1]
-det(::Type{Size{2,2}}, x::AbstractMatrix) = x[1,1]*x[2,2] - x[1,2]*x[2,1]
-# and other definitions as necessary
-```
-"""
-abstract SizeOf
-
-
-"""
-    Size{(dims...)} <: SizeOf
-
-A trait type allowing convenient trait-based dispatch on the size of a statically
-sized array.
-
-`Size` implements the "traitor" paradigm for traits, whereby an abstract trait
-class `SizeOf` returns a direct subtype, in this case `Size`.
-
-For example,
-```
-det(x::StaticMatrix) = det(SizeOf(x), x)
-det(::Type{Size{1,1}}, x::AbstractMatrix) = x[1,1]
-det(::Type{Size{2,2}}, x::AbstractMatrix) = x[1,1]*x[2,2] - x[1,2]*x[2,1]
-# and other definitions as necessary
-```
-"""
-immutable Size{S} <: SizeOf
-end
-
-@pure SizeOf{SA<:StaticArray}(::Type{SA}) = Size{size(SA)}
-@inline SizeOf(a::StaticArray) = Size(typeof(a))
-
-# Also define these, since may be more convenient than SizeOf
-"""
     Size(static_array)
     Size(StaticArrayType)
-
-Convenience constructor for the `Size` of a static array. See also `SizeOf`.
-"""
-@pure Size{SA<:StaticArray}(::Type{SA}) = Size{size(SA)}
-@inline Size(a::StaticArray) = Size(typeof(a))
-
-"""
-    Size((dims...))
     Size(dims...)
 
-Pure function that constructs a compile-time constant `Size` of an array. This
-allows for dispatch of standard (dynamically-sized) arrays to faster, specialized
-*StaticArrays* library methods when the programmer knows or can reasonably infer
-the size. For example,
+A trait type allowing convenient trait-based dispatch on the size of a statically
+sized array. The dimensions are stored as a type parameter and are statically
+propagated by the compiler.
+
+For example,
 ```
-mat = [1.0 2.0; 3.0 4.0]
-det(Size(2,2), mat)  # Faster than det(mat)
+det(x::StaticMatrix) = _det(Size(x), x)
+_det(::Size{(1,1)}, x::StaticMatrix) = x[1,1]
+_det(::Size{(2,2)}, x::StaticMatrix) = x[1,1]*x[2,2] - x[1,2]*x[2,1]
+# and other definitions as necessary
 ```
 """
-@pure Size(s::Tuple{Vararg{Int}}) = Size{s}
-@pure Size(s::Int...) = Size{s}
+immutable Size{S}
+    function Size()
+        check_size(S)
+        new()
+    end
+end
 
-@pure getindex{S}(::Type{Size{S}}, i::Int) = S[i]
+@pure check_size(S::Tuple{Vararg{Int}}) = nothing
+check_size(S) = error("Size was expected to be a tuple of `Int`s")
+
+@pure Size{SA<:StaticArray}(::Type{SA}) = Size{size(SA)}()
+@inline Size(a::StaticArray) = Size(typeof(a))
+
+@pure Size(s::Tuple{Vararg{Int}}) = Size{s}()
+@pure Size(s::Int...) = Size{s}()
+
+Base.show{S}(io::IO, ::Size{S}) = print(io, "Size", S)
+
+
+# Some @pure convenience functions.
+
+# (This type could *probably* be returned from the `size()` function.
+# This might enable some generic programming, e.g. with `similar(A, size(A))`.)
+
+@pure getindex{S}(::Size{S}, i::Int) = S[i]
+
+@pure Base.:(==){S}(::Size{S}, s::Tuple{Vararg{Int}}) = S == s
+@pure Base.:(==){S}(s::Tuple{Vararg{Int}}, ::Size{S}) = s == S
+
+@pure Base.:(!=){S}(::Size{S}, s::Tuple{Vararg{Int}}) = S != s
+@pure Base.:(!=){S}(s::Tuple{Vararg{Int}}, ::Size{S}) = s != S

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -1,0 +1,70 @@
+"""
+    SizeOf(static_array)
+
+Returns the size of a static array, wrapped in a `Size` trait such as
+`Size{(2,3)}` for a 2×3 matrix.
+
+`SizeOf` implements the "traitor" paradigm for traits, whereby an abstract trait
+class `SizeOf` returns a direct subtype, in this case `Size`.
+
+For example,
+```
+det(x::StaticMatrix) = det(SizeOf(x), x)
+det(::Type{Size{1,1}}, x::AbstractMatrix) = x[1,1]
+det(::Type{Size{2,2}}, x::AbstractMatrix) = x[1,1]*x[2,2] - x[1,2]*x[2,1]
+# and other definitions as necessary
+```
+"""
+abstract SizeOf
+
+
+"""
+    Size{(dims...)} <: SizeOf
+
+A trait type allowing convenient trait-based dispatch on the size of a statically
+sized array.
+
+`Size` implements the "traitor" paradigm for traits, whereby an abstract trait
+class `SizeOf` returns a direct subtype, in this case `Size`.
+
+For example,
+```
+det(x::StaticMatrix) = det(SizeOf(x), x)
+det(::Type{Size{1,1}}, x::AbstractMatrix) = x[1,1]
+det(::Type{Size{2,2}}, x::AbstractMatrix) = x[1,1]*x[2,2] - x[1,2]*x[2,1]
+# and other definitions as necessary
+```
+"""
+immutable Size{S} <: SizeOf
+end
+
+@pure SizeOf{SA<:StaticArray}(::Type{SA}) = Size{size(SA)}
+@inline SizeOf(a::StaticArray) = Size(typeof(a))
+
+# Also define these, since may be more convenient than SizeOf
+"""
+    Size(static_array)
+    Size(StaticArrayType)
+
+Convenience constructor for the `Size` of a static array. See also `SizeOf`.
+"""
+@pure Size{SA<:StaticArray}(::Type{SA}) = Size{size(SA)}
+@inline Size(a::StaticArray) = Size(typeof(a))
+
+"""
+    Size((dims...))
+    Size(dims...)
+
+Pure function that constructs a compile-time constant `Size` of an array. This
+allows for dispatch of standard (dynamically-sized) arrays to faster, specialized
+*StaticArrays* library methods when the programmer knows or can reasonably infer
+the size. For example,
+```
+mat = [1.0 2.0; 3.0 4.0]
+det(Size(2,2), mat)  # Faster than det(mat)
+```
+"""
+@pure Size(s::Tuple{Vararg{Int}}) = Size{s}
+@pure Size(s::Int...) = Size{s}
+
+@pure getindex{S}(::Type{Size{S}}, i::Int) = S[i]


### PR DESCRIPTION
Adds a trait-based scheme for dispatch on the size of a statically-sized arrays. The `Size{(m,n,...)}` type represents the trait (and currently isn't constructed). It's abstract supertype `SizeOf` helps implement the "traitor" style of automated trait dispatch whereby a supertype is used to construct a trait.

One standout feature is that it allows me to relax the type signature of a size-dispatched method to `AbstractArray`. As an example, similar methods to these are now defined:

```julia
det(x::StaticMatrix) = det(SizeOf(x), x)
det(::Type{Size{(1,1)}}, x::AbstractMatrix) = x[1,1]
det(::Type{Size{(2,2)}}, x::AbstractMatrix) = x[1,1]*x[2,2] - x[1,2]*x[2,1]
# and other definitions as necessary
```

Using BenchmarkTools we see a 6.5x speedup on the 2x2 case:
```
julia> using StaticArrays, BenchmarkTools

julia> mat = [1.0 2.0; 3.0 4.0]
2×2 Array{Float64,2}:
 1.0  2.0
 3.0  4.0

julia> @benchmark det(mat)
BenchmarkTools.Trial:
  samples:          10000
  evals/sample:     455
  time tolerance:   5.00%
  memory tolerance: 1.00%
  memory estimate:  320.00 bytes
  allocs estimate:  7
  minimum time:     235.00 ns (0.00% GC)
  median time:      243.00 ns (0.00% GC)
  mean time:        280.85 ns (10.09% GC)
  maximum time:     6.76 μs (93.27% GC)

julia> @benchmark det(Size(2,2),mat)
BenchmarkTools.Trial:
  samples:          10000
  evals/sample:     997
  time tolerance:   5.00%
  memory tolerance: 1.00%
  memory estimate:  16.00 bytes
  allocs estimate:  1
  minimum time:     36.00 ns (0.00% GC)
  median time:      37.00 ns (0.00% GC)
  mean time:        38.60 ns (1.35% GC)
  maximum time:     1.34 μs (96.21% GC)
```
There was also a 7x speedup for the 3x3 case. Obviously static arrays were already getting this benefit but this might be easier to use than `MMatrix` for example.

CC @c42f @timholy @SimonDanisch 