### PR TITLE
Implement versions of maximum(), minimum(), diff() with Val{dim} as second argument

### DIFF
--- a/src/StaticArrays.jl
+++ b/src/StaticArrays.jl
@@ -3,12 +3,12 @@ __precompile__()
 module StaticArrays
 
 import Base: @pure, @propagate_inbounds, getindex, setindex!, size, similar,
-             length, convert, promote_op, map, map!, reduce, mapreduce,
-             broadcast, broadcast!, conj, transpose, ctranspose, hcat, vcat,
-             ones, zeros, eye, one, cross, vecdot, reshape, fill, fill!, det,
-             inv, eig, eigvals, trace, vecnorm, norm, dot, diagm, sum, prod,
-             count, any, all, sumabs, sumabs2, minimum, maximum, extrema, mean,
-             copy, diff
+             length, convert, promote_op, map, map!, reduce, reducedim,
+             mapreduce, broadcast, broadcast!, conj, transpose, ctranspose,
+             hcat, vcat, ones, zeros, eye, one, cross, vecdot, reshape, fill,
+             fill!, det, inv, eig, eigvals, trace, vecnorm, norm, dot, diagm,
+             sum, diff, prod, count, any, all, sumabs, sumabs2, minimum,
+             maximum, extrema, mean, copy
 
 export StaticScalar, StaticArray, StaticVector, StaticMatrix
 export Scalar, SArray, SVector, SMatrix

--- a/src/StaticArrays.jl
+++ b/src/StaticArrays.jl
@@ -8,7 +8,7 @@ import Base: @pure, @propagate_inbounds, getindex, setindex!, size, similar,
              ones, zeros, eye, one, cross, vecdot, reshape, fill, fill!, det,
              inv, eig, eigvals, trace, vecnorm, norm, dot, diagm, sum, prod,
              count, any, all, sumabs, sumabs2, minimum, maximum, extrema, mean,
-             copy
+             copy, diff
 
 export StaticScalar, StaticArray, StaticVector, StaticMatrix
 export Scalar, SArray, SVector, SMatrix

--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -90,13 +90,13 @@ end
     end
 end
 
-@generated function reduce{D}(op, a::StaticArray, ::Type{Val{D}})
+@generated function reducedim{D}(op, a::StaticArray, ::Type{Val{D}})
     S = size(a)
     if S[D] == 1
         return :(return a)
     else
         N = ndims(a)
-        Snew = ([n==D ? 1:S[n] for n = 1:N]...)
+        Snew = ([n==D ? 1 : S[n] for n = 1:N]...)
         newtype = similar_type(a, Snew)
 
         exprs = Array{Expr}(Snew)
@@ -131,8 +131,8 @@ end
 @inline sumabs2{T}(a::StaticArray{T}) = mapreduce(abs2, +, zero(T), a)
 @inline minimum(a::StaticArray) = reduce(min, a) # base has mapreduce(idenity, scalarmin, a)
 @inline maximum(a::StaticArray) = reduce(max, a) # base has mapreduce(idenity, scalarmax, a)
-@inline minimum{D}(a::StaticArray, dim::Type{Val{D}}) = reduce(min, a, dim)
-@inline maximum{D}(a::StaticArray, dim::Type{Val{D}}) = reduce(max, a, dim)
+@inline minimum{D}(a::StaticArray, dim::Type{Val{D}}) = reducedim(min, a, dim)
+@inline maximum{D}(a::StaticArray, dim::Type{Val{D}}) = reducedim(max, a, dim)
 
 @generated function diff{D}(a::StaticArray, ::Type{Val{D}}=Val{1})
     S = size(a)

--- a/test/mapreduce.jl
+++ b/test/mapreduce.jl
@@ -24,6 +24,23 @@
         @test prod(v1) === 384
     end
 
+    @testset "reduce in dim" begin
+        a = @SArray rand(4,3,2)
+        @test maximum(a, Val{1}) == maximum(a, 1)
+        @test maximum(a, Val{2}) == maximum(a, 2)
+        @test maximum(a, Val{3}) == maximum(a, 3)
+        @test minimum(a, Val{1}) == minimum(a, 1)
+        @test minimum(a, Val{2}) == minimum(a, 2)
+        @test minimum(a, Val{3}) == minimum(a, 3)
+        @test diff(a) == diff(a, Val{1}) == a[2:end,:,:] - a[1:end-1,:,:]
+        @test diff(a, Val{2}) == a[:,2:end,:] - a[:,1:end-1,:]
+        @test diff(a, Val{3}) == a[:,:,2:end] - a[:,:,1:end-1]
+
+        a = @SArray rand(4,3)  # as of Julia v0.5, diff() for regular Array is defined only for vectors and matrices
+        @test diff(a) == diff(a, Val{1}) == diff(a, 1)
+        @test diff(a, Val{2}) == diff(a, 2)
+    end
+
     @testset "mapreduce" begin
         v1 = @SVector [2,4,6,8]
         v2 = @SVector [4,3,2,1]


### PR DESCRIPTION
- Implement `reduce{D}(op, a, ::Type{Val{D}})` that takes `Val{D}` indicating the direction of reduction.
- Implement `maximum{D}(a, ::Type{Val{D}})` and `minimum{D}(a, ::Type{Val{D}})` using `reduce{D}(op, a, ::Type{Val{D}})`.
- Implement `diff{D}(a, ::Type{Val{D}})` separately, because it cannot be implemented using `reduce{D}(op, a, ::Type{Val{D}})`.