### PR TITLE
modify varargs signatures to ensure at least one input

### DIFF
--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -4,8 +4,8 @@
 
 # TODO: bad codegen for `broadcast(-, SVector(1,2,3))`
 
-@propagate_inbounds function broadcast(f, a::Union{Number, StaticArray}...)
-    _broadcast(f, broadcast_sizes(a...), a...)
+@propagate_inbounds function broadcast(f, a::Union{Number, StaticArray}, b::Union{Number, StaticArray}...)
+    _broadcast(f, broadcast_sizes(a, b...), a, b...)
 end
 
 @inline broadcast_sizes(a...) = _broadcast_sizes((), a...)

--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -15,8 +15,8 @@ end
 ## map / map! ##
 ################
 
-@inline function map(f, a::StaticArray...)
-    _map(f, same_size(a...), a...)
+@inline function map(f, a::StaticArray, b::StaticArray...)
+    _map(f, same_size(a, b...), a, b...)
 end
 
 @generated function _map(f, ::Size{S}, a::StaticArray...) where {S}
@@ -62,12 +62,12 @@ end
 ## mapreduce ##
 ###############
 
-@inline function mapreduce(f, op, a::StaticArray...)
-    _mapreduce(f, op, same_size(a...), a...)
+@inline function mapreduce(f, op, a::StaticArray, b::StaticArray...)
+    _mapreduce(f, op, same_size(a, b...), a, b...)
 end
 
-@inline function mapreduce(f, op, v0, a::StaticArray...)
-    _mapreduce(f, op, v0, same_size(a...), a...)
+@inline function mapreduce(f, op, v0, a::StaticArray, b::StaticArray...)
+    _mapreduce(f, op, v0, same_size(a, b...), a, b...)
 end
 
 @generated function _mapreduce(f, op, ::Size{S}, a::StaticArray...) where {S}


### PR DESCRIPTION
to avoid defining methods that don't make much sense like `mapreduce(f, op)`