### PR TITLE
Bugfix: Avoid emitting Expr(:meta, :inline) in a macro (!)

### DIFF
--- a/src/MArray.jl
+++ b/src/MArray.jl
@@ -209,7 +209,6 @@ macro MArray(ex)
         end
 
         return quote
-            $(Expr(:meta, :inline))
             $(esc(f_expr))
             $(esc(Expr(:call, Expr(:curly, :MArray, (rng_lengths...)), Expr(:tuple, exprs...))))
         end
@@ -249,7 +248,6 @@ macro MArray(ex)
         end
 
         return quote
-            $(Expr(:meta, :inline))
             $(esc(f_expr))
             $(esc(Expr(:call, Expr(:curly, :MArray, (rng_lengths...), T), Expr(:tuple, exprs...))))
         end
@@ -259,7 +257,6 @@ macro MArray(ex)
                 error("@MArray got bad expression: $(ex.args[1])()")
             else
                 return quote
-                    $(Expr(:meta, :inline))
                     if isa($(esc(ex.args[2])), DataType)
                         $(ex.args[1])($(esc(Expr(:curly, MArray, Expr(:tuple, ex.args[3:end]...), ex.args[2]))))
                     else
@@ -274,20 +271,17 @@ macro MArray(ex)
                 error("@MArray got bad expression: $(ex.args[1])($(ex.args[2]))")
             else
                 return quote
-                    $(Expr(:meta, :inline))
                     $(esc(ex.args[1]))($(esc(ex.args[2])), MArray{$(esc(Expr(:tuple, ex.args[3:end]...)))})
                 end
             end
         elseif ex.args[1] == :eye
             if length(ex.args) == 2
                 return quote
-                    $(Expr(:meta, :inline))
                     eye(MArray{($(esc(ex.args[2])), $(esc(ex.args[2])))})
                 end
             elseif length(ex.args) == 3
                 # We need a branch, depending if the first argument is a type or a size.
                 return quote
-                    $(Expr(:meta, :inline))
                     if isa($(esc(ex.args[2])), DataType)
                         eye(MArray{($(esc(ex.args[3])), $(esc(ex.args[3]))), $(esc(ex.args[2]))})
                     else
@@ -296,7 +290,6 @@ macro MArray(ex)
                 end
             elseif length(ex.args) == 4
                 return quote
-                    $(Expr(:meta, :inline))
                     eye(MArray{($(esc(ex.args[3])), $(esc(ex.args[4]))), $(esc(ex.args[2]))})
                 end
             else

--- a/src/MMatrix.jl
+++ b/src/MMatrix.jl
@@ -206,7 +206,6 @@ macro MMatrix(ex)
         exprs = [:($f($j1, $j2)) for j1 in rng1, j2 in rng2]
 
         return quote
-            $(Expr(:meta, :inline))
             $(esc(f_expr))
             $(esc(Expr(:call, Expr(:curly, :MMatrix, length(rng1), length(rng2)), Expr(:tuple, exprs...))))
         end
@@ -227,7 +226,6 @@ macro MMatrix(ex)
         exprs = [:($f($j1, $j2)) for j1 in rng1, j2 in rng2]
 
         return quote
-            $(Expr(:meta, :inline))
             $(esc(f_expr))
             $(esc(Expr(:call, Expr(:curly, :MMatrix, length(rng1), length(rng2), T), Expr(:tuple, exprs...))))
         end
@@ -235,12 +233,10 @@ macro MMatrix(ex)
         if ex.args[1] == :zeros || ex.args[1] == :ones || ex.args[1] == :rand || ex.args[1] == :randn
             if length(ex.args) == 3
                 return quote
-                    $(Expr(:meta, :inline))
                     $(ex.args[1])(MMatrix{$(esc(ex.args[2])),$(esc(ex.args[3]))})
                 end
             elseif length(ex.args) == 4
                 return quote
-                    $(Expr(:meta, :inline))
                     $(ex.args[1])(MMatrix{$(esc(ex.args[3])), $(esc(ex.args[4])), $(esc(ex.args[2]))})
                 end
             else
@@ -249,7 +245,6 @@ macro MMatrix(ex)
         elseif ex.args[1] == :fill
             if length(ex.args) == 4
                 return quote
-                    $(Expr(:meta, :inline))
                     $(esc(ex.args[1]))($(esc(ex.args[2])), MMatrix{$(esc(ex.args[3])), $(esc(ex.args[4]))})
                 end
             else
@@ -258,13 +253,11 @@ macro MMatrix(ex)
         elseif ex.args[1] == :eye
             if length(ex.args) == 2
                 return quote
-                    $(Expr(:meta, :inline))
                     eye(MMatrix{$(esc(ex.args[2]))})
                 end
             elseif length(ex.args) == 3
                 # We need a branch, depending if the first argument is a type or a size.
                 return quote
-                    $(Expr(:meta, :inline))
                     if isa($(esc(ex.args[2])), DataType)
                         eye(MMatrix{$(esc(ex.args[3])), $(esc(ex.args[3])), $(esc(ex.args[2]))})
                     else
@@ -273,7 +266,6 @@ macro MMatrix(ex)
                 end
             elseif length(ex.args) == 4
                 return quote
-                    $(Expr(:meta, :inline))
                     eye(MMatrix{$(esc(ex.args[3])), $(esc(ex.args[4])), $(esc(ex.args[2]))})
                 end
             else

--- a/src/MVector.jl
+++ b/src/MVector.jl
@@ -97,7 +97,6 @@ macro MVector(ex)
         exprs = [:($f($j)) for j in rng]
 
         return quote
-            $(Expr(:meta, :inline))
             $(esc(f_expr))
             $(esc(Expr(:call, Expr(:curly, :MVector, length(rng)), Expr(:tuple, exprs...))))
         end
@@ -117,7 +116,6 @@ macro MVector(ex)
         exprs = [:($f($j)) for j in rng]
 
         return quote
-            $(Expr(:meta, :inline))
             $(esc(f_expr))
             $(esc(Expr(:call, Expr(:curly, :MVector, length(rng), T), Expr(:tuple, exprs...))))
         end
@@ -125,12 +123,10 @@ macro MVector(ex)
         if ex.args[1] == :zeros || ex.args[1] == :ones || ex.args[1] == :rand ||ex.args[1] == :randn
             if length(ex.args) == 2
                 return quote
-                    $(Expr(:meta, :inline))
                     $(esc(ex.args[1]))(MVector{$(esc(ex.args[2]))})
                 end
             elseif length(ex.args) == 3
                 return quote
-                    $(Expr(:meta, :inline))
                     $(esc(ex.args[1]))(MVector{$(esc(ex.args[3])), $(esc(ex.args[2]))})
                 end
             else
@@ -139,7 +135,6 @@ macro MVector(ex)
         elseif ex.args[1] == :fill
             if length(ex.args) == 3
                 return quote
-                    $(Expr(:meta, :inline))
                     $(esc(ex.args[1]))($(esc(ex.args[2])), MVector{$(esc(ex.args[3]))})
                 end
             else

--- a/src/SArray.jl
+++ b/src/SArray.jl
@@ -173,7 +173,6 @@ macro SArray(ex)
         end
 
         return quote
-            $(Expr(:meta, :inline))
             $(esc(f_expr))
             $(esc(Expr(:call, Expr(:curly, :SArray, (rng_lengths...)), Expr(:tuple, exprs...))))
         end
@@ -213,7 +212,6 @@ macro SArray(ex)
         end
 
         return quote
-            $(Expr(:meta, :inline))
             $(esc(f_expr))
             $(esc(Expr(:call, Expr(:curly, :SArray, (rng_lengths...), T), Expr(:tuple, exprs...))))
         end
@@ -223,7 +221,6 @@ macro SArray(ex)
                 error("@SArray got bad expression: $(ex.args[1])()")
             else
                 return quote
-                    $(Expr(:meta, :inline))
                     if isa($(esc(ex.args[2])), DataType)
                         $(ex.args[1])($(esc(Expr(:curly, SArray, Expr(:tuple, ex.args[3:end]...), ex.args[2]))))
                     else
@@ -238,20 +235,17 @@ macro SArray(ex)
                 error("@SArray got bad expression: $(ex.args[1])($(ex.args[2]))")
             else
                 return quote
-                    $(Expr(:meta, :inline))
                     $(esc(ex.args[1]))($(esc(ex.args[2])), SArray{$(esc(Expr(:tuple, ex.args[3:end]...)))})
                 end
             end
         elseif ex.args[1] == :eye
             if length(ex.args) == 2
                 return quote
-                    $(Expr(:meta, :inline))
                     eye(SArray{($(esc(ex.args[2])), $(esc(ex.args[2])))})
                 end
             elseif length(ex.args) == 3
                 # We need a branch, depending if the first argument is a type or a size.
                 return quote
-                    $(Expr(:meta, :inline))
                     if isa($(esc(ex.args[2])), DataType)
                         eye(SArray{($(esc(ex.args[3])), $(esc(ex.args[3]))), $(esc(ex.args[2]))})
                     else
@@ -260,7 +254,6 @@ macro SArray(ex)
                 end
             elseif length(ex.args) == 4
                 return quote
-                    $(Expr(:meta, :inline))
                     eye(SArray{($(esc(ex.args[3])), $(esc(ex.args[4]))), $(esc(ex.args[2]))})
                 end
             else

--- a/src/SMatrix.jl
+++ b/src/SMatrix.jl
@@ -188,7 +188,6 @@ macro SMatrix(ex)
         exprs = [:($f($j1, $j2)) for j1 in rng1, j2 in rng2]
 
         return quote
-            $(Expr(:meta, :inline))
             $(esc(f_expr))
             $(esc(Expr(:call, Expr(:curly, :SMatrix, length(rng1), length(rng2)), Expr(:tuple, exprs...))))
         end
@@ -209,7 +208,6 @@ macro SMatrix(ex)
         exprs = [:($f($j1, $j2)) for j1 in rng1, j2 in rng2]
 
         return quote
-            $(Expr(:meta, :inline))
             $(esc(f_expr))
             $(esc(Expr(:call, Expr(:curly, :SMatrix, length(rng1), length(rng2), T), Expr(:tuple, exprs...))))
         end
@@ -217,12 +215,10 @@ macro SMatrix(ex)
         if ex.args[1] == :zeros || ex.args[1] == :ones || ex.args[1] == :rand || ex.args[1] == :randn
             if length(ex.args) == 3
                 return quote
-                    $(Expr(:meta, :inline))
                     $(ex.args[1])(SMatrix{$(esc(ex.args[2])),$(esc(ex.args[3]))})
                 end
             elseif length(ex.args) == 4
                 return quote
-                    $(Expr(:meta, :inline))
                     $(ex.args[1])(SMatrix{$(esc(ex.args[3])), $(esc(ex.args[4])), $(esc(ex.args[2]))})
                 end
             else
@@ -231,7 +227,6 @@ macro SMatrix(ex)
         elseif ex.args[1] == :fill
             if length(ex.args) == 4
                 return quote
-                    $(Expr(:meta, :inline))
                     $(esc(ex.args[1]))($(esc(ex.args[2])), SMatrix{$(esc(ex.args[3])), $(esc(ex.args[4]))})
                 end
             else
@@ -240,13 +235,11 @@ macro SMatrix(ex)
         elseif ex.args[1] == :eye
             if length(ex.args) == 2
                 return quote
-                    $(Expr(:meta, :inline))
                     eye(SMatrix{$(esc(ex.args[2]))})
                 end
             elseif length(ex.args) == 3
                 # We need a branch, depending if the first argument is a type or a size.
                 return quote
-                    $(Expr(:meta, :inline))
                     if isa($(esc(ex.args[2])), DataType)
                         eye(SMatrix{$(esc(ex.args[3])), $(esc(ex.args[3])), $(esc(ex.args[2]))})
                     else
@@ -255,7 +248,6 @@ macro SMatrix(ex)
                 end
             elseif length(ex.args) == 4
                 return quote
-                    $(Expr(:meta, :inline))
                     eye(SMatrix{$(esc(ex.args[3])), $(esc(ex.args[4])), $(esc(ex.args[2]))})
                 end
             else

--- a/src/SVector.jl
+++ b/src/SVector.jl
@@ -81,7 +81,6 @@ macro SVector(ex)
         exprs = [:($f($j)) for j in rng]
 
         return quote
-            $(Expr(:meta, :inline))
             $(esc(f_expr))
             $(esc(Expr(:call, Expr(:curly, :SVector, length(rng)), Expr(:tuple, exprs...))))
         end
@@ -101,7 +100,6 @@ macro SVector(ex)
         exprs = [:($f($j)) for j in rng]
 
         return quote
-            $(Expr(:meta, :inline))
             $(esc(f_expr))
             $(esc(Expr(:call, Expr(:curly, :SVector, length(rng), T), Expr(:tuple, exprs...))))
         end
@@ -109,12 +107,10 @@ macro SVector(ex)
         if ex.args[1] == :zeros || ex.args[1] == :ones || ex.args[1] == :rand ||ex.args[1] == :randn
             if length(ex.args) == 2
                 return quote
-                    $(Expr(:meta, :inline))
                     $(esc(ex.args[1]))(SVector{$(esc(ex.args[2]))})
                 end
             elseif length(ex.args) == 3
                 return quote
-                    $(Expr(:meta, :inline))
                     $(esc(ex.args[1]))(SVector{$(esc(ex.args[3])), $(esc(ex.args[2]))})
                 end
             else
@@ -123,7 +119,6 @@ macro SVector(ex)
         elseif ex.args[1] == :fill
             if length(ex.args) == 3
                 return quote
-                    $(Expr(:meta, :inline))
                     $(esc(ex.args[1]))($(esc(ex.args[2])), SVector{$(esc(ex.args[3]))})
                 end
             else


### PR DESCRIPTION
Emitting the inline meta inside a macro causes unsuspecting user
functions to become inline, leading to surprises in type stability.

@andyferris it's all those generated functions, they've made you :meta :inline trigger happy :-P