### PR TITLE
Use new inner constructor and type declaration syntax

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,1 @@
-julia 0.5
+julia 0.6-

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,2 @@
-julia 0.6-
+julia 0.5
+Compat 0.19.0

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,8 +2,8 @@ environment:
   matrix:
   - JULIAVERSION: "julialang/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
   - JULIAVERSION: "julialang/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
-#  - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
-#  - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
+  - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
+  - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
 
 branches:
   only:

--- a/src/FieldVector.jl
+++ b/src/FieldVector.jl
@@ -15,7 +15,7 @@ For example:
         z::Float64
     end
 """
-abstract FieldVector{T} <: StaticVector{T}
+abstract type FieldVector{T} <: StaticVector{T} end
 
 # Is this a good idea?? Should people just define constructors that accept tuples?
 @inline (::Type{FV}){FV<:FieldVector}(x::Tuple) = FV(x...)

--- a/src/FieldVector.jl
+++ b/src/FieldVector.jl
@@ -15,7 +15,7 @@ For example:
         z::Float64
     end
 """
-abstract type FieldVector{T} <: StaticVector{T} end
+@compat abstract type FieldVector{T} <: StaticVector{T} end
 
 # Is this a good idea?? Should people just define constructors that accept tuples?
 @inline (::Type{FV}){FV<:FieldVector}(x::Tuple) = FV(x...)

--- a/src/ImmutableArrays.jl
+++ b/src/ImmutableArrays.jl
@@ -1,31 +1,32 @@
 module ImmutableArrays
 
 using ..StaticArrays
+using Compat
 
-Vector1{T} = SVector{1,T}
-Vector2{T} = SVector{2,T}
-Vector3{T} = SVector{3,T}
-Vector4{T} = SVector{4,T}
+@compat Vector1{T} = SVector{1,T}
+@compat Vector2{T} = SVector{2,T}
+@compat Vector3{T} = SVector{3,T}
+@compat Vector4{T} = SVector{4,T}
 
-Matrix1x1{T} = SMatrix{1,1,T,1}
-Matrix1x2{T} = SMatrix{1,2,T,2}
-Matrix1x3{T} = SMatrix{1,3,T,3}
-Matrix1x4{T} = SMatrix{1,4,T,4}
+@compat Matrix1x1{T} = SMatrix{1,1,T,1}
+@compat Matrix1x2{T} = SMatrix{1,2,T,2}
+@compat Matrix1x3{T} = SMatrix{1,3,T,3}
+@compat Matrix1x4{T} = SMatrix{1,4,T,4}
 
-Matrix2x1{T} = SMatrix{2,1,T,2}
-Matrix2x2{T} = SMatrix{2,2,T,4}
-Matrix2x3{T} = SMatrix{2,3,T,6}
-Matrix2x4{T} = SMatrix{2,4,T,8}
+@compat Matrix2x1{T} = SMatrix{2,1,T,2}
+@compat Matrix2x2{T} = SMatrix{2,2,T,4}
+@compat Matrix2x3{T} = SMatrix{2,3,T,6}
+@compat Matrix2x4{T} = SMatrix{2,4,T,8}
 
-Matrix3x1{T} = SMatrix{3,1,T,3}
-Matrix3x2{T} = SMatrix{3,2,T,6}
-Matrix3x3{T} = SMatrix{3,3,T,9}
-Matrix3x4{T} = SMatrix{3,4,T,12}
+@compat Matrix3x1{T} = SMatrix{3,1,T,3}
+@compat Matrix3x2{T} = SMatrix{3,2,T,6}
+@compat Matrix3x3{T} = SMatrix{3,3,T,9}
+@compat Matrix3x4{T} = SMatrix{3,4,T,12}
 
-Matrix4x1{T} = SMatrix{4,1,T,4}
-Matrix4x2{T} = SMatrix{4,2,T,8}
-Matrix4x3{T} = SMatrix{4,3,T,12}
-Matrix4x4{T} = SMatrix{4,4,T,16}
+@compat Matrix4x1{T} = SMatrix{4,1,T,4}
+@compat Matrix4x2{T} = SMatrix{4,2,T,8}
+@compat Matrix4x3{T} = SMatrix{4,3,T,12}
+@compat Matrix4x4{T} = SMatrix{4,4,T,16}
 
 export Vector1,   Vector2,   Vector3,   Vector4,
        Matrix1x1, Matrix1x2, Matrix1x3, Matrix1x4,

--- a/src/ImmutableArrays.jl
+++ b/src/ImmutableArrays.jl
@@ -2,30 +2,30 @@ module ImmutableArrays
 
 using ..StaticArrays
 
-typealias Vector1{T} SVector{1,T}
-typealias Vector2{T} SVector{2,T}
-typealias Vector3{T} SVector{3,T}
-typealias Vector4{T} SVector{4,T}
+Vector1{T} = SVector{1,T}
+Vector2{T} = SVector{2,T}
+Vector3{T} = SVector{3,T}
+Vector4{T} = SVector{4,T}
 
-typealias Matrix1x1{T} SMatrix{1,1,T,1}
-typealias Matrix1x2{T} SMatrix{1,2,T,2}
-typealias Matrix1x3{T} SMatrix{1,3,T,3}
-typealias Matrix1x4{T} SMatrix{1,4,T,4}
+Matrix1x1{T} = SMatrix{1,1,T,1}
+Matrix1x2{T} = SMatrix{1,2,T,2}
+Matrix1x3{T} = SMatrix{1,3,T,3}
+Matrix1x4{T} = SMatrix{1,4,T,4}
 
-typealias Matrix2x1{T} SMatrix{2,1,T,2}
-typealias Matrix2x2{T} SMatrix{2,2,T,4}
-typealias Matrix2x3{T} SMatrix{2,3,T,6}
-typealias Matrix2x4{T} SMatrix{2,4,T,8}
+Matrix2x1{T} = SMatrix{2,1,T,2}
+Matrix2x2{T} = SMatrix{2,2,T,4}
+Matrix2x3{T} = SMatrix{2,3,T,6}
+Matrix2x4{T} = SMatrix{2,4,T,8}
 
-typealias Matrix3x1{T} SMatrix{3,1,T,3}
-typealias Matrix3x2{T} SMatrix{3,2,T,6}
-typealias Matrix3x3{T} SMatrix{3,3,T,9}
-typealias Matrix3x4{T} SMatrix{3,4,T,12}
+Matrix3x1{T} = SMatrix{3,1,T,3}
+Matrix3x2{T} = SMatrix{3,2,T,6}
+Matrix3x3{T} = SMatrix{3,3,T,9}
+Matrix3x4{T} = SMatrix{3,4,T,12}
 
-typealias Matrix4x1{T} SMatrix{4,1,T,4}
-typealias Matrix4x2{T} SMatrix{4,2,T,8}
-typealias Matrix4x3{T} SMatrix{4,3,T,12}
-typealias Matrix4x4{T} SMatrix{4,4,T,16}
+Matrix4x1{T} = SMatrix{4,1,T,4}
+Matrix4x2{T} = SMatrix{4,2,T,8}
+Matrix4x3{T} = SMatrix{4,3,T,12}
+Matrix4x4{T} = SMatrix{4,4,T,16}
 
 export Vector1,   Vector2,   Vector3,   Vector4,
        Matrix1x1, Matrix1x2, Matrix1x3, Matrix1x4,

--- a/src/MArray.jl
+++ b/src/MArray.jl
@@ -19,19 +19,19 @@ compiler (the element type may optionally also be specified).
 type MArray{Size, T, N, L} <: StaticArray{T, N}
     data::NTuple{L,T}
 
-    function MArray{Size,T,N,L}(x::NTuple{L,T}) where {Size,T,N,L}
+    function (::Type{MArray{Size,T,N,L}}){Size,T,N,L}(x::NTuple{L,T})
         check_marray_parameters(Val{Size}, T, Val{N}, Val{L})
-        new(x)
+        new{Size,T,N,L}(x)
     end
 
-    function MArray{Size,T,N,L}(x::NTuple{L,Any}) where {Size,T,N,L}
+    function (::Type{MArray{Size,T,N,L}}){Size,T,N,L}(x::NTuple{L,Any})
         check_marray_parameters(Val{Size}, T, Val{N}, Val{L})
-        new(convert_ntuple(T, x))
+        new{Size,T,N,L}(convert_ntuple(T, x))
     end
 
-    function MArray{Size,T,N,L}() where {Size,T,N,L}
+    function (::Type{MArray{Size,T,N,L}}){Size,T,N,L}()
         check_marray_parameters(Val{Size}, T, Val{N}, Val{L})
-        new()
+        new{Size,T,N,L}()
     end
 end
 

--- a/src/MArray.jl
+++ b/src/MArray.jl
@@ -19,17 +19,17 @@ compiler (the element type may optionally also be specified).
 type MArray{Size, T, N, L} <: StaticArray{T, N}
     data::NTuple{L,T}
 
-    function MArray(x::NTuple{L,T})
+    function MArray{Size,T,N,L}(x::NTuple{L,T}) where {Size,T,N,L}
         check_marray_parameters(Val{Size}, T, Val{N}, Val{L})
         new(x)
     end
 
-    function MArray(x::NTuple{L,Any})
+    function MArray{Size,T,N,L}(x::NTuple{L,Any}) where {Size,T,N,L}
         check_marray_parameters(Val{Size}, T, Val{N}, Val{L})
         new(convert_ntuple(T, x))
     end
 
-    function MArray()
+    function MArray{Size,T,N,L}() where {Size,T,N,L}
         check_marray_parameters(Val{Size}, T, Val{N}, Val{L})
         new()
     end

--- a/src/MMatrix.jl
+++ b/src/MMatrix.jl
@@ -18,14 +18,14 @@ unknown to the compiler (the element type may optionally also be specified).
 type MMatrix{S1, S2, T, L} <: StaticMatrix{T}
     data::NTuple{L, T}
 
-    function MMatrix{S1,S2,T,L}(d::NTuple{L,T}) where {S1,S2,T,L}
+    function (::Type{MMatrix{S1,S2,T,L}}){S1,S2,T,L}(d::NTuple{L,T})
         check_MMatrix_params(Val{S1}, Val{S2}, T, Val{L})
-        new(d)
+        new{S1,S2,T,L}(d)
     end
 
-    function MMatrix{S1,S2,T,L}(d::NTuple{L,Any}) where {S1,S2,T,L}
+    function (::Type{MMatrix{S1,S2,T,L}}){S1,S2,T,L}(d::NTuple{L,Any})
         check_MMatrix_params(Val{S1}, Val{S2}, T, Val{L})
-        new(convert_ntuple(T, d))
+        new{S1,S2,T,L}(convert_ntuple(T, d))
     end
 
     function MMatrix{S1,S2,T,L}() where {S1,S2,T,L}

--- a/src/MMatrix.jl
+++ b/src/MMatrix.jl
@@ -28,9 +28,9 @@ type MMatrix{S1, S2, T, L} <: StaticMatrix{T}
         new{S1,S2,T,L}(convert_ntuple(T, d))
     end
 
-    function MMatrix{S1,S2,T,L}() where {S1,S2,T,L}
+    function (::Type{MMatrix{S1,S2,T,L}}){S1,S2,T,L}()
         check_MMatrix_params(Val{S1}, Val{S2}, T, Val{L})
-        new()
+        new{S1,S2,T,L}()
     end
 end
 

--- a/src/MMatrix.jl
+++ b/src/MMatrix.jl
@@ -18,17 +18,17 @@ unknown to the compiler (the element type may optionally also be specified).
 type MMatrix{S1, S2, T, L} <: StaticMatrix{T}
     data::NTuple{L, T}
 
-    function MMatrix(d::NTuple{L,T})
+    function MMatrix{S1,S2,T,L}(d::NTuple{L,T}) where {S1,S2,T,L}
         check_MMatrix_params(Val{S1}, Val{S2}, T, Val{L})
         new(d)
     end
 
-    function MMatrix(d::NTuple{L,Any})
+    function MMatrix{S1,S2,T,L}(d::NTuple{L,Any}) where {S1,S2,T,L}
         check_MMatrix_params(Val{S1}, Val{S2}, T, Val{L})
         new(convert_ntuple(T, d))
     end
 
-    function MMatrix()
+    function MMatrix{S1,S2,T,L}() where {S1,S2,T,L}
         check_MMatrix_params(Val{S1}, Val{S2}, T, Val{L})
         new()
     end

--- a/src/MVector.jl
+++ b/src/MVector.jl
@@ -17,19 +17,19 @@ compiler (the element type may optionally also be specified).
 type MVector{S, T} <: StaticVector{T}
     data::NTuple{S, T}
 
-    function MVector(in::NTuple{S, T})
+    function MVector{S,T}(in::NTuple{S, T}) where {S,T}
         new(in)
     end
 
-    function MVector(in::NTuple{S, Any})
+    function MVector{S,T}(in::NTuple{S, Any}) where {S,T}
         new(convert_ntuple(T,in))
     end
 
-    function MVector(in::T)
+    function MVector{S,T}(in::T) where {S,T}
         new((in,))
     end
 
-    function MVector()
+    function MVector{S,T}() where {S,T}
         new()
     end
 end

--- a/src/MVector.jl
+++ b/src/MVector.jl
@@ -17,20 +17,20 @@ compiler (the element type may optionally also be specified).
 type MVector{S, T} <: StaticVector{T}
     data::NTuple{S, T}
 
-    function MVector{S,T}(in::NTuple{S, T}) where {S,T}
-        new(in)
+    function (::Type{MVector{S,T}}){S,T}(in::NTuple{S, T})
+        new{S,T}(in)
     end
 
-    function MVector{S,T}(in::NTuple{S, Any}) where {S,T}
-        new(convert_ntuple(T,in))
+    function (::Type{MVector{S,T}}){S,T}(in::NTuple{S, Any})
+        new{S,T}(convert_ntuple(T,in))
     end
 
-    function MVector{S,T}(in::T) where {S,T}
-        new((in,))
+    function (::Type{MVector{S,T}}){S,T}(in::T)
+        new{S,T}((in,))
     end
 
-    function MVector{S,T}() where {S,T}
-        new()
+    function (::Type{MVector{S,T}}){S,T}()
+        new{S,T}()
     end
 end
 

--- a/src/SArray.jl
+++ b/src/SArray.jl
@@ -18,12 +18,12 @@ compiler (the element type may optionally also be specified).
 immutable SArray{Size, T, N, L} <: StaticArray{T, N}
     data::NTuple{L,T}
 
-    function SArray(x::NTuple{L,T})
+    function SArray{Size,T,N,L}(x::NTuple{L,T}) where {Size,T,N,L}
         check_sarray_parameters(Val{Size}, T, Val{N}, Val{L})
         new(x)
     end
 
-    function SArray(x::NTuple{L,Any})
+    function SArray{Size,T,N,L}(x::NTuple{L,Any}) where {Size,T,N,L}
         check_sarray_parameters(Val{Size}, T, Val{N}, Val{L})
         new(convert_ntuple(T, x))
     end

--- a/src/SArray.jl
+++ b/src/SArray.jl
@@ -18,14 +18,14 @@ compiler (the element type may optionally also be specified).
 immutable SArray{Size, T, N, L} <: StaticArray{T, N}
     data::NTuple{L,T}
 
-    function SArray{Size,T,N,L}(x::NTuple{L,T}) where {Size,T,N,L}
+    function (::Type{SArray{Size,T,N,L}}){Size,T,N,L}(x::NTuple{L,T})
         check_sarray_parameters(Val{Size}, T, Val{N}, Val{L})
-        new(x)
+        new{Size,T,N,L}(x)
     end
 
-    function SArray{Size,T,N,L}(x::NTuple{L,Any}) where {Size,T,N,L}
+    function (::Type{SArray{Size,T,N,L}}){Size,T,N,L}(x::NTuple{L,Any})
         check_sarray_parameters(Val{Size}, T, Val{N}, Val{L})
-        new(convert_ntuple(T, x))
+        new{Size,T,N,L}(convert_ntuple(T, x))
     end
 end
 

--- a/src/SMatrix.jl
+++ b/src/SMatrix.jl
@@ -66,7 +66,7 @@ end
         SMatrix{S1, S2, $T, L}(x)
     end
 end
-SMatrixNoType{S1, S2, L, T} = SMatrix{S1, S2, T, L}
+@compat SMatrixNoType{S1, S2, L, T} = SMatrix{S1, S2, T, L}
 @generated function (::Type{SMatrixNoType{S1, S2, L}}){S1,S2,L}(x::NTuple{L,Any})
     T = promote_tuple_eltype(x)
     return quote

--- a/src/SMatrix.jl
+++ b/src/SMatrix.jl
@@ -17,14 +17,14 @@ unknown to the compiler (the element type may optionally also be specified).
 immutable SMatrix{S1, S2, T, L} <: StaticMatrix{T}
     data::NTuple{L, T}
 
-    function SMatrix{S1,S2,T,L}(d::NTuple{L,T}) where {S1,S2,T,L}
+    function (::Type{SMatrix{S1,S2,T,L}}){S1,S2,T,L}(d::NTuple{L,T})
         check_smatrix_params(Val{S1}, Val{S2}, T, Val{L})
-        new(d)
+        new{S1,S2,T,L}(d)
     end
 
-    function SMatrix{S1,S2,T,L}(d::NTuple{L,Any}) where {S1,S2,T,L}
+    function (::Type{SMatrix{S1,S2,T,L}}){S1,S2,T,L}(d::NTuple{L,Any})
         check_smatrix_params(Val{S1}, Val{S2}, T, Val{L})
-        new(convert_ntuple(T, d))
+        new{S1,S2,T,L}(convert_ntuple(T, d))
     end
 end
 

--- a/src/SMatrix.jl
+++ b/src/SMatrix.jl
@@ -17,12 +17,12 @@ unknown to the compiler (the element type may optionally also be specified).
 immutable SMatrix{S1, S2, T, L} <: StaticMatrix{T}
     data::NTuple{L, T}
 
-    function SMatrix(d::NTuple{L,T})
+    function SMatrix{S1,S2,T,L}(d::NTuple{L,T}) where {S1,S2,T,L}
         check_smatrix_params(Val{S1}, Val{S2}, T, Val{L})
         new(d)
     end
 
-    function SMatrix(d::NTuple{L,Any})
+    function SMatrix{S1,S2,T,L}(d::NTuple{L,Any}) where {S1,S2,T,L}
         check_smatrix_params(Val{S1}, Val{S2}, T, Val{L})
         new(convert_ntuple(T, d))
     end
@@ -66,7 +66,7 @@ end
         SMatrix{S1, S2, $T, L}(x)
     end
 end
-typealias SMatrixNoType{S1, S2, L, T} SMatrix{S1, S2, T, L}
+SMatrixNoType{S1, S2, L, T} = SMatrix{S1, S2, T, L}
 @generated function (::Type{SMatrixNoType{S1, S2, L}}){S1,S2,L}(x::NTuple{L,Any})
     T = promote_tuple_eltype(x)
     return quote

--- a/src/SVector.jl
+++ b/src/SVector.jl
@@ -16,12 +16,12 @@ compiler (the element type may optionally also be specified).
 immutable SVector{S, T} <: StaticVector{T}
     data::NTuple{S, T}
 
-    function SVector{S, T}(x::NTuple{S,T}) where {S, T}
-        new(x)
+    function (::Type{SVector{S, T}}){S, T}(x::NTuple{S,T})
+        new{S, T}(x)
     end
 
-    function SVector{S, T}(x::NTuple{S,Any}) where {S, T}
-        new(convert_ntuple(T, x))
+    function (::Type{SVector{S, T}}){S, T}(x::NTuple{S,Any})
+        new{S, T}(convert_ntuple(T, x))
     end
 end
 

--- a/src/SVector.jl
+++ b/src/SVector.jl
@@ -16,11 +16,11 @@ compiler (the element type may optionally also be specified).
 immutable SVector{S, T} <: StaticVector{T}
     data::NTuple{S, T}
 
-    function SVector(x::NTuple{S,T})
+    function SVector{S, T}(x::NTuple{S,T}) where {S, T}
         new(x)
     end
 
-    function SVector(x::NTuple{S,Any})
+    function SVector{S, T}(x::NTuple{S,Any}) where {S, T}
         new(convert_ntuple(T, x))
     end
 end

--- a/src/SizedArray.jl
+++ b/src/SizedArray.jl
@@ -12,15 +12,15 @@ array may be reshaped.
 immutable SizedArray{S,T,N,M} <: StaticArray{T,N}
     data::Array{T,M}
 
-    function SizedArray{S,T,N,M}(a::Array) where {S,T,N,M}
+    function (::Type{SizedArray{S,T,N,M}}){S,T,N,M}(a::Array)
         if length(a) != prod(S)
             error("Dimensions $(size(a)) don't match static size $S")
         end
-        new(a)
+        new{S,T,N,M}(a)
     end
 
-    function SizedArray{S,T,N,M}() where {S,T,N,M}
-        new(Array{T,M}(S))
+    function (::Type{SizedArray{S,T,N,M}}){S,T,N,M}()
+        new{S,T,N,M}(Array{T,M}(S))
     end
 end
 

--- a/src/SizedArray.jl
+++ b/src/SizedArray.jl
@@ -12,14 +12,14 @@ array may be reshaped.
 immutable SizedArray{S,T,N,M} <: StaticArray{T,N}
     data::Array{T,M}
 
-    function SizedArray(a::Array)
+    function SizedArray{S,T,N,M}(a::Array) where {S,T,N,M}
         if length(a) != prod(S)
             error("Dimensions $(size(a)) don't match static size $S")
         end
         new(a)
     end
 
-    function SizedArray()
+    function SizedArray{S,T,N,M}() where {S,T,N,M}
         new(Array{T,M}(S))
     end
 end
@@ -71,14 +71,14 @@ end
 @propagate_inbounds getindex(a::SizedArray, i::Int) = getindex(a.data, i)
 @propagate_inbounds setindex!(a::SizedArray, v, i::Int) = setindex!(a.data, v, i)
 
-typealias SizedVector{S,T,M} SizedArray{S,T,1,M}
+@compat SizedVector{S,T,M} = SizedArray{S,T,1,M}
 @pure Size{S}(::Type{SizedVector{S}}) = Size(S)
 @inline (::Type{SizedVector{S}}){S,T,M}(a::Array{T,M}) = SizedArray{S,T,1,M}(a)
 @inline (::Type{SizedVector{S}}){S,T,L}(x::NTuple{L,T}) = SizedArray{S,T,1,1}(x)
 @inline (::Type{Vector})(sa::SizedVector) = sa.data
 @inline convert(::Type{Vector}, sa::SizedVector) = sa.data
 
-typealias SizedMatrix{S,T,M} SizedArray{S,T,2,M}
+@compat SizedMatrix{S,T,M} = SizedArray{S,T,2,M}
 @pure Size{S}(::Type{SizedMatrix{S}}) = Size(S)
 @inline (::Type{SizedMatrix{S}}){S,T,M}(a::Array{T,M}) = SizedArray{S,T,2,M}(a)
 @inline (::Type{SizedMatrix{S}}){S,T,L}(x::NTuple{L,T}) = SizedArray{S,T,2,2}(x)

--- a/src/StaticArrays.jl
+++ b/src/StaticArrays.jl
@@ -10,6 +10,8 @@ import Base: @pure, @propagate_inbounds, getindex, setindex!, size, similar,
              sum, diff, prod, count, any, all, sumabs, sumabs2, minimum,
              maximum, extrema, mean, copy
 
+using Compat
+
 export StaticScalar, StaticArray, StaticVector, StaticMatrix
 export Scalar, SArray, SVector, SMatrix
 export MArray, MVector, MMatrix

--- a/src/abstractarray.jl
+++ b/src/abstractarray.jl
@@ -1,4 +1,4 @@
-StaticScalar{T} = StaticArray{T,0}
+@compat StaticScalar{T} = StaticArray{T,0}
 
 length{T<:StaticArray}(a::T) = prod(Size(T))
 length{T<:StaticArray}(a::Type{T}) = prod(Size(T))
@@ -30,8 +30,7 @@ end
     1 <= ii <= length(a) ? true : false
 end
 
-Base.linearindexing(::StaticArray) = Base.LinearFast()
-Base.linearindexing{T<:StaticArray}(::Type{T}) = Base.LinearFast()
+@compat Base.IndexStyle{T<:StaticArray}(::Type{T}) = Base.IndexLinear()
 
 # Default type search for similar_type
 """

--- a/src/abstractarray.jl
+++ b/src/abstractarray.jl
@@ -1,4 +1,4 @@
-typealias StaticScalar{T} StaticArray{T,0}
+StaticScalar{T} = StaticArray{T,0}
 
 length{T<:StaticArray}(a::T) = prod(Size(T))
 length{T<:StaticArray}(a::Type{T}) = prod(Size(T))

--- a/src/abstractarray.jl
+++ b/src/abstractarray.jl
@@ -30,7 +30,7 @@ end
     1 <= ii <= length(a) ? true : false
 end
 
-@compat Base.IndexStyle{T<:StaticArray}(::Type{T}) = Base.IndexLinear()
+@compat Base.IndexStyle{T<:StaticArray}(::Type{T}) = IndexLinear()
 
 # Default type search for similar_type
 """

--- a/src/core.jl
+++ b/src/core.jl
@@ -27,10 +27,10 @@ For mutable containers you may also need to define the following:
 
 (see also `SVector`, `SMatrix`, `SArray`, `MVector`, `MMatrix`, `MArray`, `SizedArray` and `FieldVector`)
 """
-abstract type StaticArray{T, N} <: AbstractArray{T, N} end
+@compat abstract type StaticArray{T, N} <: AbstractArray{T, N} end
 
-StaticVector{T} = StaticArray{T, 1}
-StaticMatrix{T} = StaticArray{T, 2}
+@compat StaticVector{T} = StaticArray{T, 1}
+@compat StaticMatrix{T} = StaticArray{T, 2}
 
 # People might not want to use Tuple for everything (TODO: check this with FieldVector...)
 # Generic case, with least 2 inputs

--- a/src/core.jl
+++ b/src/core.jl
@@ -1,7 +1,7 @@
 """
     abstract StaticArray{T, N} <: AbstractArray{T, N}
-    typealias StaticVector{T} StaticArray{T, 1}
-    typealias StaticMatrix{T} StaticArray{T, 2}
+    StaticVector{T} = StaticArray{T, 1}
+    StaticMatrix{T} = StaticArray{T, 2}
 
 `StaticArray`s are Julia arrays with fixed, known size.
 
@@ -27,10 +27,10 @@ For mutable containers you may also need to define the following:
 
 (see also `SVector`, `SMatrix`, `SArray`, `MVector`, `MMatrix`, `MArray`, `SizedArray` and `FieldVector`)
 """
-abstract StaticArray{T, N} <: AbstractArray{T, N}
+abstract type StaticArray{T, N} <: AbstractArray{T, N} end
 
-typealias StaticVector{T} StaticArray{T, 1}
-typealias StaticMatrix{T} StaticArray{T, 2}
+StaticVector{T} = StaticArray{T, 1}
+StaticMatrix{T} = StaticArray{T, 2}
 
 # People might not want to use Tuple for everything (TODO: check this with FieldVector...)
 # Generic case, with least 2 inputs

--- a/src/matrix_multiply.jl
+++ b/src/matrix_multiply.jl
@@ -1,8 +1,6 @@
 import Base: *,        Ac_mul_B,  A_mul_Bc,  Ac_mul_Bc,  At_mul_B,  A_mul_Bt,  At_mul_Bt
 import Base: A_mul_B!, Ac_mul_B!, A_mul_Bc!, Ac_mul_Bc!, At_mul_B!, A_mul_Bt!, At_mul_Bt!
 
-typealias BlasEltypes Union{Float64, Float32, Complex{Float64}, Complex{Float32}}
-
 # Idea inspired by https://github.com/JuliaLang/julia/pull/18218
 promote_matprod{T1,T2}(::Type{T1}, ::Type{T2}) = typeof(zero(T1)*zero(T2) + zero(T1)*zero(T2))
 

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -21,9 +21,9 @@ _det(::Size{(2,2)}, x::StaticMatrix) = x[1,1]*x[2,2] - x[1,2]*x[2,1]
 ```
 """
 immutable Size{S}
-    function Size{S}() where S
+    function (::Type{Size{S}}){S}()
         check_size(S)
-        new()
+        new{S}()
     end
 end
 

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -21,7 +21,7 @@ _det(::Size{(2,2)}, x::StaticMatrix) = x[1,1]*x[2,2] - x[1,2]*x[2,1]
 ```
 """
 immutable Size{S}
-    function Size()
+    function Size{S}() where S
         check_size(S)
         new()
     end

--- a/src/util.jl
+++ b/src/util.jl
@@ -1,5 +1,5 @@
 # For convenience
-TupleN{T,N} = NTuple{N,T}
+@compat TupleN{T,N} = NTuple{N,T}
 
 # Cast any Tuple to an TupleN{T}
 @inline convert_ntuple{T}(::Type{T},d::T) = T # For zero-dimensional arrays

--- a/src/util.jl
+++ b/src/util.jl
@@ -1,5 +1,5 @@
 # For convenience
-typealias TupleN{T,N} NTuple{N,T}
+TupleN{T,N} = NTuple{N,T}
 
 # Cast any Tuple to an TupleN{T}
 @inline convert_ntuple{T}(::Type{T},d::T) = T # For zero-dimensional arrays

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -3,7 +3,7 @@
         m = @SMatrix [1 2 3; 4 5 6; 7 8 9; 10 11 12]
 
         @test length(m) == 12
-        @test @compat(Base.IndexStyle(m)) == @compat(Base.IndexLinear())
+        @test IndexStyle(m) == IndexLinear()
         @test Base.isassigned(m, 2, 2) == true
     end
 

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -3,7 +3,7 @@
         m = @SMatrix [1 2 3; 4 5 6; 7 8 9; 10 11 12]
 
         @test length(m) == 12
-        @test Base.linearindexing(m) == Base.LinearFast()
+        @test @compat(Base.IndexStyle(m)) == @compat(Base.IndexLinear())
         @test Base.isassigned(m, 2, 2) == true
     end
 

--- a/test/fixed_size_arrays.jl
+++ b/test/fixed_size_arrays.jl
@@ -8,15 +8,15 @@ import StaticArrays.FixedSizeArrays: @fixed_vector
 
 @fixed_vector Point StaticVector
 
-const Vec1d = Vec{1, Float64}
-const Vec2d = Vec{2, Float64}
-const Vec3d = Vec{3, Float64}
-const Vec4d = Vec{4, Float64}
-const Vec3f = Vec{3, Float32}
+@compat const Vec1d = Vec{1, Float64}
+@compat const Vec2d = Vec{2, Float64}
+@compat const Vec3d = Vec{3, Float64}
+@compat const Vec4d = Vec{4, Float64}
+@compat const Vec3f = Vec{3, Float32}
 
-const Mat2d = Mat{2,2, Float64, 4}
-const Mat3d = Mat{3,3, Float64, 9}
-const Mat4d = Mat{4,4, Float64, 16}
+@compat const Mat2d = Mat{2,2, Float64, 4}
+@compat const Mat3d = Mat{3,3, Float64, 9}
+@compat const Mat4d = Mat{4,4, Float64, 16}
 
 immutable RGB{T} <: FieldVector{T}
     x::T

--- a/test/fixed_size_arrays.jl
+++ b/test/fixed_size_arrays.jl
@@ -8,15 +8,15 @@ import StaticArrays.FixedSizeArrays: @fixed_vector
 
 @fixed_vector Point StaticVector
 
-typealias Vec1d Vec{1, Float64}
-typealias Vec2d Vec{2, Float64}
-typealias Vec3d Vec{3, Float64}
-typealias Vec4d Vec{4, Float64}
-typealias Vec3f Vec{3, Float32}
+const Vec1d = Vec{1, Float64}
+const Vec2d = Vec{2, Float64}
+const Vec3d = Vec{3, Float64}
+const Vec4d = Vec{4, Float64}
+const Vec3f = Vec{3, Float32}
 
-typealias Mat2d Mat{2,2, Float64, 4}
-typealias Mat3d Mat{3,3, Float64, 9}
-typealias Mat4d Mat{4,4, Float64, 16}
+const Mat2d = Mat{2,2, Float64, 4}
+const Mat3d = Mat{3,3, Float64, 9}
+const Mat4d = Mat{4,4, Float64, 16}
 
 immutable RGB{T} <: FieldVector{T}
     x::T

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using StaticArrays
 using Base.Test
+using Compat
 
 @testset "StaticArrays" begin
     include("SVector.jl")


### PR DESCRIPTION
The new syntax for inner constructors doesn't parse on 0.5 so it will be ugly and more demanding to support on both versions. Furthermore, 0.6 will be out soon and nobody will care about 0.5. If they care anyway and we add features then we can backport those features to a 0.5 branch.