### PR TITLE
RFC: add colwise function

### DIFF
--- a/src/StaticArrays.jl
+++ b/src/StaticArrays.jl
@@ -22,6 +22,7 @@ export @SVector, @SMatrix, @SArray
 export @MVector, @MMatrix, @MArray
 
 export similar_type, setindex
+export colwise
 
 include("util.jl")
 

--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -428,3 +428,24 @@ end
         end
     end
 end
+
+#############
+## colwise ##
+#############
+@generated function colwise(f, vec::StaticVector, mat::StaticArray)
+    length(vec) == size(mat, 1) || throw(DimensionMismatch())
+    exprs = [:(f(vec, mat[:, $j])) for j = 1:size(mat, 2)]
+    return quote
+        $(Expr(:meta, :inline))
+        @inbounds return $(Expr(:call, hcat, exprs...))
+    end
+end
+
+@generated function colwise(f, mat::StaticArray, vec::StaticVector)
+    length(vec) == size(mat, 1) || throw(DimensionMismatch())
+    exprs = [:(f(mat[:, $j], vec)) for j = 1:size(mat, 2)]
+    return quote
+        $(Expr(:meta, :inline))
+        @inbounds return $(Expr(:call, hcat, exprs...))
+    end
+end

--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -432,6 +432,11 @@ end
 #############
 ## colwise ##
 #############
+"""
+    colwise(f, vec, mat)
+
+Return a matrix `A` such that `A[:, i] == f(vec, mat[:, i])`.
+"""
 @generated function colwise(f, vec::StaticVector, mat::StaticArray)
     length(vec) == size(mat, 1) || throw(DimensionMismatch())
     exprs = [:(f(vec, mat[:, $j])) for j = 1:size(mat, 2)]
@@ -441,6 +446,11 @@ end
     end
 end
 
+"""
+    colwise(f, mat, vec)
+
+Return a matrix `A` such that `A[:, i] == f(mat[:, i], vec)`.
+"""
 @generated function colwise(f, mat::StaticArray, vec::StaticVector)
     length(vec) == size(mat, 1) || throw(DimensionMismatch())
     exprs = [:(f(mat[:, $j], vec)) for j = 1:size(mat, 2)]

--- a/test/mapreduce.jl
+++ b/test/mapreduce.jl
@@ -73,4 +73,18 @@
         broadcast!(+, mm, v1, M)
         @test mm == @MMatrix [3 4; 7 8; 11 12; 15 16]
     end
+
+    @testset "colwise" begin
+        v = @SVector [2, 4, 6]
+        M = @SMatrix [1 2 3; 4 5 6; 7 8 9]
+        T = eltype(v)
+        vcross = @SMatrix [zero(T) -v[3] v[2];
+                       v[3] zero(T) -v[1];
+                      -v[2] v[1] zero(T)]
+        @test vcross * M == colwise(cross, v, M)
+        @test colwise(cross, M, v) == -colwise(cross, v, M)
+        @test colwise(+, M, v) == broadcast(+, M, v)
+        v2 = @SVector [1, 2, 3, 4]
+        @test_throws DimensionMismatch colwise(+, M, v2)
+    end
 end


### PR DESCRIPTION
I needed something like this in my own package, and thought it might be useful for others as well.

Note that this is not the same as `broadcast`, since `broadcast` expects a function that takes a number of scalars as its arguments, whereas `colwise` expects a function that takes two vectors as its arguments.

I can add a `rowwise` too if you like.

This is inspired by Eigen's [`.colwise()`](http://eigen.tuxfamily.org/dox/classEigen_1_1DenseBase.html#a7e5a0184a798ffb18c586c3ca43fde68) functionality.