### PR TITLE
Workaround for comprehensions built from svectors

### DIFF
--- a/src/SArray.jl
+++ b/src/SArray.jl
@@ -145,7 +145,7 @@ macro SArray(ex)
         ex = ex.args[1]
         n_rng = length(ex.args) - 1
         rng_args = [ex.args[i+1].args[1] for i = 1:n_rng]
-        rngs = [eval(current_module(), ex.args[i+1].args[2]) for i = 1:n_rng]
+        rngs = Any[eval(current_module(), ex.args[i+1].args[2]) for i = 1:n_rng]
         rng_lengths = map(length, rngs)
 
         f = gensym()

--- a/test/SArray.jl
+++ b/test/SArray.jl
@@ -56,6 +56,9 @@
 
         m = [1 2; 3 4]
         @test SArray{(2,2)}(m) === @SArray [1 2; 3 4]
+
+        # Non-square comprehensions built from SVectors - see #76
+        @test @SArray([1 for x = SVector(1,2), y = SVector(1,2,3)]) == ones(2,3)
     end
 
     @testset "Methods" begin


### PR DESCRIPTION
This doesn't address the root cause, but works around the issue reported in #76.