### PR TITLE
Rewrite all `@pure` functions

### DIFF
--- a/src/FieldVector.jl
+++ b/src/FieldVector.jl
@@ -1,12 +1,11 @@
 """
     abstract FieldVector{T} <: StaticVector{T}
 
-Inheriting from this type will make it easy to create your own vector types.
-A `FieldVector` will automatically determine its size from the number of fields
-(or it can be overriden by `size()`), and define `getindex` and `setindex!`
-appropriately. An immutable `FieldVector` will be as performant as an `SVector`
-of similar length and element type, while a mutable `FieldVector` will behave
-similarly to an `MVector`.
+Inheriting from this type will make it easy to create your own vector types. A `FieldVector`
+will automatically determine its size from the number of fields, and define `getindex` and
+`setindex!` appropriately. An immutable `FieldVector` will be as performant as an `SVector`
+of similar length and element type, while a mutable `FieldVector` will behave similarly to
+an `MVector`.
 
 For example:
 
@@ -21,10 +20,7 @@ abstract FieldVector{T} <: StaticVector{T}
 # Is this a good idea?? Should people just define constructors that accept tuples?
 @inline (::Type{FV}){FV<:FieldVector}(x::Tuple) = FV(x...)
 
-@pure length{FV<:FieldVector}(::FV) = nfields(FV)
-@pure length{FV<:FieldVector}(::Type{FV}) = nfields(FV)
-@pure size{FV<:FieldVector}(::FV) = (length(FV),)
-@pure size{FV<:FieldVector}(::Type{FV}) = (length(FV),)
+@pure Size{FV<:FieldVector}(::Type{FV}) = Size(nfields(FV))
 
 @inline getindex(v::FieldVector, i::Integer) = getfield(v, i)
 @inline setindex!(v::FieldVector, x, i::Integer) = setfield!(v, i, x)

--- a/src/MArray.jl
+++ b/src/MArray.jl
@@ -94,12 +94,10 @@ end
 ## MArray methods ##
 ####################
 
-similar_type{M,T,N,L,S}(::Type{MArray{M,T,N,L}}, ::Type{S}) = MArray{M,S,N,L}
-
-@pure size{Size}(::Type{MArray{Size}}) = Size
-@pure size{Size,T}(::Type{MArray{Size,T}}) = Size
-@pure size{Size,T,N}(::Type{MArray{Size,T,N}}) = Size
-@pure size{Size,T,N,L}(::Type{MArray{Size,T,N,L}}) = Size
+@pure Size{S}(::Type{MArray{S}}) = Size(S)
+@pure Size{S,T}(::Type{MArray{S,T}}) = Size(S)
+@pure Size{S,T,N}(::Type{MArray{S,T,N}}) = Size(S)
+@pure Size{S,T,N,L}(::Type{MArray{S,T,N,L}}) = Size(S)
 
 function getindex(v::MArray, i::Integer)
     Base.@_inline_meta

--- a/src/MMatrix.jl
+++ b/src/MMatrix.jl
@@ -102,12 +102,9 @@ end
 ## MMatrix methods ##
 #####################
 
-similar_type{T,N,M,L,S}(::Type{MMatrix{N,M,T,L}}, ::Type{S})                   = MMatrix{M,N,S,L}
-similar_type{T,N,M,L,S}(::Type{MMatrix{N,M,T,L}}, ::Type{S}, Size::Tuple{Int}) = MVector{Size[1],S}
-
-@pure size{S1,S2}(::Type{MMatrix{S1,S2}}) = (S1, S2)
-@pure size{S1,S2,T}(::Type{MMatrix{S1,S2,T}}) = (S1, S2)
-@pure size{S1,S2,T,L}(::Type{MMatrix{S1,S2,T,L}}) = (S1, S2)
+@pure Size{S1,S2}(::Type{MMatrix{S1,S2}}) = Size(S1, S2)
+@pure Size{S1,S2,T}(::Type{MMatrix{S1,S2,T}}) = Size(S1, S2)
+@pure Size{S1,S2,T,L}(::Type{MMatrix{S1,S2,T,L}}) = Size(S1, S2)
 
 @propagate_inbounds function getindex{S1,S2,T}(m::MMatrix{S1,S2,T}, i::Integer)
     #@boundscheck if i < 1 || i > length(m)

--- a/src/MVector.jl
+++ b/src/MVector.jl
@@ -46,10 +46,8 @@ end
 ## MVector methods ##
 #####################
 
-similar_type{T,N,S}(::Type{MVector{N,T}}, ::Type{S}) = MVector{N,S}
-
-@pure size{S}(::Type{MVector{S}}) = (S, )
-@pure size{S,T}(::Type{MVector{S,T}}) = (S,)
+@pure Size{S}(::Type{MVector{S}}) = Size(S)
+@pure Size{S,T}(::Type{MVector{S,T}}) = Size(S)
 
 @propagate_inbounds function getindex(v::MVector, i::Integer)
     v.data[i]

--- a/src/SArray.jl
+++ b/src/SArray.jl
@@ -74,12 +74,10 @@ end
 ## SArray methods ##
 ####################
 
-similar_type{M,T,N,L,S}(::Type{SArray{M,T,N,L}}, ::Type{S}) = SArray{M,S,N,L}
-
-@pure size{Size}(::Type{SArray{Size}}) = Size
-@pure size{Size,T}(::Type{SArray{Size,T}}) = Size
-@pure size{Size,T,N}(::Type{SArray{Size,T,N}}) = Size
-@pure size{Size,T,N,L}(::Type{SArray{Size,T,N,L}}) = Size
+@pure Size{S}(::Type{SArray{S}}) = Size(S)
+@pure Size{S,T}(::Type{SArray{S,T}}) = Size(S)
+@pure Size{S,T,N}(::Type{SArray{S,T,N}}) = Size(S)
+@pure Size{S,T,N,L}(::Type{SArray{S,T,N,L}}) = Size(S)
 
 function getindex(v::SArray, i::Integer)
     Base.@_inline_meta

--- a/src/SMatrix.jl
+++ b/src/SMatrix.jl
@@ -116,12 +116,9 @@ end
 ## SMatrix methods ##
 #####################
 
-similar_type{T,N,M,L,S}(::Type{SMatrix{N,M,T,L}}, ::Type{S}) = SMatrix{N, M, S, L}
-similar_type{T,N,M,L,S}(::Type{SMatrix{N,M,T,L}}, ::Type{S}, Size::Tuple{Int}) = SVector{Size[1],S}
-
-@pure size{S1,S2}(::Type{SMatrix{S1,S2}}) = (S1, S2)
-@pure size{S1,S2,T}(::Type{SMatrix{S1,S2,T}}) = (S1, S2)
-@pure size{S1,S2,T,L}(::Type{SMatrix{S1,S2,T,L}}) = (S1, S2)
+@pure Size{S1,S2}(::Type{SMatrix{S1,S2}}) = Size(S1, S2)
+@pure Size{S1,S2,T}(::Type{SMatrix{S1,S2,T}}) = Size(S1, S2)
+@pure Size{S1,S2,T,L}(::Type{SMatrix{S1,S2,T,L}}) = Size(S1, S2)
 
 function getindex(v::SMatrix, i::Integer)
     Base.@_inline_meta

--- a/src/SVector.jl
+++ b/src/SVector.jl
@@ -40,10 +40,8 @@ end
 ## SVector methods ##
 #####################
 
-similar_type{T,N,S}(::Type{SVector{N,T}}, ::Type{S}) = SVector{N,S}
-
-@pure size{S}(::Type{SVector{S}}) = (S, )
-@pure size{S,T}(::Type{SVector{S,T}}) = (S,)
+@pure Size{S}(::Type{SVector{S}}) = Size(S)
+@pure Size{S,T}(::Type{SVector{S,T}}) = Size(S)
 
 @propagate_inbounds function getindex(v::SVector, i::Integer)
     v.data[i]

--- a/src/Scalar.jl
+++ b/src/Scalar.jl
@@ -10,10 +10,8 @@ end
 
 @inline (::Type{Scalar{T}}){T}(x::Tuple{T}) = Scalar{T}(x[1])
 
-similar_type{T,S}(::Type{Scalar{T}}, ::Type{S}) = Scalar{S}
-
-@pure size(::Type{Scalar}) = ()
-@pure size{T}(::Type{Scalar{T}}) = ()
+@pure Size(::Type{Scalar}) = Size()
+@pure Size{T}(::Type{Scalar{T}}) = Size()
 
 getindex(v::Scalar) = v.data
 @inline function getindex(v::Scalar, i::Int)

--- a/src/SizedArray.jl
+++ b/src/SizedArray.jl
@@ -48,8 +48,6 @@ end
 @inline (::Type{SizedArray{S,T}}){S,T}(x::Tuple) = SizedArray{S,T,_dims(S),_dims(S)}(x)
 @inline (::Type{SizedArray{S}}){S,T,L}(x::NTuple{L,T}) = SizedArray{S,T,_dims(S),_dims(S)}(x)
 
-similar_type{S,T,N,M,R}(::Type{SizedArray{S,T,N,M}}, ::Type{R}) = SizedArray{S,R,N,M}
-
 # Overide some problematic default behaviour
 @inline convert{SA<:SizedArray}(::Type{SA}, sa::SizedArray) = SA(sa.data)
 @inline convert{SA<:SizedArray}(::Type{SA}, sa::SA) = sa
@@ -65,23 +63,23 @@ similar_type{S,T,N,M,R}(::Type{SizedArray{S,T,N,M}}, ::Type{R}) = SizedArray{S,R
 
 @pure _ndims{N}(::NTuple{N,Int}) = N
 
-@pure size{S}(::Type{SizedArray{S}}) = S
-@pure size{S,T}(::Type{SizedArray{S,T}}) = S
-@pure size{S,T,N}(::Type{SizedArray{S,T,N}}) = S
-@pure size{S,T,N,M}(::Type{SizedArray{S,T,N,M}}) = S
+@pure Size{S}(::Type{SizedArray{S}}) = Size(S)
+@pure Size{S,T}(::Type{SizedArray{S,T}}) = Size(S)
+@pure Size{S,T,N}(::Type{SizedArray{S,T,N}}) = Size(S)
+@pure Size{S,T,N,M}(::Type{SizedArray{S,T,N,M}}) = Size(S)
 
 @propagate_inbounds getindex(a::SizedArray, i::Int) = getindex(a.data, i)
 @propagate_inbounds setindex!(a::SizedArray, v, i::Int) = setindex!(a.data, v, i)
 
 typealias SizedVector{S,T,M} SizedArray{S,T,1,M}
-@pure size{S}(::Type{SizedVector{S}}) = S
+@pure Size{S}(::Type{SizedVector{S}}) = Size(S)
 @inline (::Type{SizedVector{S}}){S,T,M}(a::Array{T,M}) = SizedArray{S,T,1,M}(a)
 @inline (::Type{SizedVector{S}}){S,T,L}(x::NTuple{L,T}) = SizedArray{S,T,1,1}(x)
 @inline (::Type{Vector})(sa::SizedVector) = sa.data
 @inline convert(::Type{Vector}, sa::SizedVector) = sa.data
 
 typealias SizedMatrix{S,T,M} SizedArray{S,T,2,M}
-@pure size{S}(::Type{SizedMatrix{S}}) = S
+@pure Size{S}(::Type{SizedMatrix{S}}) = Size(S)
 @inline (::Type{SizedMatrix{S}}){S,T,M}(a::Array{T,M}) = SizedArray{S,T,2,M}(a)
 @inline (::Type{SizedMatrix{S}}){S,T,L}(x::NTuple{L,T}) = SizedArray{S,T,2,2}(x)
 @inline (::Type{Matrix})(sa::SizedMatrix) = sa.data

--- a/src/StaticArrays.jl
+++ b/src/StaticArrays.jl
@@ -21,7 +21,8 @@ export Size
 export @SVector, @SMatrix, @SArray
 export @MVector, @MMatrix, @MArray
 
-export similar_type, setindex
+export similar_type
+export push, pop, shift, unshift, insert, deleteat, setindex
 
 include("util.jl")
 
@@ -54,18 +55,6 @@ if VERSION < v"0.6.0-dev.1671"
     include("FixedSizeArrays.jl")
 end
 include("ImmutableArrays.jl")
-
-# TODO list
-# ---------
-#
-# * more tests
-#
-# * reshape() - accept Val? Currently uses `ReshapedArray`. Cool :)
-#
-# * permutedims() - accept Val? Or wait for `PermutedDimsArray` ?
-#
-# * Linear algebra - matrix functions (det, inv, eig, svd, qr, etc...)
-#                    (currently, we use pointers to interact with LAPACK, etc)
 
 
 end # module

--- a/src/arraymath.jl
+++ b/src/arraymath.jl
@@ -57,6 +57,7 @@ Base.promote_op{Op,T<:Number,A<:StaticArray}(op::Op, ::Type{T}, ::Type{A}) = sim
 end
 
 # The remaining auto-vectorized boolean operators
+# TODO Julia v0.6 changes this
 @inline !(a::StaticArray{Bool}) = broadcast(!, a)
 
 @inline (&){T1,T2}(a1::StaticArray{T1}, a2::StaticArray{T2}) = broadcast(&, a1, a2)

--- a/src/core.jl
+++ b/src/core.jl
@@ -20,7 +20,7 @@ It may be useful to implement:
 
 For mutable containers you may also need to define the following:
 
- - `setindex!` for a single elmenent (linear indexing).
+ - `setindex!` for a single element (linear indexing).
  - `similar(::Type{MyStaticArray}, ::Type{NewElType}, ::Size{NewSize})`.
  - In some cases, a zero-parameter constructor, `MyStaticArray{...}()` for unintialized data
    is assumed to exist.

--- a/src/deque.jl
+++ b/src/deque.jl
@@ -1,5 +1,5 @@
 @generated function push(vec::StaticVector, x)
-    newtype = similar_type(vec, Size(length(vec) + 1 ,))
+    newtype = similar_type(vec, Size(length(vec) + 1))
     exprs = vcat([:(vec[$i]) for i = 1:length(vec)], :x)
     return quote
         $(Expr(:meta, :inline))
@@ -8,7 +8,7 @@
 end
 
 @generated function unshift(vec::StaticVector, x)
-    newtype = similar_type(vec, Size(length(vec) + 1 ,))
+    newtype = similar_type(vec, Size(length(vec) + 1))
     exprs = vcat(:x, [:(vec[$i]) for i = 1:length(vec)])
     return quote
         $(Expr(:meta, :inline))
@@ -17,7 +17,7 @@ end
 end
 
 @generated function insert(vec::StaticVector, index, x)
-    newtype = similar_type(vec, Size(length(vec) + 1 ,))
+    newtype = similar_type(vec, Size(length(vec) + 1))
     exprs = [(i == 1 ? :(ifelse($i < index, vec[$i], x)) :
               i == length(vec)+1 ? :(ifelse($i == index, x, vec[$i-1])) :
               :(ifelse($i < index, vec[$i], ifelse($i == index, x, vec[$i-1])))) for i = 1:length(vec) + 1]
@@ -31,7 +31,7 @@ end
 end
 
 @generated function pop(vec::StaticVector)
-    newtype = similar_type(vec, Size(length(vec) - 1 ,))
+    newtype = similar_type(vec, Size(length(vec) - 1))
     exprs = [:(vec[$i]) for i = 1:length(vec)-1]
     return quote
         $(Expr(:meta, :inline))
@@ -40,7 +40,7 @@ end
 end
 
 @generated function shift(vec::StaticVector)
-    newtype = similar_type(vec, Size(length(vec) - 1 ,))
+    newtype = similar_type(vec, Size(length(vec) - 1))
     exprs = [:(vec[$i]) for i = 2:length(vec)]
     return quote
         $(Expr(:meta, :inline))
@@ -49,7 +49,7 @@ end
 end
 
 @generated function deleteat(vec::StaticVector, index)
-    newtype = similar_type(vec, Size(length(vec) - 1 ,))
+    newtype = similar_type(vec, Size(length(vec) - 1))
     exprs = [:(ifelse($i < index, vec[$i], vec[$i+1])) for i = 1:length(vec) - 1]
     return quote
         $(Expr(:meta, :inline))

--- a/src/deque.jl
+++ b/src/deque.jl
@@ -1,7 +1,5 @@
-export push, pop, shift, unshift, insert, deleteat, setindex
-
 @generated function push(vec::StaticVector, x)
-    newtype = similar_type(vec, (length(vec) + 1 ,))
+    newtype = similar_type(vec, Size(length(vec) + 1 ,))
     exprs = vcat([:(vec[$i]) for i = 1:length(vec)], :x)
     return quote
         $(Expr(:meta, :inline))
@@ -10,7 +8,7 @@ export push, pop, shift, unshift, insert, deleteat, setindex
 end
 
 @generated function unshift(vec::StaticVector, x)
-    newtype = similar_type(vec, (length(vec) + 1 ,))
+    newtype = similar_type(vec, Size(length(vec) + 1 ,))
     exprs = vcat(:x, [:(vec[$i]) for i = 1:length(vec)])
     return quote
         $(Expr(:meta, :inline))
@@ -19,7 +17,7 @@ end
 end
 
 @generated function insert(vec::StaticVector, index, x)
-    newtype = similar_type(vec, (length(vec) + 1 ,))
+    newtype = similar_type(vec, Size(length(vec) + 1 ,))
     exprs = [(i == 1 ? :(ifelse($i < index, vec[$i], x)) :
               i == length(vec)+1 ? :(ifelse($i == index, x, vec[$i-1])) :
               :(ifelse($i < index, vec[$i], ifelse($i == index, x, vec[$i-1])))) for i = 1:length(vec) + 1]
@@ -33,7 +31,7 @@ end
 end
 
 @generated function pop(vec::StaticVector)
-    newtype = similar_type(vec, (length(vec) - 1 ,))
+    newtype = similar_type(vec, Size(length(vec) - 1 ,))
     exprs = [:(vec[$i]) for i = 1:length(vec)-1]
     return quote
         $(Expr(:meta, :inline))
@@ -42,7 +40,7 @@ end
 end
 
 @generated function shift(vec::StaticVector)
-    newtype = similar_type(vec, (length(vec) - 1 ,))
+    newtype = similar_type(vec, Size(length(vec) - 1 ,))
     exprs = [:(vec[$i]) for i = 2:length(vec)]
     return quote
         $(Expr(:meta, :inline))
@@ -51,7 +49,7 @@ end
 end
 
 @generated function deleteat(vec::StaticVector, index)
-    newtype = similar_type(vec, (length(vec) - 1 ,))
+    newtype = similar_type(vec, Size(length(vec) - 1 ,))
     exprs = [:(ifelse($i < index, vec[$i], vec[$i+1])) for i = 1:length(vec) - 1]
     return quote
         $(Expr(:meta, :inline))

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -4,7 +4,7 @@
 
 # What to do about @boundscheck and @inbounds? It's worse sometimes than @inline, for tuples...
 @generated function getindex{SA<:StaticArray, S}(a::SA, inds::NTuple{S,Integer})
-    newtype = similar_type(SA, (S,))
+    newtype = similar_type(SA, Size(S))
     exprs = [:(a[inds[$i]]) for i = 1:S]
 
     return quote
@@ -18,7 +18,7 @@ end
         a::AbstractArray{T}, inds::StaticVector{I}
     )
     S = length(inds)
-    newtype = similar_type(inds, T, (S,))
+    newtype = similar_type(inds, T, Size(S))
     exprs = [:(a[inds[$i]]) for i = 1:S]
     return quote
         $(Expr(:meta, :inline, :propagate_inbounds))
@@ -31,7 +31,7 @@ end
         m::AbstractArray{T}, inds1::StaticVector{I}, i2::Integer
     )
     S = length(inds1)
-    newtype = similar_type(inds1, T, (S,)) # drop singular dimension like in base
+    newtype = similar_type(inds1, T, Size(S)) # drop singular dimension like in base
     exprs = [:(m[inds1[$j], i2]) for j = 1:S]
     return Expr(:call, newtype, Expr(:tuple, exprs...))
 end
@@ -40,7 +40,7 @@ end
         m::AbstractArray{T}, i1::Integer, inds2::StaticVector{I}
     )
     S = length(inds2)
-    newtype = similar_type(inds2, T, (S,))
+    newtype = similar_type(inds2, T, Size(S))
     exprs = [:(m[i1, inds2[$j]]) for j = 1:S]
     return Expr(:call, newtype, Expr(:tuple, exprs...))
 end
@@ -183,7 +183,7 @@ end
 
 # TODO put bounds checks here, as they should have less overhead here
 @generated function getindex{SM<:StaticMatrix, S1, S2}(m::SM, inds1::NTuple{S1,Integer}, inds2::NTuple{S2,Integer})
-    newtype = similar_type(SM, (S1, S2))
+    newtype = similar_type(SM, Size(S1, S2))
     exprs = [:(m[inds1[$i1], inds2[$i2]]) for i1 = 1:S1, i2 = 1:S2]
 
     return quote
@@ -193,7 +193,7 @@ end
 end
 
 @generated function getindex{SM<:StaticMatrix, S2}(m::SM, i1::Integer, inds2::NTuple{S2,Integer})
-    newtype = similar_type(SM, (S2,))
+    newtype = similar_type(SM, Size(S2))
     exprs = [:(m[i1, inds2[$i2]]) for i2 = 1:S2]
 
     return quote
@@ -203,7 +203,7 @@ end
 end
 
 @generated function getindex{SM<:StaticMatrix, S1}(m::SM, inds1::NTuple{S1,Integer}, i2::Integer)
-    newtype = similar_type(SM, (S1,))
+    newtype = similar_type(SM, Size(S1))
     exprs = [:(m[inds1[$i1], i2]) for i1 = 1:S1]
 
     return quote
@@ -258,7 +258,7 @@ end
 
 
 @generated function setindex!{SM<:StaticMatrix, S2}(m::SM, val, i1::Integer, inds2::NTuple{S2,Integer})
-    newtype = similar_type(SM, (S2,))
+    newtype = similar_type(SM, Size(S2))
     exprs = [:(m[i1, inds2[$i2]] = val[$i2]) for i2 = 1:S2]
 
     return quote
@@ -284,7 +284,7 @@ end
 
 
 @generated function setindex!{SM<:StaticMatrix, S1}(m::SM, val, inds1::NTuple{S1,Integer}, i2::Integer)
-    newtype = similar_type(SM, (S1,))
+    newtype = similar_type(SM, Size(S1))
     exprs = [:(m[inds1[$i1], i2] = val[$i1]) for i1 = 1:S1]
 
     return quote

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -101,11 +101,12 @@ end
 
 
 # Transpose, conjugate, etc
+# TODO different methods for v0.5, v0.6 (due to `RowVector`)
 @inline conj(a::StaticArray) = map(conj, a)
 
 @generated function transpose(v::StaticVector)
     n = length(v)
-    newtype = similar_type(v, (1,n))
+    newtype = similar_type(v, Size(1,n))
     exprs = [:(v[$j]) for j = 1:n]
 
     return quote
@@ -116,7 +117,7 @@ end
 
 @generated function ctranspose(v::StaticVector)
     n = length(v)
-    newtype = similar_type(v, (1,n))
+    newtype = similar_type(v, Size(1,n))
     exprs = [:(conj(v[$j])) for j = 1:n]
 
     return quote
@@ -130,7 +131,7 @@ end
     if s1 == s2
         newtype = m
     else
-        newtype = similar_type(m, (s2,s1))
+        newtype = similar_type(m, Size(s2,s1))
     end
 
     exprs = [:(m[$j1, $j2]) for j2 = 1:s2, j1 = 1:s1]
@@ -146,7 +147,7 @@ end
     if s1 == s2
         newtype = m
     else
-        newtype = similar_type(m, (s2,s1))
+        newtype = similar_type(m, Size(s2,s1))
     end
 
     exprs = [:(conj(m[$j1, $j2])) for j2 = 1:s2, j1 = 1:s1]
@@ -165,11 +166,11 @@ end
     end
 
     if a <: StaticVector && b <: StaticVector
-        newtype = similar_type(a, (length(a) + length(b),))
+        newtype = similar_type(a, Size(length(a) + length(b)))
         exprs = vcat([:(a[$i]) for i = 1:length(a)],
                      [:(b[$i]) for i = 1:length(b)])
     else
-        newtype = similar_type(a, (size(a,1) + size(b,1), size(a,2)))
+        newtype = similar_type(a, Size(size(a,1) + size(b,1), size(a,2)))
         exprs = [((i <= size(a,1)) ? ((a <: StaticVector) ? :(a[$i]) : :(a[$i,$j]))
                                    : ((b <: StaticVector) ? :(b[$(i-size(a,1))]) : :(b[$(i-size(a,1)),$j])))
                                    for i = 1:(size(a,1)+size(b,1)), j = 1:size(a,2)]
@@ -187,7 +188,7 @@ end
     vcat(vcat(a,b), c...)
 
 @generated function hcat(a::StaticVector)
-    newtype = similar_type(a, (length(a),1))
+    newtype = similar_type(a, Size(length(a),1))
     exprs = [:(a[$i]) for i = 1:length(a)]
     return quote
         $(Expr(:meta, :inline))
@@ -203,7 +204,7 @@ end
     exprs1 = [:(a[$i]) for i = 1:length(a)]
     exprs2 = [:(b[$i]) for i = 1:length(b)]
 
-    newtype = similar_type(a, (size(a,1), size(a,2) + size(b,2)))
+    newtype = similar_type(a, Size(size(a,1), size(a,2) + size(b,2)))
 
     return quote
         $(Expr(:meta, :inline))
@@ -277,7 +278,7 @@ end
 @generated function diagm(v::StaticVector)
     T = eltype(v)
     exprs = [i == j ? :(v[$i]) : zero(T) for i = 1:length(v), j = 1:length(v)]
-    newtype = similar_type(v, (length(v), length(v)))
+    newtype = similar_type(v, Size(length(v), length(v)))
     return quote
         $(Expr(:meta, :inline))
         @inbounds return $(Expr(:call, newtype, Expr(:tuple, exprs...)))
@@ -430,7 +431,7 @@ end
 
 # some micro-optimizations
 @inline Base.LinAlg.checksquare{SM<:StaticMatrix}(::SM) = _checksquare(Size(SM))
-@pure Base.LinAlg.checksquare{SM<:StaticMatrix}(::Type{SM}) = _checksquare(Size(SM))
+@inline Base.LinAlg.checksquare{SM<:StaticMatrix}(::Type{SM}) = _checksquare(Size(SM))
 
 @pure _checksquare{S}(::Size{S}) = (S[1] == S[2] || error("marix must be square"); S[1])
 

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -54,7 +54,7 @@ end
         error("Dimension mismatch")
     end
 
-    exprs = [i == j ? :(a.λ + b[$(sub2ind(size(a), i, j))]) : :(b[$(sub2ind(size(a), i, j))]) for i = 1:n, j = 1:n]
+    exprs = [i == j ? :(a.λ + b[$(sub2ind(size(b), i, j))]) : :(b[$(sub2ind(size(b), i, j))]) for i = 1:n, j = 1:n]
 
     return quote
         $(Expr(:meta, :inline))
@@ -86,7 +86,7 @@ end
         error("Dimension mismatch")
     end
 
-    exprs = [i == j ? :(a.λ - b[$(sub2ind(size(a), i, j))]) : :(-b[$(sub2ind(size(a), i, j))]) for i = 1:n, j = 1:n]
+    exprs = [i == j ? :(a.λ - b[$(sub2ind(size(b), i, j))]) : :(-b[$(sub2ind(size(b), i, j))]) for i = 1:n, j = 1:n]
 
     return quote
         $(Expr(:meta, :inline))
@@ -220,6 +220,7 @@ end
 @inline Base.zero{SA <: StaticArray}(a::SA) = zeros(SA)
 @inline Base.zero{SA <: StaticArray}(a::Type{SA}) = zeros(SA)
 
+@inline one{SM <: StaticMatrix}(::SM) = one(SM)
 @generated function one{SM <: StaticArray}(::Type{SM})
     s = size(SM)
     if (length(s) != 2) || (s[1] != s[2])
@@ -236,19 +237,7 @@ end
     end
 end
 
-@generated function one{SM <: StaticMatrix}(::SM)
-    s = size(SM)
-    if s[1] != s[2]
-        error("multiplicative identity defined only for square matrices")
-    end
-    T = eltype(SM)
-    e = eye(T, s...)
-    return quote
-        $(Expr(:meta, :inline))
-        $(Expr(:call, SM, Expr(:tuple, e...)))
-    end
-end
-
+@inline eye{SM <: StaticMatrix}(::SM) = eye(SM)
 @generated function eye{SM <: StaticArray}(::Type{SM})
     s = size(SM)
     if length(s) != 2
@@ -258,16 +247,6 @@ end
     if T == Any
         T = Float64
     end
-    e = eye(T, s...)
-    return quote
-        $(Expr(:meta, :inline))
-        $(Expr(:call, SM, Expr(:tuple, e...)))
-    end
-end
-
-@generated function eye{SM <: StaticMatrix}(::SM)
-    s = size(SM)
-    T = eltype(SM)
     e = eye(T, s...)
     return quote
         $(Expr(:meta, :inline))

--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -97,7 +97,7 @@ end
     else
         N = ndims(a)
         Snew = ([n==D ? 1 : S[n] for n = 1:N]...)
-        newtype = similar_type(a, Snew)
+        newtype = similar_type(a, Size(Snew))
 
         exprs = Array{Expr}(Snew)
         itr = [1:n for n = Snew]
@@ -138,7 +138,7 @@ end
     S = size(a)
     N = ndims(a)
     Snew = ([n==D ? S[n]-1 : S[n] for n = 1:N]...)
-    newtype = similar_type(a, Snew)
+    newtype = similar_type(a, Size(Snew))
 
     exprs = Array{Expr}(Snew)
     itr = [1:n for n = Snew]
@@ -276,7 +276,7 @@ end
         if s == s1
             newtype = :( similar_type($a1, promote_op(f, $(eltype(a1)), $(eltype(a2)))) )
         else
-            newtype = :( similar_type($a1, promote_op(f, $(eltype(a1)), $(eltype(a2))), $s) )
+            newtype = :( similar_type($a1, promote_op(f, $(eltype(a1)), $(eltype(a2))), $(Size(s))) )
         end
 
         exprs = Vector{Expr}(L)

--- a/src/matrix_multiply.jl
+++ b/src/matrix_multiply.jl
@@ -92,7 +92,7 @@ end
     sA = size(A)
     sb = size(b)
 
-    s = (sA[1],)
+    s = Size(sA[1])
     T = promote_matprod(TA, Tb)
     #println(T)
 
@@ -131,7 +131,7 @@ end
     sA = size(A)
     sb = size(b)
 
-    s = (sA[1],)
+    s = Size(sA[1])
     T = promote_matprod(TA, Tb)
     #println(T)
 
@@ -170,7 +170,7 @@ end
     sA = size(A)
     #sb = size(b)
 
-    s = (sA[1],)
+    s = Size(sA[1])
     T = promote_matprod(TA, Tb)
 
     if T == TA
@@ -198,7 +198,7 @@ end
 @generated function *{TA <: Base.LinAlg.BlasFloat, Tb}(A::StaticMatrix{TA}, b::StridedVector{Tb})
     sA = size(A)
 
-    s = (sA[1],)
+    s = Size(sA[1])
     T = promote_matprod(TA, Tb)
 
     if T == TA
@@ -228,7 +228,7 @@ end
     sa = size(a)
     sB = size(B)
 
-    s = (sa[1],sB[2])
+    s = Size(sa[1],sB[2])
     T = promote_matprod(Ta, TB)
 
     if sB[1] != 1
@@ -271,7 +271,7 @@ end
     if can_mutate
         sA = size(A)
         sB = size(B)
-        s = (sA[1], sB[2])
+        s = Size(sA[1], sB[2])
 
         # Heuristic choice between BLAS and explicit unrolling (or chunk-based unrolling)
         if can_blas && size(A,1)*size(A,2)*size(B,2) >= 14*14*14
@@ -324,7 +324,7 @@ end
     TA = eltype(A)
     TB = eltype(B)
 
-    s = (sA[1], sB[2])
+    s = Size(sA[1], sB[2])
     T = promote_matprod(TA, TB)
 
     if sB[1] != sA[2]
@@ -365,7 +365,7 @@ end
     TA = eltype(A)
     TB = eltype(B)
 
-    s = (sA[1], sB[2])
+    s = Size(sA[1], sB[2])
     T = promote_matprod(TA, TB)
 
     if sB[1] != sA[2]
@@ -410,7 +410,7 @@ end
     TA = eltype(A)
     TB = eltype(B)
 
-    s = (sA[1], sB[2])
+    s = Size(sA[1], sB[2])
     T = promote_matprod(TA, TB)
 
     if sB[1] != sA[2]
@@ -454,7 +454,7 @@ end
     sA = size(A)
     sb = size(b)
 
-    s = (sA[1],)
+    s = Size(sA[1])
     T = promote_matprod(TA, Tb)
 
     if sb[1] != sA[2]

--- a/test/FieldVector.jl
+++ b/test/FieldVector.jl
@@ -7,8 +7,6 @@
                 z::Float64
             end
 
-            @inline Point3D(xyz::NTuple{3,Float64}) = Point3D(xyz[1], xyz[2], xyz[3])
-
             StaticArrays.similar_type(::Type{Point3D}, ::Type{Float64}, s::Size{(3,)}) = Point3D
         end)
 
@@ -19,6 +17,8 @@
         @test size(p) === (3,)
         @test length(p) === 3
         @test eltype(p) === Float64
+
+        @test (p + p) === Point3D(2.0, 4.0, 6.0)
 
         @test (p[1], p[2], p[3]) === (p.x, p.y, p.z)
 
@@ -41,8 +41,6 @@
                 x::T
                 y::T
             end
-
-            @inline Point2D(xy::NTuple{2,Any}) = Point2D(xy[1], xy[2])
 
             StaticArrays.similar_type{P2D<:Point2D,T}(::Type{P2D}, ::Type{T}, s::Size{(2,)}) = Point2D{T}
         end)

--- a/test/FieldVector.jl
+++ b/test/FieldVector.jl
@@ -8,6 +8,8 @@
             end
 
             @inline Point3D(xyz::NTuple{3,Float64}) = Point3D(xyz[1], xyz[2], xyz[3])
+
+            StaticArrays.similar_type(::Type{Point3D}, ::Type{Float64}, s::Size{(3,)}) = Point3D
         end)
 
         p = Point3D(1.0, 2.0, 3.0)
@@ -24,13 +26,13 @@
                       0.0 2.0 0.0;
                       0.0 0.0 2.0]
 
-        @test m*p === Point3D(2.0, 4.0, 6.0)
+        @test @inferred(m*p) === Point3D(2.0, 4.0, 6.0)
 
-        @test similar_type(Point3D) == Point3D
-        # @test similar_type(Point3D, Float64) == Point3D
-        # @test similar_type(Point3D, Float32) == SVector{3,Float32}
-        # @test similar_type(Point3D, (4,)) == SVector{4,Float64}
-        # @test similar_type(Point3D, Float32, (4,)) == SVector{4,Float32}
+        @test @inferred(similar_type(Point3D)) == Point3D
+        @test @inferred(similar_type(Point3D, Float64)) == Point3D
+        @test @inferred(similar_type(Point3D, Float32)) == SVector{3,Float32}
+        @test @inferred(similar_type(Point3D, Size(4))) == SVector{4,Float64}
+        @test @inferred(similar_type(Point3D, Float32, Size(4))) == SVector{4,Float32}
     end
 
     @testset "Mutable Point2D" begin
@@ -41,6 +43,8 @@
             end
 
             @inline Point2D(xy::NTuple{2,Any}) = Point2D(xy[1], xy[2])
+
+            StaticArrays.similar_type{P2D<:Point2D,T}(::Type{P2D}, ::Type{T}, s::Size{(2,)}) = Point2D{T}
         end)
 
         p = Point2D(0.0, 0.0)
@@ -57,11 +61,11 @@
         m = @SMatrix [2.0 0.0;
                       0.0 2.0]
 
-        @test (m*p)::Point2D == Point2D(2.0, 4.0)
+        @test @inferred(m*p)::Point2D == Point2D(2.0, 4.0)
 
-        @test similar_type(Point2D{Float64}) == Point2D{Float64}
-        # @test similar_type(Point2D{Float64}, Float32) == Point2D{Float32}
-        # @test similar_type(Point2D{Float64}, (4,)) == SVector{4,Float64}
-        # @test similar_type(Point2D{Float64}, Float32, (4,)) == SVector{4,Float32}
+        @test @inferred(similar_type(Point2D{Float64})) == Point2D{Float64}
+        @test @inferred(similar_type(Point2D{Float64}, Float32)) == Point2D{Float32}
+        @test @inferred(similar_type(Point2D{Float64}, Size(4))) == SVector{4,Float64}
+        @test @inferred(similar_type(Point2D{Float64}, Float32, Size(4))) == SVector{4,Float32}
     end
 end

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -8,37 +8,35 @@
     end
 
     @testset "similar_type" begin
-        @test similar_type(SVector{3,Int}) == SVector{3,Int}
-        @test similar_type(@SVector [1,2,3]) == SVector{3,Int}
+        @test @inferred(similar_type(SVector{3,Int})) == SVector{3,Int}
+        @test @inferred(similar_type(@SVector [1,2,3])) == SVector{3,Int}
 
-        @test similar_type(SVector{3,Int}, Float64) == SVector{3,Float64}
-        @test similar_type(SMatrix{3,3,Int,9}, 2) == SVector{2, Int}
-        @test similar_type(SMatrix{3,3,Int,9}, (2,)) == SVector{2, Int}
-        @test similar_type(SMatrix{3,3,Int,9}, Float64, 2) == SVector{2, Float64}
-        @test similar_type(SMatrix{3,3,Int,9}, Float64, 2) == SVector{2, Float64}
+        @test @inferred(similar_type(SVector{3,Int}, Float64)) == SVector{3,Float64}
+        @test @inferred(similar_type(SMatrix{3,3,Int,9}, Size(2))) == SVector{2, Int}
+        @test @inferred(similar_type(SMatrix{3,3,Int,9}, Float64, Size(2))) == SVector{2, Float64}
+        @test @inferred(similar_type(SMatrix{3,3,Int,9}, Float64, Size(2))) == SVector{2, Float64}
 
-        @test similar_type(SMatrix{3,3,Int,9}, Float64) == SMatrix{3, 3, Float64, 9}
-        @test similar_type(SVector{2,Int}, (3,3)) == SMatrix{3, 3, Int, 9}
-        @test similar_type(SVector{2,Int}, Float64, (3,3)) == SMatrix{3, 3, Float64, 9}
+        @test @inferred(similar_type(SMatrix{3,3,Int,9}, Float64)) == SMatrix{3, 3, Float64, 9}
+        @test @inferred(similar_type(SVector{2,Int}, Size(3,3))) == SMatrix{3, 3, Int, 9}
+        @test @inferred(similar_type(SVector{2,Int}, Float64, Size(3,3))) == SMatrix{3, 3, Float64, 9}
 
-        @test similar_type(SArray{(4,4,4),Int,3,64}, Float64) == SArray{(4,4,4), Float64, 3, 64}
-        @test similar_type(SVector{2,Int}, (3,3,3)) == SArray{(3,3,3), Int, 3, 27}
-        @test similar_type(SVector{2,Int}, Float64, (3,3,3)) == SArray{(3,3,3), Float64, 3, 27}
+        @test @inferred(similar_type(SArray{(4,4,4),Int,3,64}, Float64)) == SArray{(4,4,4), Float64, 3, 64}
+        @test @inferred(similar_type(SVector{2,Int}, Size(3,3,3))) == SArray{(3,3,3), Int, 3, 27}
+        @test @inferred(similar_type(SVector{2,Int}, Float64, Size(3,3,3))) == SArray{(3,3,3), Float64, 3, 27}
 
         # Some specializations for the mutable case
-        @test similar_type(MVector{3,Int}, Float64) == MVector{3,Float64}
-        @test similar_type(MMatrix{3,3,Int,9}, 2) == MVector{2, Int}
-        @test similar_type(MMatrix{3,3,Int,9}, (2,)) == MVector{2, Int}
-        @test similar_type(MMatrix{3,3,Int,9}, Float64, 2) == MVector{2, Float64}
-        @test similar_type(MMatrix{3,3,Int,9}, Float64, 2) == MVector{2, Float64}
+        @test @inferred(similar_type(MVector{3,Int}, Float64)) == MVector{3,Float64}
+        @test @inferred(similar_type(MMatrix{3,3,Int,9}, Size(2))) == MVector{2, Int}
+        @test @inferred(similar_type(MMatrix{3,3,Int,9}, Float64, Size(2))) == MVector{2, Float64}
+        @test @inferred(similar_type(MMatrix{3,3,Int,9}, Float64, Size(2))) == MVector{2, Float64}
 
-        @test similar_type(MMatrix{3,3,Int,9}, Float64) == MMatrix{3, 3, Float64, 9}
-        @test similar_type(MVector{2,Int}, (3,3)) == MMatrix{3, 3, Int, 9}
-        @test similar_type(MVector{2,Int}, Float64, (3,3)) == MMatrix{3, 3, Float64, 9}
+        @test @inferred(similar_type(MMatrix{3,3,Int,9}, Float64)) == MMatrix{3, 3, Float64, 9}
+        @test @inferred(similar_type(MVector{2,Int}, Size(3,3))) == MMatrix{3, 3, Int, 9}
+        @test @inferred(similar_type(MVector{2,Int}, Float64, Size(3,3))) == MMatrix{3, 3, Float64, 9}
 
-        @test similar_type(MArray{(4,4,4),Int,3,64}, Float64) == MArray{(4,4,4), Float64, 3, 64}
-        @test similar_type(MVector{2,Int}, (3,3,3)) == MArray{(3,3,3), Int, 3, 27}
-        @test similar_type(MVector{2,Int}, Float64, (3,3,3)) == MArray{(3,3,3), Float64, 3, 27}
+        @test @inferred(similar_type(MArray{(4,4,4),Int,3,64}, Float64)) == MArray{(4,4,4), Float64, 3, 64}
+        @test @inferred(similar_type(MVector{2,Int}, Size(3,3,3))) == MArray{(3,3,3), Int, 3, 27}
+        @test @inferred(similar_type(MVector{2,Int}, Float64, Size(3,3,3))) == MArray{(3,3,3), Float64, 3, 27}
     end
 
     @testset "similar" begin
@@ -46,24 +44,24 @@
         sm = @SMatrix [1 2; 3 4]
         sa = SArray{(1,1,1),Int,3,1}((1,))
 
-        @test isa(similar(sv), MVector{3,Int})
-        @test isa(similar(sv, Float64), MVector{3,Float64})
-        @test isa(similar(sv, Size(4)), MVector{4,Int})
-        @test isa(similar(sv, Float64, Size(4)), MVector{4,Float64})
+        @test isa(@inferred(similar(sv)), MVector{3,Int})
+        @test isa(@inferred(similar(sv, Float64)), MVector{3,Float64})
+        @test isa(@inferred(similar(sv, Size(4))), MVector{4,Int})
+        @test isa(@inferred(similar(sv, Float64, Size(4))), MVector{4,Float64})
 
-        @test isa(similar(sm), MMatrix{2,2,Int,4})
-        @test isa(similar(sm, Float64), MMatrix{2,2,Float64,4})
-        @test isa(similar(sv, Size(3,3)), MMatrix{3,3,Int,9})
-        @test isa(similar(sv, Float64, Size(3,3)), MMatrix{3,3,Float64,9})
+        @test isa(@inferred(similar(sm)), MMatrix{2,2,Int,4})
+        @test isa(@inferred(similar(sm, Float64)), MMatrix{2,2,Float64,4})
+        @test isa(@inferred(similar(sv, Size(3,3))), MMatrix{3,3,Int,9})
+        @test isa(@inferred(similar(sv, Float64, Size(3,3))), MMatrix{3,3,Float64,9})
 
-        @test isa(similar(sa), MArray{(1,1,1),Int,3,1})
-        @test isa(similar(sa, Float64), MArray{(1,1,1),Float64,3,1})
-        @test isa(similar(sv, Size(3,3,3)), MArray{(3,3,3),Int,3,27})
-        @test isa(similar(sv, Float64, Size(3,3,3)), MArray{(3,3,3),Float64,3,27})
+        @test isa(@inferred(similar(sa)), MArray{(1,1,1),Int,3,1})
+        @test isa(@inferred(similar(sa, Float64)), MArray{(1,1,1),Float64,3,1})
+        @test isa(@inferred(similar(sv, Size(3,3,3))), MArray{(3,3,3),Int,3,27})
+        @test isa(@inferred(similar(sv, Float64, Size(3,3,3))), MArray{(3,3,3),Float64,3,27})
     end
 
     @testset "reshape" begin
-        @test reshape(SVector(1,2,3,4), Size(2,2)) === SMatrix{2,2}(1,2,3,4)
-        @test reshape([1,2,3,4], Size(2,2))::SizedArray{(2,2),Int,2,1} == [1 3; 2 4]
+        @test @inferred(reshape(SVector(1,2,3,4), Size(2,2))) === SMatrix{2,2}(1,2,3,4)
+        @test @inferred(reshape([1,2,3,4], Size(2,2)))::SizedArray{(2,2),Int,2,1} == [1 3; 2 4]
     end
 end

--- a/test/arraymath.jl
+++ b/test/arraymath.jl
@@ -63,4 +63,10 @@
         @test all(@inferred(fill(3., SMatrix{4, 16, Float64})) .== 3.)
         @test @allocated(fill(0., SMatrix{1, 16, Float64})) == 0 # #81
     end
+
+    @testset "fill!()" begin
+        m = MMatrix{4,16,Float64}()
+        fill!(m, 3)
+        @test all(m .== 3.)
+    end
 end

--- a/test/arraymath.jl
+++ b/test/arraymath.jl
@@ -1,26 +1,23 @@
 @testset "Array math" begin
     @testset "AbstractArray-of-StaticArray with scalar math" begin
         v = SVector{2,Float64}[SVector{2,Float64}(1,1)]
-        @test v .* 1.0 == v
-        @test typeof(v .* 1.0) == typeof(v)
-        @test 1 .- v == v .- v
-        @test typeof(1 .- v) == typeof(v)
+        @test @inferred(v .* 1.0)::typeof(v) == v
+        @test @inferred(1 .- v)::typeof(v) == v .- v
         v2 = SVector{2,Int}[SVector{2,Int}(1,1)]
-        @test v2 .* 1.0 == v
-        @test typeof(v2 .* 1.0) == typeof(v)
+        @test @inferred(v2 .* 1.0)::typeof(v) == v
     end
 
     @testset "Array-scalar math" begin
         m = @SMatrix [1 2; 3 4]
 
-        @test m .+ 1 === @SMatrix [2 3; 4 5]
-        @test 1 .+ m === @SMatrix [2 3; 4 5]
-        @test m .* 2 === @SMatrix [2 4; 6 8]
-        @test 2 .* m === @SMatrix [2 4; 6 8]
-        @test m .- 1 === @SMatrix [0 1; 2 3]
-        @test 1 .- m === @SMatrix [0 -1; -2 -3]
-        @test m ./ 2 === @SMatrix [0.5 1.0; 1.5 2.0]
-        @test 12 ./ m === @SMatrix [12.0 6.0; 4.0 3.0]
+        @test @inferred(m .+ 1) === @SMatrix [2 3; 4 5]
+        @test @inferred(1 .+ m) === @SMatrix [2 3; 4 5]
+        @test @inferred(m .* 2) === @SMatrix [2 4; 6 8]
+        @test @inferred(2 .* m) === @SMatrix [2 4; 6 8]
+        @test @inferred(m .- 1) === @SMatrix [0 1; 2 3]
+        @test @inferred(1 .- m) === @SMatrix [0 -1; -2 -3]
+        @test @inferred(m ./ 2) === @SMatrix [0.5 1.0; 1.5 2.0]
+        @test @inferred(12 ./ m) === @SMatrix [12.0 6.0; 4.0 3.0]
 
     end
 
@@ -28,42 +25,42 @@
         m1 = @SMatrix [1 2; 3 4]
         m2 = @SMatrix [4 3; 2 1]
 
-        @test .-(m1) === @SMatrix [-1 -2; -3 -4]
+        @test @inferred(.-(m1)) === @SMatrix [-1 -2; -3 -4]
 
-        @test m1 .+ m2 === @SMatrix [5 5; 5 5]
-        @test m1 .* m2 === @SMatrix [4 6; 6 4]
-        @test m1 .- m2 === @SMatrix [-3 -1; 1 3]
-        @test m1 ./ m2 === @SMatrix [0.25 2/3; 1.5 4.0]
+        @test @inferred(m1 .+ m2) === @SMatrix [5 5; 5 5]
+        @test @inferred(m1 .* m2) === @SMatrix [4 6; 6 4]
+        @test @inferred(m1 .- m2) === @SMatrix [-3 -1; 1 3]
+        @test @inferred(m1 ./ m2) === @SMatrix [0.25 2/3; 1.5 4.0]
     end
 
     @testset "zeros() and ones()" begin
-        @test zeros(SVector{3,Float64}) === @SVector [0.0, 0.0, 0.0]
-        @test zeros(SVector{3,Int}) === @SVector [0, 0, 0]
-        @test ones(SVector{3,Float64}) === @SVector [1.0, 1.0, 1.0]
-        @test ones(SVector{3,Int}) === @SVector [1, 1, 1]
+        @test @inferred(zeros(SVector{3,Float64})) === @SVector [0.0, 0.0, 0.0]
+        @test @inferred(zeros(SVector{3,Int})) === @SVector [0, 0, 0]
+        @test @inferred(ones(SVector{3,Float64})) === @SVector [1.0, 1.0, 1.0]
+        @test @inferred(ones(SVector{3,Int})) === @SVector [1, 1, 1]
 
-        @test zeros(SVector{3}) === @SVector [0.0, 0.0, 0.0]
-        @test zeros(SMatrix{2,2}) === @SMatrix [0.0 0.0; 0.0 0.0]
-        @test zeros(SArray{(1,1,1)}) === SArray{(1,1,1)}((0.0,))
-        @test zeros(MVector{3})::MVector == @MVector [0.0, 0.0, 0.0]
-        @test zeros(MMatrix{2,2})::MMatrix == @MMatrix [0.0 0.0; 0.0 0.0]
-        @test zeros(MArray{(1,1,1)})::MArray == MArray{(1,1,1)}((0.0,))
+        @test @inferred(zeros(SVector{3})) === @SVector [0.0, 0.0, 0.0]
+        @test @inferred(zeros(SMatrix{2,2})) === @SMatrix [0.0 0.0; 0.0 0.0]
+        @test @inferred(zeros(SArray{(1,1,1)})) === SArray{(1,1,1)}((0.0,))
+        @test @inferred(zeros(MVector{3}))::MVector == @MVector [0.0, 0.0, 0.0]
+        @test @inferred(zeros(MMatrix{2,2}))::MMatrix == @MMatrix [0.0 0.0; 0.0 0.0]
+        @test @inferred(zeros(MArray{(1,1,1)}))::MArray == MArray{(1,1,1)}((0.0,))
 
-        @test ones(SVector{3}) === @SVector [1.0, 1.0, 1.0]
-        @test ones(SMatrix{2,2}) === @SMatrix [1.0 1.0; 1.0 1.0]
-        @test ones(SArray{(1,1,1)}) === SArray{(1,1,1)}((1.0,))
-        @test ones(MVector{3})::MVector == @MVector [1.0, 1.0, 1.0]
-        @test ones(MMatrix{2,2})::MMatrix == @MMatrix [1.0 1.0; 1.0 1.0]
-        @test ones(MArray{(1,1,1)})::MArray == MArray{(1,1,1)}((1.0,))
+        @test @inferred(ones(SVector{3})) === @SVector [1.0, 1.0, 1.0]
+        @test @inferred(ones(SMatrix{2,2})) === @SMatrix [1.0 1.0; 1.0 1.0]
+        @test @inferred(ones(SArray{(1,1,1)})) === SArray{(1,1,1)}((1.0,))
+        @test @inferred(ones(MVector{3}))::MVector == @MVector [1.0, 1.0, 1.0]
+        @test @inferred(ones(MMatrix{2,2}))::MMatrix == @MMatrix [1.0 1.0; 1.0 1.0]
+        @test @inferred(ones(MArray{(1,1,1)}))::MArray == MArray{(1,1,1)}((1.0,))
     end
 
     @testset "zero()" begin
-        @test zero(SVector{3, Float64}) === @SVector [0.0, 0.0, 0.0]
-        @test zero(SVector{3, Int}) === @SVector [0, 0, 0]
+        @test @inferred(zero(SVector{3, Float64})) === @SVector [0.0, 0.0, 0.0]
+        @test @inferred(zero(SVector{3, Int})) === @SVector [0, 0, 0]
     end
 
     @testset "fill()" begin
-        @test all(fill(3., SMatrix{4, 16, Float64}) .== 3.)
+        @test all(@inferred(fill(3., SMatrix{4, 16, Float64})) .== 3.)
         @test @allocated(fill(0., SMatrix{1, 16, Float64})) == 0 # #81
     end
 end

--- a/test/deque.jl
+++ b/test/deque.jl
@@ -1,14 +1,14 @@
 @testset "Push, pop, shift, unshift, etc" begin
     v = @SVector [1, 2, 3]
 
-    @test push(v, 4) === @SVector [1, 2, 3, 4]
-    @test pop(v) === @SVector [1, 2]
+    @test @inferred(push(v, 4)) === @SVector [1, 2, 3, 4]
+    @test @inferred(pop(v)) === @SVector [1, 2]
 
-    @test unshift(v, 0) === @SVector [0, 1, 2, 3]
-    @test shift(v) === @SVector [2, 3]
+    @test @inferred(unshift(v, 0)) === @SVector [0, 1, 2, 3]
+    @test @inferred(shift(v)) === @SVector [2, 3]
 
-    @test (@inferred insert(v, 2, -2)) === @SVector [1, -2, 2, 3]
-    @test (@inferred deleteat(v, 2)) === @SVector [1, 3]
+    @test @inferred(insert(v, 2, -2)) === @SVector [1, -2, 2, 3]
+    @test @inferred(deleteat(v, 2)) === @SVector [1, 3]
 
-    @test setindex(v, -2, 2) === @SVector [1, -2, 3]
+    @test @inferred(setindex(v, -2, 2)) === @SVector [1, -2, 3]
 end

--- a/test/fixed_size_arrays.jl
+++ b/test/fixed_size_arrays.jl
@@ -26,7 +26,7 @@ end
 RGB{T}(x::T) = RGB{T}(x, x, x)
 (::RGB{T}){T}(r, g, b) = RGB{T}(T(r), T(g), T(b))
 (::RGB{T}){T}(r::Real) = RGB(T(r), T(r), T(r))
-StaticArrays.similar_type{SV <: RGB, T}(::Union{SV, Type{SV}}, ::Type{T}) = RGB{T}
+StaticArrays.similar_type{SV <: RGB, T}(::Type{SV}, ::Type{T}, ::Size{(3,)}) = RGB{T}
 
 # TODO find equivalent in StaticArrays
 # testset "scalar nan" begin

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -9,9 +9,30 @@
         @test @inferred(v1 - c) === @SVector [0,2,4,6]
         @test @inferred(v1 * c) === @SVector [4,8,12,16]
         @test @inferred(v1 / c) === @SVector [1.0,2.0,3.0,4.0]
+        @test @inferred(c \ v1)::SVector ≈ @SVector [1.0,2.0,3.0,4.0]
 
         @test @inferred(v1 + v2) === @SVector [6, 7, 8, 9]
         @test @inferred(v1 - v2) === @SVector [-2, 1, 4, 7]
+
+        v3 = [2,4,6,8]
+        v4 = [4,3,2,1]
+
+        @test @inferred(v1 - v4) === @SVector [-2, 1, 4, 7]
+        @test @inferred(v3 - v2) === @SVector [-2, 1, 4, 7]
+        @test @inferred(v1 - v4) === @SVector [-2, 1, 4, 7]
+        @test @inferred(v3 - v2) === @SVector [-2, 1, 4, 7]
+    end
+
+    @testset "Interaction with `UniformScaling`" begin
+        @test @inferred(@SMatrix([0 1; 2 3]) + I) === @SMatrix [1 1; 2 4]
+        @test @inferred(I + @SMatrix([0 1; 2 3])) === @SMatrix [1 1; 2 4]
+        @test @inferred(@SMatrix([0 1; 2 3]) - I) === @SMatrix [-1 1; 2 2]
+        @test @inferred(I - @SMatrix([0 1; 2 3])) === @SMatrix [1 -1; -2 -2]
+
+        @test @inferred(@SMatrix([0 1; 2 3]) * I) === @SMatrix [0 1; 2 3]
+        @test @inferred(I * @SMatrix([0 1; 2 3])) === @SMatrix [0 1; 2 3]
+        @test @inferred(@SMatrix([0 1; 2 3]) / I) === @SMatrix [0.0 1.0; 2.0 3.0]
+        @test @inferred(I \ @SMatrix([0 1; 2 3])) === @SMatrix [0.0 1.0; 2.0 3.0]
     end
 
     @testset "diagm()" begin
@@ -22,6 +43,7 @@
         @test @inferred(one(SMatrix{2,2,Int})) === @SMatrix [1 0; 0 1]
         @test @inferred(one(SMatrix{2,2})) === @SMatrix [1.0 0.0; 0.0 1.0]
         @test @inferred(one(SMatrix{2})) === @SMatrix [1.0 0.0; 0.0 1.0]
+        @test @inferred(one(one(SMatrix{2,2,Int}))) === @SMatrix [1 0; 0 1]
 
         @test @inferred(one(MMatrix{2,2,Int}))::MMatrix == @MMatrix [1 0; 0 1]
         @test @inferred(one(MMatrix{2,2}))::MMatrix == @MMatrix [1.0 0.0; 0.0 1.0]
@@ -32,6 +54,7 @@
         @test @inferred(eye(SMatrix{2,2,Int})) === @SMatrix [1 0; 0 1]
         @test @inferred(eye(SMatrix{2,2})) === @SMatrix [1.0 0.0; 0.0 1.0]
         @test @inferred(eye(SMatrix{2})) === @SMatrix [1.0 0.0; 0.0 1.0]
+        @test @inferred(eye(eye(SMatrix{2,2,Int}))) === @SMatrix [1 0; 0 1]
 
         @test @inferred(eye(SMatrix{2,3,Int})) === @SMatrix [1 0 0; 0 1 0]
         @test @inferred(eye(SMatrix{2,3})) === @SMatrix [1.0 0.0 0.0; 0.0 1.0 0.0]
@@ -43,6 +66,8 @@
 
     @testset "cross()" begin
         @test @inferred(cross(SVector(1,2,3), SVector(4,5,6))) === SVector(-3, 6, -3)
+        @test @inferred(cross(SVector(1,2), SVector(4,5))) === -3
+
     end
 
     @testset "transpose() and conj()" begin
@@ -58,6 +83,10 @@
     end
 
     @testset "vcat() and hcat()" begin
+        @test @inferred(vcat(SVector(1,2,3))) === SVector(1,2,3)
+        @test @inferred(hcat(SVector(1,2,3))) === SMatrix{3,1}(1,2,3)
+        @test @inferred(hcat(SMatrix{3,1}(1,2,3))) === SMatrix{3,1}(1,2,3)
+
         @test @inferred(vcat(SVector(1,2,3), SVector(4,5,6))) === SVector(1,2,3,4,5,6)
         @test @inferred(hcat(SVector(1,2,3), SVector(4,5,6))) === @SMatrix [1 4; 2 5; 3 6]
 
@@ -68,6 +97,9 @@
 
         @test @inferred(vcat(@SMatrix([1;2;3]), @SMatrix([4;5;6]))) === @SMatrix([1;2;3;4;5;6])
         @test @inferred(hcat(@SMatrix([1;2;3]), @SMatrix([4;5;6]))) === @SMatrix [1 4; 2 5; 3 6]
+
+        @test @inferred(vcat(SVector(1),SVector(2),SVector(3),SVector(4))) === SVector(1,2,3,4)
+        @test @inferred(hcat(SVector(1),SVector(2),SVector(3),SVector(4))) === SMatrix{1,4}(1,2,3,4)
     end
 
     @testset "normalization" begin
@@ -81,5 +113,9 @@
         @test vecnorm(@SMatrix [1 2; 3 4.0+im]) ≈ vecnorm([1 2; 3 4.0+im])
 
         @test normalize(SVector(1,2,3)) ≈ normalize([1,2,3])
+    end
+
+    @testset "trace" begin
+        @test trace(@SMatrix [1.0 2.0; 3.0 4.0]) === 5.0
     end
 end

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -5,69 +5,69 @@
         v1 = @SVector [2,4,6,8]
         v2 = @SVector [4,3,2,1]
 
-        @test v1 + c === @SVector [4,6,8,10]
-        @test v1 - c === @SVector [0,2,4,6]
-        @test v1 * c === @SVector [4,8,12,16]
-        @test v1 / c === @SVector [1.0,2.0,3.0,4.0]
+        @test @inferred(v1 + c) === @SVector [4,6,8,10]
+        @test @inferred(v1 - c) === @SVector [0,2,4,6]
+        @test @inferred(v1 * c) === @SVector [4,8,12,16]
+        @test @inferred(v1 / c) === @SVector [1.0,2.0,3.0,4.0]
 
-        @test v1 + v2 === @SVector [6, 7, 8, 9]
-        @test v1 - v2 === @SVector [-2, 1, 4, 7]
+        @test @inferred(v1 + v2) === @SVector [6, 7, 8, 9]
+        @test @inferred(v1 - v2) === @SVector [-2, 1, 4, 7]
     end
 
     @testset "diagm()" begin
-        @test diagm(SVector(1,2)) === @SMatrix [1 0; 0 2]
+        @test @inferred(diagm(SVector(1,2))) === @SMatrix [1 0; 0 2]
     end
 
     @testset "one()" begin
-        @test one(SMatrix{2,2,Int}) === @SMatrix [1 0; 0 1]
-        @test one(SMatrix{2,2}) === @SMatrix [1.0 0.0; 0.0 1.0]
-        @test one(SMatrix{2}) === @SMatrix [1.0 0.0; 0.0 1.0]
+        @test @inferred(one(SMatrix{2,2,Int})) === @SMatrix [1 0; 0 1]
+        @test @inferred(one(SMatrix{2,2})) === @SMatrix [1.0 0.0; 0.0 1.0]
+        @test @inferred(one(SMatrix{2})) === @SMatrix [1.0 0.0; 0.0 1.0]
 
-        @test one(MMatrix{2,2,Int})::MMatrix == @MMatrix [1 0; 0 1]
-        @test one(MMatrix{2,2})::MMatrix == @MMatrix [1.0 0.0; 0.0 1.0]
-        @test one(MMatrix{2})::MMatrix == @MMatrix [1.0 0.0; 0.0 1.0]
+        @test @inferred(one(MMatrix{2,2,Int}))::MMatrix == @MMatrix [1 0; 0 1]
+        @test @inferred(one(MMatrix{2,2}))::MMatrix == @MMatrix [1.0 0.0; 0.0 1.0]
+        @test @inferred(one(MMatrix{2}))::MMatrix == @MMatrix [1.0 0.0; 0.0 1.0]
     end
 
     @testset "eye()" begin
-        @test eye(SMatrix{2,2,Int}) === @SMatrix [1 0; 0 1]
-        @test eye(SMatrix{2,2}) === @SMatrix [1.0 0.0; 0.0 1.0]
-        @test eye(SMatrix{2}) === @SMatrix [1.0 0.0; 0.0 1.0]
+        @test @inferred(eye(SMatrix{2,2,Int})) === @SMatrix [1 0; 0 1]
+        @test @inferred(eye(SMatrix{2,2})) === @SMatrix [1.0 0.0; 0.0 1.0]
+        @test @inferred(eye(SMatrix{2})) === @SMatrix [1.0 0.0; 0.0 1.0]
 
-        @test eye(SMatrix{2,3,Int}) === @SMatrix [1 0 0; 0 1 0]
-        @test eye(SMatrix{2,3}) === @SMatrix [1.0 0.0 0.0; 0.0 1.0 0.0]
+        @test @inferred(eye(SMatrix{2,3,Int})) === @SMatrix [1 0 0; 0 1 0]
+        @test @inferred(eye(SMatrix{2,3})) === @SMatrix [1.0 0.0 0.0; 0.0 1.0 0.0]
 
-        @test eye(MMatrix{2,2,Int})::MMatrix == @MMatrix [1 0; 0 1]
-        @test eye(MMatrix{2,2})::MMatrix == @MMatrix [1.0 0.0; 0.0 1.0]
-        @test eye(MMatrix{2})::MMatrix == @MMatrix [1.0 0.0; 0.0 1.0]
+        @test @inferred(eye(MMatrix{2,2,Int}))::MMatrix == @MMatrix [1 0; 0 1]
+        @test @inferred(eye(MMatrix{2,2}))::MMatrix == @MMatrix [1.0 0.0; 0.0 1.0]
+        @test @inferred(eye(MMatrix{2}))::MMatrix == @MMatrix [1.0 0.0; 0.0 1.0]
     end
 
     @testset "cross()" begin
-        @test cross(SVector(1,2,3), SVector(4,5,6)) === SVector(-3, 6, -3)
+        @test @inferred(cross(SVector(1,2,3), SVector(4,5,6))) === SVector(-3, 6, -3)
     end
 
     @testset "transpose() and conj()" begin
-        @test conj(SVector(1+im, 2+im)) === SVector(1-im, 2-im)
+        @test @inferred(conj(SVector(1+im, 2+im))) === SVector(1-im, 2-im)
 
-        @test @SVector([1, 2, 3]).' === @SMatrix([1 2 3])
-        @test @SMatrix([1 2; 0 3]).' === @SMatrix([1 0; 2 3])
-        @test @SMatrix([1 2 3; 4 5 6]).' === @SMatrix([1 4; 2 5; 3 6])
+        @test @inferred(transpose(@SVector([1, 2, 3]))) === @SMatrix([1 2 3])
+        @test @inferred(transpose(@SMatrix([1 2; 0 3]))) === @SMatrix([1 0; 2 3])
+        @test @inferred(transpose(@SMatrix([1 2 3; 4 5 6]))) === @SMatrix([1 4; 2 5; 3 6])
 
-        @test @SVector([1, 2, 3])' === @SMatrix([1 2 3])
-        @test @SMatrix([1 2; 0 3])' === @SMatrix([1 0; 2 3])
-        @test @SMatrix([1 2 3; 4 5 6])' === @SMatrix([1 4; 2 5; 3 6])
+        @test @inferred(ctranspose(@SVector([1, 2, 3]))) === @SMatrix([1 2 3])
+        @test @inferred(ctranspose(@SMatrix([1 2; 0 3]))) === @SMatrix([1 0; 2 3])
+        @test @inferred(ctranspose(@SMatrix([1 2 3; 4 5 6]))) === @SMatrix([1 4; 2 5; 3 6])
     end
 
     @testset "vcat() and hcat()" begin
-        @test vcat(SVector(1,2,3), SVector(4,5,6)) === SVector(1,2,3,4,5,6)
-        @test hcat(SVector(1,2,3), SVector(4,5,6)) === @SMatrix [1 4; 2 5; 3 6]
+        @test @inferred(vcat(SVector(1,2,3), SVector(4,5,6))) === SVector(1,2,3,4,5,6)
+        @test @inferred(hcat(SVector(1,2,3), SVector(4,5,6))) === @SMatrix [1 4; 2 5; 3 6]
 
-        @test vcat(@SMatrix([1;2;3]), SVector(4,5,6)) === @SMatrix([1;2;3;4;5;6])
-        @test vcat(SVector(1,2,3), @SMatrix([4;5;6])) === @SMatrix([1;2;3;4;5;6])
-        @test hcat(@SMatrix([1;2;3]), SVector(4,5,6)) === @SMatrix [1 4; 2 5; 3 6]
-        @test hcat(SVector(1,2,3), @SMatrix([4;5;6])) === @SMatrix [1 4; 2 5; 3 6]
+        @test @inferred(vcat(@SMatrix([1;2;3]), SVector(4,5,6))) === @SMatrix([1;2;3;4;5;6])
+        @test @inferred(vcat(SVector(1,2,3), @SMatrix([4;5;6]))) === @SMatrix([1;2;3;4;5;6])
+        @test @inferred(hcat(@SMatrix([1;2;3]), SVector(4,5,6))) === @SMatrix [1 4; 2 5; 3 6]
+        @test @inferred(hcat(SVector(1,2,3), @SMatrix([4;5;6]))) === @SMatrix [1 4; 2 5; 3 6]
 
-        @test vcat(@SMatrix([1;2;3]), @SMatrix([4;5;6])) === @SMatrix([1;2;3;4;5;6])
-        @test hcat(@SMatrix([1;2;3]), @SMatrix([4;5;6])) === @SMatrix [1 4; 2 5; 3 6]
+        @test @inferred(vcat(@SMatrix([1;2;3]), @SMatrix([4;5;6]))) === @SMatrix([1;2;3;4;5;6])
+        @test @inferred(hcat(@SMatrix([1;2;3]), @SMatrix([4;5;6]))) === @SMatrix [1 4; 2 5; 3 6]
     end
 
     @testset "normalization" begin

--- a/test/mapreduce.jl
+++ b/test/mapreduce.jl
@@ -7,10 +7,10 @@
         normal_v1 = [2,4,6,8]
         normal_v2 = [4,3,2,1]
 
-        @test map(-, v1) === @SVector [-2, -4, -6, -8]
-        @test map(+, v1, v2) === @SVector [6, 7, 8, 9]
-        @test map(+, normal_v1, v2) === @SVector [6, 7, 8, 9]
-        @test map(+, v1, normal_v2) === @SVector [6, 7, 8, 9]
+        @test @inferred(map(-, v1)) === @SVector [-2, -4, -6, -8]
+        @test @inferred(map(+, v1, v2)) === @SVector [6, 7, 8, 9]
+        @test @inferred(map(+, normal_v1, v2)) === @SVector [6, 7, 8, 9]
+        @test @inferred(map(+, v1, normal_v2)) === @SVector [6, 7, 8, 9]
 
         map!(+, mv, v1, v2)
         @test mv == @MVector [6, 7, 8, 9]
@@ -58,11 +58,11 @@
         mm = MMatrix{4, 2, Int}()
         M = @SMatrix [1 2; 3 4; 5 6; 7 8]
 
-        @test broadcast(-, v1) === map(-, v1)
+        @test @inferred(broadcast(-, v1)) === map(-, v1)
 
-        @test broadcast(+, v1, c) === @SVector [4, 6, 8, 10]
-        @test broadcast(+, v1, v2) === map(+, v1, v2)
-        @test broadcast(+, v1, M) === @SMatrix [3 4; 7 8; 11 12; 15 16]
+        @test @inferred(broadcast(+, v1, c)) === @SVector [4, 6, 8, 10]
+        @test @inferred(broadcast(+, v1, v2)) === map(+, v1, v2)
+        @test @inferred(broadcast(+, v1, M)) === @SMatrix [3 4; 7 8; 11 12; 15 16]
 
         broadcast!(-, mv, v1)
         @test mv == @MVector [-2, -4, -6, -8]

--- a/test/matrix_multiply.jl
+++ b/test/matrix_multiply.jl
@@ -1,4 +1,4 @@
-@testset "Matrix multiplication" begin 
+@testset "Matrix multiplication" begin
     @testset "Matrix-vector" begin
         m = @SMatrix [1 2; 3 4]
         v = @SVector [1, 2]
@@ -37,7 +37,7 @@
     @testset "Vector-matrix" begin
         m = @SMatrix [1 2 3 4]
         v = @SVector [1, 2]
-        @test v*m === @SMatrix [1 2 3 4; 2 4 6 8]
+        @test @inferred(v*m) === @SMatrix [1 2 3 4; 2 4 6 8]
     end
 
     @testset "Matrix-matrix" begin
@@ -45,7 +45,7 @@
         n = @SMatrix [2 3; 4 5]
         nc = @SMatrix [CartesianIndex((2,2)) CartesianIndex((3,3));
                        CartesianIndex((4,4)) CartesianIndex((5,5))]
-        @test m*n  === @SMatrix [10 13; 22 29]
+        @test @inferred(m*n)  === @SMatrix [10 13; 22 29]
         @test m*nc === @SMatrix [CartesianIndex((10,10)) CartesianIndex((13,13));
                                  CartesianIndex((22,22)) CartesianIndex((29,29))]
 


### PR DESCRIPTION
 * Now we use `Size` more consistently and rely less on `@pure` implementations of `similar_type`.

 * `similar` and `similar_type` both use `Size` not integers to discuss size

 * `similar` and `similar_type` are now streamlined. Users only need to
   override one definition, just like in Base.

 * Associated documentation and test changes.