### PR TITLE
fall back to constructor in convert

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -36,7 +36,7 @@ For mutable containers you may also need to define the following:
 # Generic case, with least 2 inputs
 @inline (::Type{SA}){SA<:StaticArray}(x1,x2,xs...) = SA((x1,x2,xs...))
 
-@inline convert{SA<:StaticArray}(::Type{SA}, x::Tuple) = error("No precise constructor found. Length of input was $(length(x)) while length of $SA is $(length(SA)).")
+@inline convert{SA<:StaticArray}(::Type{SA}, x::Tuple) = SA(x)
 
 # Avoiding splatting penalties. Being here, implementations of StaticArray will not have to deal with these. TODO check these are necessary or not
 #@inline (::Type{SA}){SA<:StaticArray}(x1) = SA((x1,)) # see convert below (lesser precedence than other constructors?)


### PR DESCRIPTION
... This removes the annoyance, that e.g. `convert(SVector{3, Float64}, (1.0, 1.0, 1.0))` fails with an error message which doesn't make sense!