### PR TITLE
Add `SizedArray` wrapper for `Array`

### DIFF
--- a/src/SizedArray.jl
+++ b/src/SizedArray.jl
@@ -1,0 +1,46 @@
+
+"""
+    SizedArray{(dims...)}(array)
+
+Wraps an `Array` with a static size, so to take advantage of the (faster)
+methods defined by the static array package. The size is checked once upon
+construction.
+
+(Also, `Size(dims...)(array)` acheives the same thing)
+"""
+immutable SizedArray{S,T,N} <: StaticArray{T,N}
+    data::Array{T,N}
+
+    function SizedArray(a)
+        if size(a) != S
+            error("Dimensions $(size(a)) don't match static size $S")
+        end
+        new(a)
+    end
+end
+
+@inline (::Type{SizedArray{S,T}}){S,T,N}(a::Array{T,N}) = SizedArray{S,T,N}(a)
+@inline (::Type{SizedArray{S}}){S,T,N}(a::Array{T,N}) = SizedArray{S,T,N}(a)
+
+@pure size{S}(::Type{SizedArray{S}}) = S
+@pure size{S,T}(::Type{SizedArray{S,T}}) = S
+@pure size{S,T,N}(::Type{SizedArray{S,T,N}}) = S
+
+@propagate_inbounds getindex(a::SizedArray, i::Int) = getindex(a.data, i...)
+@propagate_inbounds setindex!(a::SizedArray, v, i::Int) = setindex!(a.data, v, i...)
+
+typealias SizedVector{S,T} SizedArray{S,T,1}
+@inline (::Type{SizedVector{S}}){S,T}(a::Vector{T}) = SizedArray{S,T,1}(a)
+
+typealias SizedMatrix{S,T} SizedArray{S,T,2}
+@inline (::Type{SizedMatrix{S}}){S,T}(a::Matrix{T}) = SizedArray{S,T,2}(a)
+
+
+"""
+    Size(dims)(array)
+
+Creates a `SizedArray` wrapping `array` with the specified statically-known
+`dims`, so to take advantage of the (faster) methods defined by the static array
+package.
+"""
+(::Size{S}){S}(a::Array) = SizedArray{S}(a)

--- a/src/StaticArrays.jl
+++ b/src/StaticArrays.jl
@@ -12,6 +12,7 @@ export StaticScalar, StaticArray, StaticVector, StaticMatrix
 export Scalar, SArray, SVector, SMatrix
 export MArray, MVector, MMatrix
 export FieldVector, MutableFieldVector
+export SizedArray, SizedVector, SizedMatrix
 
 export Size
 
@@ -32,6 +33,7 @@ include("SArray.jl")
 include("MVector.jl")
 include("MMatrix.jl")
 include("MArray.jl")
+include("SizedArray.jl")
 
 include("indexing.jl")
 include("abstractarray.jl")

--- a/src/abstractarray.jl
+++ b/src/abstractarray.jl
@@ -116,12 +116,12 @@ end
 @pure similar_type{SA<:StaticArray,N}(::Union{SA,Type{SA}}, sizes::Tuple{Vararg{Int,N}}) = SArray{sizes, eltype(SA), N, prod(sizes)}
 
 # Some specializations for the mutable case
-@pure similar_type{MA<:Union{MVector,MMatrix,MArray}}(::Union{MA,Type{MA}}, size::Int) = MVector{size, eltype(MA)}
-@pure similar_type{MA<:Union{MVector,MMatrix,MArray}}(::Union{MA,Type{MA}}, sizes::Tuple{Int}) = MVector{sizes[1], eltype(MA)}
+@pure similar_type{MA<:Union{MVector,MMatrix,MArray,SizedArray}}(::Union{MA,Type{MA}}, size::Int) = MVector{size, eltype(MA)}
+@pure similar_type{MA<:Union{MVector,MMatrix,MArray,SizedArray}}(::Union{MA,Type{MA}}, sizes::Tuple{Int}) = MVector{sizes[1], eltype(MA)}
 
-@pure similar_type{MA<:Union{MVector,MMatrix,MArray}}(::Union{MA,Type{MA}}, sizes::Tuple{Int,Int}) = MMatrix{sizes[1], sizes[2], eltype(MA), sizes[1]*sizes[2]}
+@pure similar_type{MA<:Union{MVector,MMatrix,MArray,SizedArray}}(::Union{MA,Type{MA}}, sizes::Tuple{Int,Int}) = MMatrix{sizes[1], sizes[2], eltype(MA), sizes[1]*sizes[2]}
 
-@pure similar_type{MA<:Union{MVector,MMatrix,MArray},N}(::Union{MA,Type{MA}}, sizes::Tuple{Vararg{Int,N}}) = MArray{sizes, eltype(MA), N, prod(sizes)}
+@pure similar_type{MA<:Union{MVector,MMatrix,MArray,SizedArray},N}(::Union{MA,Type{MA}}, sizes::Tuple{Vararg{Int,N}}) = MArray{sizes, eltype(MA), N, prod(sizes)}
 
 # And also similar() returning mutable StaticArrays
 @inline similar{SV <: StaticVector}(::SV) = MVector{length(SV),eltype(SV)}()

--- a/src/det.jl
+++ b/src/det.jl
@@ -1,11 +1,5 @@
 @inline det(A::StaticMatrix) = _det(Size(A), A)
 
-"""
-    det(Size(m,m), mat)
-
-Calculate the matrix determinate using an algorithm specialized on the size of
-the `m`×`m` matrix `mat`, which is much faster for small matrices.
-"""
 @inline _det(::Size{(1,1)}, A::AbstractMatrix) = @inbounds return A[1]
 
 @inline function _det(::Size{(2,2)}, A::AbstractMatrix)


### PR DESCRIPTION
Now allows `Array` to use the (faster) algorithms from StaticArrays.jl, if the user knows the dimensions at compile-time. A convenience constructor from calling a `Size` instance is provided, e.g.
```julia
julia> Size(2,2)(rand(2,2))
2×2 StaticArrays.SizedArray{(2,2),Float64,2}:
 0.367002  0.592863
 0.725256  0.151296

julia> det(ans)  # Uses a StaticArrays `det()` method
-0.3744516359087295
```
