### PR TITLE
allow Union entries to SMatrix

### DIFF
--- a/src/MMatrix.jl
+++ b/src/MMatrix.jl
@@ -35,10 +35,6 @@ type MMatrix{S1, S2, T, L} <: StaticMatrix{T}
 end
 
 @generated function check_MMatrix_params{S1,S2,L}(::Type{Val{S1}}, ::Type{Val{S2}}, T, ::Type{Val{L}})
-    if !(T <: DataType) # I think the way types are handled in generated fnctions might have changed in 0.5?
-        return :(error("MMatrix: Parameter T must be a DataType. Got $T"))
-    end
-
     if !isa(S1, Int) || !isa(S2, Int) || !isa(L, Int) || S1 < 0 || S2 < 0 || L < 0
         return :(error("MMatrix: Sizes must be positive integers. Got $S1 × $S2 ($L elements)"))
     end

--- a/src/SMatrix.jl
+++ b/src/SMatrix.jl
@@ -29,10 +29,6 @@ immutable SMatrix{S1, S2, T, L} <: StaticMatrix{T}
 end
 
 @generated function check_smatrix_params{S1,S2,L}(::Type{Val{S1}}, ::Type{Val{S2}}, T, ::Type{Val{L}})
-    if !(T <: DataType) # I think the way types are handled in generated fnctions might have changed in 0.5?
-        return :(error("SMatrix: Parameter T must be a DataType. Got $T"))
-    end
-
     if !isa(S1, Int) || !isa(S2, Int) || !isa(L, Int) || S1 < 0 || S2 < 0 || L < 0
         return :(error("SMatrix: Sizes must be positive integers. Got $S1 × $S2 ($L elements)"))
     end

--- a/src/util.jl
+++ b/src/util.jl
@@ -11,6 +11,7 @@
         $(Expr(:tuple, exprs...))
     end
 end
+convert_ntuple(T,_) = error("StaticArray type parameter must be a Type, not '$T'")
 
 # Base gives up on tuples for promote_eltype... (TODO can we improve Base?)
 @generated function promote_tuple_eltype{T <: Tuple}(::Union{T,Type{T}})


### PR DESCRIPTION
Currently it looks like you can't do SMatrices with any sort of Union element type. SVectors and SArrays are fine though,

```julia
julia> SVector{1,Complex}(1)
1-element StaticArrays.SVector{1,Complex}:
 1+0im

julia> SArray{(1,),Complex}(1)
1-element StaticArrays.SArray{(1,),Complex,1,1}:
 1+0im

julia> SMatrix{1,1,Complex,1}(1)
ERROR: SMatrix: Parameter T must be a DataType. Got Complex
Stacktrace:
 [1] Type at /home/marius/.julia/v0.6/StaticArrays/src/SMatrix.jl:26 [inlined]
 [2] StaticArrays.SMatrix{1,1,Complex,1}(::Int64) at /home/marius/.julia/v0.6/StaticArrays/src/convert.jl:3
```

From a performance standpoint you would obviously never do this, but it seems it should at least work. The fix is just delete three lines which the comment there indicates might have just been forgotten about, but I've only started using this package in the last couple of days so an expert should check if this is a good fix!

(PS, thanks for the great package, and for the ahead-of-the-curve 0.6 upgrades)