### PR TITLE
WIP Add size to abstract StaticArray type

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,10 +325,10 @@ an `MArray` might be preferable.
 
 Sometimes it might be useful to imbue your own types, having multiple fields,
 with vector-like properties. *StaticArrays* can take care of this for you by
-allowing you to inherit from `FieldVector{T}`. For example, consider:
+allowing you to inherit from `FieldVector{N, T}`. For example, consider:
 
 ```julia
-immutable Point3D <: FieldVector{Float64}
+immutable Point3D <: FieldVector{3, Float64}
     x::Float64
     y::Float64
     z::Float64
@@ -337,21 +337,22 @@ end
 
 With this type, users can easily access fields to `p = Point3D(x,y,z)` using
 `p.x`, `p.y` or `p.z`, or alternatively via `p[1]`, `p[2]`, or `p[3]`. You may
-even permute the coordinates with `p[(3,2,1)]`). Furthermore, `Point3D` is a
-complete `AbstractVector` implementation where you can add, subtract or scale
-vectors, multiply them by matrices (and return the same type), etc.
+even permute the coordinates with `p[SVector(3,2,1)]`). Furthermore, `Point3D`
+is a complete `AbstractVector` implementation where you can add, subtract or
+scale vectors, multiply them by matrices, etc.
 
 It is also worth noting that `FieldVector`s may be mutable or immutable, and
-that `setindex!` is defined for use on mutable types. For mutable containers,
-you may want to define a default constructor (no inputs) that can be called by
-`similar`.
+that `setindex!` is defined for use on mutable types. For immutable containers,
+you may want to define a method for `similar_type` so that operations leave the
+type constant (otherwise they may fall back to `SVector`). For mutable
+containers, you may want to define a default constructor (no inputs) and an
+appropriate method for `similar`,
 
 ### Implementing your own types
 
-You can easily create your own `StaticArray` type, by defining both `Size` (on the
-*type*, e.g. `StaticArrays.Size(::Type{Point3D}) = Size(3)`), and linear
+You can easily create your own `StaticArray` type, by defining linear
 `getindex` (and optionally `setindex!` for mutable types - see
-`setindex(::SVector, val, i)` in *MVector.jl* for an example of how to
+`setindex(::MArray, val, i)` in *MArray.jl* for an example of how to
 achieve this through pointer manipulation). Your type should define a constructor
 that takes a tuple of the data (and mutable containers may want to define a
 default constructor).

--- a/src/FieldVector.jl
+++ b/src/FieldVector.jl
@@ -1,29 +1,26 @@
 """
-    abstract FieldVector{T} <: StaticVector{T}
+    abstract FieldVector{N, T} <: StaticVector{N, T}
 
 Inheriting from this type will make it easy to create your own vector types. A `FieldVector`
-will automatically determine its size from the number of fields, and define `getindex` and
-`setindex!` appropriately. An immutable `FieldVector` will be as performant as an `SVector`
-of similar length and element type, while a mutable `FieldVector` will behave similarly to
-an `MVector`.
+will automatically define `getindex` and `setindex!` appropriately. An immutable
+`FieldVector` will be as performant as an `SVector` of similar length and element type,
+while a mutable `FieldVector` will behave similarly to an `MVector`.
 
 For example:
 
-    immutable/type Point3D <: FieldVector{Float64}
+    immutable/type Point3D <: FieldVector{3, Float64}
         x::Float64
         y::Float64
         z::Float64
     end
 """
-abstract type FieldVector{T} <: StaticVector{T} end
+abstract type FieldVector{N, T} <: StaticVector{N, T} end
 
 # Is this a good idea?? Should people just define constructors that accept tuples?
-@inline (::Type{FV}){FV<:FieldVector}(x::Tuple) = FV(x...)
+@inline (::Type{FV})(x::Tuple) where {FV <: FieldVector} = FV(x...)
 
-@pure Size{FV<:FieldVector}(::Type{FV}) = Size(nfields(FV))
-
-@inline getindex(v::FieldVector, i::Int) = getfield(v, i)
-@inline setindex!(v::FieldVector, x, i::Int) = setfield!(v, i, x)
+@propagate_inbounds getindex(v::FieldVector, i::Int) = getfield(v, i)
+@propagate_inbounds setindex!(v::FieldVector, x, i::Int) = setfield!(v, i, x)
 
 # See #53
 Base.cconvert{T}(::Type{Ptr{T}}, v::FieldVector) = Ref(v)

--- a/src/MArray.jl
+++ b/src/MArray.jl
@@ -17,7 +17,7 @@ Construct a statically-sized, mutable array of dimensions `S` (expressed as a `T
 using the data from `a`. The `S` parameter is mandatory since the size of `a` is unknown to
 the compiler (the element type may optionally also be specified).
 """
-type MArray{S, T, N, L} <: StaticArray{S, T, N}
+type MArray{S <: Tuple, T, N, L} <: StaticArray{S, T, N}
     data::NTuple{L,T}
 
     function (::Type{MArray{S,T,N,L}}){S,T,N,L}(x::NTuple{L,T})
@@ -91,14 +91,14 @@ function getindex(v::MArray, i::Int)
     v.data[i]
 end
 
-@propagate_inbounds setindex!{S,T}(v::MArray{S,T}, val, i::Int) = setindex!(v, convert(T, val), i)
-@inline function setindex!{S,T}(v::MArray{S,T}, val::T, i::Int)
+@inline function setindex!(v::MArray, val, i::Int)
     @boundscheck if i < 1 || i > length(v)
         throw(BoundsError())
     end
 
+    T = eltype(v)
     if isbits(T)
-        unsafe_store!(Base.unsafe_convert(Ptr{T}, Base.data_pointer_from_objref(v)), val, i)
+        unsafe_store!(Base.unsafe_convert(Ptr{T}, Base.data_pointer_from_objref(v)), convert(T, val), i)
     else
         # This one is unsafe (#27)
         # unsafe_store!(Base.unsafe_convert(Ptr{Ptr{Void}}, Base.data_pointer_from_objref(v.data)), Base.data_pointer_from_objref(val), i)

--- a/src/MMatrix.jl
+++ b/src/MMatrix.jl
@@ -53,8 +53,11 @@ end
     end
 end
 
-@inline convert{S1,S2,T}(::Type{MMatrix{S1,S2}}, a::StaticArray{T}) = MMatrix{S1,S2,T}(Tuple(a))
+@inline convert{S1,S2,T}(::Type{MMatrix{S1,S2}}, a::StaticArray{<:Any, T}) = MMatrix{S1,S2,T}(Tuple(a))
 @inline MMatrix(a::StaticMatrix) = MMatrix{size(typeof(a),1),size(typeof(a),2)}(Tuple(a))
+
+# Simplified show for the type
+show(io::IO, ::Type{MMatrix{N, M, T}}) where {N, M, T} = print(io, "MMatrix{$N,$M,$T}")
 
 # Some more advanced constructor-like functions
 @inline one{N}(::Type{MMatrix{N}}) = one(MMatrix{N,N})
@@ -63,10 +66,6 @@ end
 #####################
 ## MMatrix methods ##
 #####################
-
-@pure Size{S1,S2}(::Type{MMatrix{S1,S2}}) = Size(S1, S2)
-@pure Size{S1,S2,T}(::Type{MMatrix{S1,S2,T}}) = Size(S1, S2)
-@pure Size{S1,S2,T,L}(::Type{MMatrix{S1,S2,T,L}}) = Size(S1, S2)
 
 @propagate_inbounds function getindex{S1,S2,T}(m::MMatrix{S1,S2,T}, i::Int)
     #@boundscheck if i < 1 || i > length(m)

--- a/src/MVector.jl
+++ b/src/MVector.jl
@@ -16,9 +16,12 @@ compiler (the element type may optionally also be specified).
 """
 const MVector{S, T} = MArray{Tuple{S}, T, 1, S}
 
-@inline (::Type{MVector}){S}(x::NTuple{S,Any}) = MVector{S}(x)
-@inline (::Type{MVector{S}}){S, T}(x::NTuple{S,T}) = MVector{S,T}(x)
-@inline (::Type{MVector{S}}){S, T <: Tuple}(x::T) = MVector{S,promote_tuple_eltype(T)}(x)
+@inline MVector(x::NTuple{S,Any}) where {S} = MVector{S}(x)
+@inline MVector{S}(x::NTuple{S,T}) where {S, T} = MVector{S, T}(x)
+@inline MVector{S}(x::NTuple{S,Any}) where {S} = MVector{S, promote_tuple_eltype(typeof(x))}(x)
+
+# Simplified show for the type
+show(io::IO, ::Type{MVector{N, T}}) where {N, T} = print(io, "MVector{$N,$T}")
 
 # Some more advanced constructor-like functions
 @inline zeros{N}(::Type{MVector{N}}) = zeros(MVector{N,Float64})
@@ -27,9 +30,6 @@ const MVector{S, T} = MArray{Tuple{S}, T, 1, S}
 #####################
 ## MVector methods ##
 #####################
-
-@pure Size{S}(::Type{MVector{S}}) = Size(S)
-@pure Size{S,T}(::Type{MVector{S,T}}) = Size(S)
 
 @propagate_inbounds function getindex(v::MVector, i::Int)
     v.data[i]

--- a/src/SArray.jl
+++ b/src/SArray.jl
@@ -15,7 +15,7 @@ Construct a statically-sized array of dimensions `S` (expressed as a `Tuple{...}
 the data from `a`. The `S` parameter is mandatory since the size of `a` is unknown to the
 compiler (the element type may optionally also be specified).
 """
-immutable SArray{S, T, N, L} <: StaticArray{S, T, N}
+immutable SArray{S <: Tuple, T, N, L} <: StaticArray{S, T, N}
     data::NTuple{L,T}
 
     function (::Type{SArray{S, T, N, L}}){S, T, N, L}(x::NTuple{L,T})

--- a/src/SMatrix.jl
+++ b/src/SMatrix.jl
@@ -53,8 +53,11 @@ end
     end
 end
 
-@inline convert{S1,S2,T}(::Type{SMatrix{S1,S2}}, a::StaticArray{T}) = SMatrix{S1,S2,T}(Tuple(a))
+@inline convert{S1,S2,T}(::Type{SMatrix{S1,S2}}, a::StaticArray{<:Any, T}) = SMatrix{S1,S2,T}(Tuple(a))
 @inline SMatrix(a::StaticMatrix) = SMatrix{size(typeof(a),1),size(typeof(a),2)}(Tuple(a))
+
+# Simplified show for the type
+show(io::IO, ::Type{SMatrix{N, M, T}}) where {N, M, T} = print(io, "SMatrix{$N,$M,$T}")
 
 # Some more advanced constructor-like functions
 @inline one{N}(::Type{SMatrix{N}}) = one(SMatrix{N,N})
@@ -63,10 +66,6 @@ end
 #####################
 ## SMatrix methods ##
 #####################
-
-@pure Size{S1,S2}(::Type{SMatrix{S1,S2}}) = Size(S1, S2)
-@pure Size{S1,S2,T}(::Type{SMatrix{S1,S2,T}}) = Size(S1, S2)
-@pure Size{S1,S2,T,L}(::Type{SMatrix{S1,S2,T,L}}) = Size(S1, S2)
 
 function getindex(v::SMatrix, i::Int)
     Base.@_inline_meta

--- a/src/SUnitRange.jl
+++ b/src/SUnitRange.jl
@@ -1,8 +1,23 @@
 # `Start` and `End` should be `Int`
-struct SUnitRange{Start,End} <: StaticVector{Int}
+struct SUnitRange{Start, End, L} <: StaticVector{L, Int}
+    function SUnitRange{Start, End, L}() where {Start, End, L}
+        check_sunitrange_params(Start, End, L)
+        new{Start, End, L}()
+    end
 end
 
-@pure Size(::SUnitRange{Start, End}) where {Start,End} = Size(End-Start+1)
+@pure function check_sunitrange_params(a::Int, b::Int, c::Int)
+    if max(0, b - a + 1) != c
+        throw(DimensionMismatch("Static unit range $a:$b does not have length $c"))
+    end
+end
+
+function check_sunitrange_params(a, b, c)
+    throw(TypeError(:SUnitRange, "type parameters must be `Int`s", Tuple{Int, Int, Int}, Tuple{typeof(a), typeof(b), typeof(c)}))
+end
+
+@pure SUnitRange{Start, End}() where {Start, End} = SUnitRange{Start, End, max(0, End - Start + 1)}()
+@pure SUnitRange(a::Int, b::Int) = SUnitRange{a, b}()
 
 @pure @propagate_inbounds function getindex(x::SUnitRange{Start,End}, i::Int) where {Start, End}
     @boundscheck if i < Start || i > End

--- a/src/SUnitRange.jl
+++ b/src/SUnitRange.jl
@@ -1,27 +1,32 @@
 # `Start` and `End` should be `Int`
-struct SUnitRange{Start, End, L} <: StaticVector{L, Int}
-    function SUnitRange{Start, End, L}() where {Start, End, L}
-        check_sunitrange_params(Start, End, L)
-        new{Start, End, L}()
+struct SUnitRange{Start, L} <: StaticVector{L, Int}
+    function SUnitRange{Start, L}() where {Start, L}
+        check_sunitrange_params(L)
+        new{Start, L}()
     end
 end
 
-@pure function check_sunitrange_params(a::Int, b::Int, c::Int)
-    if max(0, b - a + 1) != c
-        throw(DimensionMismatch("Static unit range $a:$b does not have length $c"))
+@pure function check_sunitrange_params(L::Int)
+    if L < 0
+        error("Static unit range length is negative")
     end
 end
 
-function check_sunitrange_params(a, b, c)
+function check_sunitrange_params(L)
     throw(TypeError(:SUnitRange, "type parameters must be `Int`s", Tuple{Int, Int, Int}, Tuple{typeof(a), typeof(b), typeof(c)}))
 end
 
-@pure SUnitRange{Start, End}() where {Start, End} = SUnitRange{Start, End, max(0, End - Start + 1)}()
-@pure SUnitRange(a::Int, b::Int) = SUnitRange{a, b}()
+@pure SUnitRange(a::Int, b::Int) = SUnitRange{a, max(0, b - a + 1)}()
 
-@pure @propagate_inbounds function getindex(x::SUnitRange{Start,End}, i::Int) where {Start, End}
-    @boundscheck if i < Start || i > End
+@pure @propagate_inbounds function getindex(x::SUnitRange{Start, L}, i::Int) where {Start, L}
+    @boundscheck if i < Start || i >= (Start + L)
         throw(BoundsError(x, i))
     end
-    return i
+    return Start + i - 1
+end
+
+# Shorten show for REPL use.
+show(io::IO, ::Type{SUnitRange}) = print(io, "SUnitRange")
+function show(io::IO, ::MIME"text/plain", ::SUnitRange{Start, L}) where {Start, L}
+    print(io, "SUnitRange($Start,$(Start + L - 1))")
 end

--- a/src/SVector.jl
+++ b/src/SVector.jl
@@ -1,6 +1,6 @@
 """
-    SVector{S,T}(x::NTuple{S, T})
-    SVector{S,T}(x1, x2, x3, ...)
+    SVector{S, T}(x::NTuple{S, T})
+    SVector{S, T}(x1, x2, x3, ...)
 
 Construct a statically-sized vector `SVector`. Since this type is immutable,
 the data must be provided upon construction and cannot be mutated later.
@@ -22,6 +22,9 @@ const SVector{S, T} = SArray{Tuple{S}, T, 1, S}
 # conversion from AbstractVector / AbstractArray (better inference than default)
 #@inline convert{S,T}(::Type{SVector{S}}, a::AbstractArray{T}) = SVector{S,T}((a...))
 
+# Simplified show for the type
+show(io::IO, ::Type{SVector{N, T}}) where {N, T} = print(io, "SVector{$N,$T}")
+
 # Some more advanced constructor-like functions
 @inline zeros{N}(::Type{SVector{N}}) = zeros(SVector{N,Float64})
 @inline ones{N}(::Type{SVector{N}}) = ones(SVector{N,Float64})
@@ -29,9 +32,6 @@ const SVector{S, T} = SArray{Tuple{S}, T, 1, S}
 #####################
 ## SVector methods ##
 #####################
-
-@pure Size{S}(::Type{SVector{S}}) = Size(S)
-@pure Size{S,T}(::Type{SVector{S,T}}) = Size(S)
 
 @propagate_inbounds function getindex(v::SVector, i::Int)
     v.data[i]

--- a/src/Scalar.jl
+++ b/src/Scalar.jl
@@ -13,9 +13,6 @@ const Scalar{T} = SArray{Tuple{},T,0,1}
     return SA((a,))
 end
 
-@pure Size(::Type{Scalar}) = Size()
-@pure Size{T}(::Type{Scalar{T}}) = Size()
-
 getindex(v::Scalar) = v.data[1]
 @inline function getindex(v::Scalar, i::Int)
     @boundscheck if i != 1
@@ -28,3 +25,6 @@ end
 
 # A lot more compact than the default array show
 Base.show(io::IO, ::MIME"text/plain", x::Scalar{T}) where {T} = print(io, "Scalar{$T}(", x.data, ")")
+
+# Simplified show for the type
+show(io::IO, ::Type{Scalar{T}}) where {T} = print(io, "Scalar{T}")

--- a/src/SizedArray.jl
+++ b/src/SizedArray.jl
@@ -1,6 +1,6 @@
 
 """
-    SizedArray{(dims...)}(array)
+    SizedArray{Tuple{dims...}}(array)
 
 Wraps an `Array` with a static size, so to take advantage of the (faster)
 methods defined by the static array package. The size is checked once upon
@@ -9,11 +9,11 @@ array may be reshaped.
 
 (Also, `Size(dims...)(array)` acheives the same thing)
 """
-immutable SizedArray{S,T,N,M} <: StaticArray{T,N}
+immutable SizedArray{S,T,N,M} <: StaticArray{S,T,N}
     data::Array{T,M}
 
     function (::Type{SizedArray{S,T,N,M}}){S,T,N,M}(a::Array)
-        if length(a) != prod(S)
+        if length(a) != tuple_prod(S)
             error("Dimensions $(size(a)) don't match static size $S")
         end
         new{S,T,N,M}(a)
@@ -25,14 +25,14 @@ immutable SizedArray{S,T,N,M} <: StaticArray{T,N}
 end
 
 @inline (::Type{SizedArray{S,T,N}}){S,T,N,M}(a::Array{T,M}) = SizedArray{S,T,N,M}(a)
-@inline (::Type{SizedArray{S,T}}){S,T,M}(a::Array{T,M}) = SizedArray{S,T,_ndims(S),M}(a)
-@inline (::Type{SizedArray{S}}){S,T,M}(a::Array{T,M}) = SizedArray{S,T,_ndims(S),M}(a)
+@inline (::Type{SizedArray{S,T}}){S,T,M}(a::Array{T,M}) = SizedArray{S,T,tuple_length(S),M}(a)
+@inline (::Type{SizedArray{S}}){S,T,M}(a::Array{T,M}) = SizedArray{S,T,tuple_length(S),M}(a)
 
 @inline (::Type{SizedArray{S,T,N}}){S,T,N}() = SizedArray{S,T,N,N}()
-@inline (::Type{SizedArray{S,T}}){S,T}() = SizedArray{S,T,_ndims(S),_ndims(S)}()
+@inline (::Type{SizedArray{S,T}}){S,T}() = SizedArray{S,T,tuple_length(S),tuple_length(S)}()
 
 @generated function (::Type{SizedArray{S,T,N,M}}){S,T,N,M,L}(x::NTuple{L,Any})
-    if L != prod(S)
+    if L != tuple_prod(S)
         error("Dimension mismatch")
     end
     exprs = [:(a[$i] = x[$i]) for i = 1:L]
@@ -61,25 +61,16 @@ end
 @inline convert{T,S}(::Type{Array{T}}, sa::SizedArray{S,T}) = sa.data
 @inline convert{T,S,N}(::Type{Array{T,N}}, sa::SizedArray{S,T,N}) = sa.data
 
-@pure _ndims{N}(::NTuple{N,Int}) = N
-
-@pure Size{S}(::Type{SizedArray{S}}) = Size(S)
-@pure Size{S,T}(::Type{SizedArray{S,T}}) = Size(S)
-@pure Size{S,T,N}(::Type{SizedArray{S,T,N}}) = Size(S)
-@pure Size{S,T,N,M}(::Type{SizedArray{S,T,N,M}}) = Size(S)
-
 @propagate_inbounds getindex(a::SizedArray, i::Int) = getindex(a.data, i)
 @propagate_inbounds setindex!(a::SizedArray, v, i::Int) = setindex!(a.data, v, i)
 
 SizedVector{S,T,M} = SizedArray{S,T,1,M}
-@pure Size{S}(::Type{SizedVector{S}}) = Size(S)
 @inline (::Type{SizedVector{S}}){S,T,M}(a::Array{T,M}) = SizedArray{S,T,1,M}(a)
 @inline (::Type{SizedVector{S}}){S,T,L}(x::NTuple{L,T}) = SizedArray{S,T,1,1}(x)
 @inline (::Type{Vector})(sa::SizedVector) = sa.data
 @inline convert(::Type{Vector}, sa::SizedVector) = sa.data
 
 SizedMatrix{S,T,M} = SizedArray{S,T,2,M}
-@pure Size{S}(::Type{SizedMatrix{S}}) = Size(S)
 @inline (::Type{SizedMatrix{S}}){S,T,M}(a::Array{T,M}) = SizedArray{S,T,2,M}(a)
 @inline (::Type{SizedMatrix{S}}){S,T,L}(x::NTuple{L,T}) = SizedArray{S,T,2,2}(x)
 @inline (::Type{Matrix})(sa::SizedMatrix) = sa.data
@@ -93,4 +84,4 @@ Creates a `SizedArray` wrapping `array` with the specified statically-known
 `dims`, so to take advantage of the (faster) methods defined by the static array
 package.
 """
-(::Size{S}){S}(a::Array) = SizedArray{S}(a)
+(::Size{S}){S}(a::Array) = SizedArray{Tuple{S...}}(a)

--- a/src/SizedArray.jl
+++ b/src/SizedArray.jl
@@ -9,18 +9,18 @@ array may be reshaped.
 
 (Also, `Size(dims...)(array)` acheives the same thing)
 """
-immutable SizedArray{S,T,N,M} <: StaticArray{S,T,N}
-    data::Array{T,M}
+immutable SizedArray{S <: Tuple, T, N, M} <: StaticArray{S, T, N}
+    data::Array{T, M}
 
-    function (::Type{SizedArray{S,T,N,M}}){S,T,N,M}(a::Array)
+    function (::Type{SizedArray{S, T, N, M}}){S, T, N, M}(a::Array)
         if length(a) != tuple_prod(S)
             error("Dimensions $(size(a)) don't match static size $S")
         end
         new{S,T,N,M}(a)
     end
 
-    function (::Type{SizedArray{S,T,N,M}}){S,T,N,M}()
-        new{S,T,N,M}(Array{T,M}(S))
+    function (::Type{SizedArray{S, T, N, M}}){S, T, N, M}()
+        new{S, T, N, M}(Array{T, M}(S))
     end
 end
 

--- a/src/StaticArrays.jl
+++ b/src/StaticArrays.jl
@@ -4,7 +4,7 @@ module StaticArrays
 
 import Base: @_inline_meta, @_propagate_inbounds_meta, @_pure_meta, @propagate_inbounds, @pure
 
-import Base: getindex, setindex!, size, similar, vec,
+import Base: getindex, setindex!, size, similar, vec, show,
              length, convert, promote_op, map, map!, reduce, reducedim, mapreducedim,
              mapreduce, broadcast, broadcast!, conj, transpose, ctranspose,
              hcat, vcat, ones, zeros, eye, one, cross, vecdot, reshape, fill,
@@ -57,12 +57,13 @@ For mutable containers you may also need to define the following:
 
 (see also `SVector`, `SMatrix`, `SArray`, `MVector`, `MMatrix`, `MArray`, `SizedArray` and `FieldVector`)
 """
-abstract type StaticArray{T, N} <: AbstractArray{T, N} end
-const StaticScalar{T} = StaticArray{T, 0}
-const StaticVector{T} = StaticArray{T, 1}
-const StaticMatrix{T} = StaticArray{T, 2}
+abstract type StaticArray{S <: Tuple, T, N} <: AbstractArray{T, N} end
+const StaticScalar{T} = StaticArray{Tuple{}, T, 0}
+const StaticVector{N, T} = StaticArray{Tuple{N}, T, 1}
+const StaticMatrix{N, M, T} = StaticArray{Tuple{N, M}, T, 2}
 
 const AbstractScalar{T} = AbstractArray{T, 0} # not exported, but useful none-the-less
+const StaticArrayNoEltype{S, N, T} = StaticArray{S, T, N}
 
 include("util.jl")
 include("traits.jl")
@@ -73,9 +74,9 @@ include("FieldVector.jl")
 include("SArray.jl")
 include("SMatrix.jl")
 include("SVector.jl")
+include("Scalar.jl")
 include("MArray.jl")
 include("MVector.jl")
-include("Scalar.jl")
 include("MMatrix.jl")
 include("SizedArray.jl")
 

--- a/src/abstractarray.jl
+++ b/src/abstractarray.jl
@@ -1,12 +1,11 @@
-length(a::T) where {T <: StaticArray} = prod(Size(T))
-length(a::Type{T}) where {T<:StaticArray} = prod(Size(T))
+length(a::SA) where {SA <: StaticArray} = prod(Size(SA))
+length(a::Type{SA}) where {SA <: StaticArray} = prod(Size(SA))
 
-size{T<:StaticArray}(::T) = get(Size(T))
-size{T<:StaticArray}(::Type{T}) = get(Size(T))
+size(::StaticArray{S}) where {S} = get(Size(S))
+@pure size(::Type{<:StaticArray{S}}) where {S} = get(Size(S))
 
-size{T<:StaticArray}(::T, d::Int) = Size(T)[d]
-size{T<:StaticArray}(::Type{T}, d::Int) = Size(T)[d]
-
+size(::SA, d::Int) where {SA <: StaticArray} = Size(SA)[d]
+@pure size(::Type{SA}, d::Int) where {SA <: StaticArray} = Size(SA)[d]
 
 # This seems to confuse Julia a bit in certain circumstances (specifically for trailing 1's)
 @inline function Base.isassigned(a::StaticArray, i::Int...)
@@ -39,32 +38,26 @@ if they wish to overload the default behavior.
 """
 function similar_type end
 
-similar_type{SA<:StaticArray}(::SA) = similar_type(SA,eltype(SA))
-similar_type{SA<:StaticArray}(::Type{SA}) = similar_type(SA,eltype(SA))
+similar_type(::SA) where {SA<:StaticArray} = similar_type(SA,eltype(SA))
+similar_type(::Type{SA}) where {SA<:StaticArray} = similar_type(SA,eltype(SA))
 
-similar_type{SA<:StaticArray,T}(::SA,::Type{T}) = similar_type(SA,T,Size(SA))
-similar_type{SA<:StaticArray,T}(::Type{SA},::Type{T}) = similar_type(SA,T,Size(SA))
+similar_type(::SA,::Type{T}) where {SA<:StaticArray,T} = similar_type(SA,T,Size(SA))
+similar_type(::Type{SA},::Type{T}) where {SA<:StaticArray,T} = similar_type(SA,T,Size(SA))
 
-similar_type{A<:AbstractArray,S}(::A,s::Size{S}) = similar_type(A,eltype(A),s)
-similar_type{A<:AbstractArray,S}(::Type{A},s::Size{S}) = similar_type(A,eltype(A),s)
+similar_type(::A,s::Size{S}) where {A<:AbstractArray,S} = similar_type(A,eltype(A),s)
+similar_type(::Type{A},s::Size{S}) where {A<:AbstractArray,S} = similar_type(A,eltype(A),s)
 
-similar_type{A<:AbstractArray,T,S}(::A,::Type{T},s::Size{S}) = similar_type(A,T,s)
+similar_type(::A,::Type{T},s::Size{S}) where {A<:AbstractArray,T,S} = similar_type(A,T,s)
 
 # Default types
-# Generally, use SVector, etc
+# Generally, use SArray
 similar_type{A<:AbstractArray,T,S}(::Type{A},::Type{T},s::Size{S}) = default_similar_type(T,s,length_val(s))
-
-default_similar_type{T,S}(::Type{T}, s::Size{S}, ::Type{Val{0}}) = Scalar{T}
-default_similar_type{T,S}(::Type{T}, s::Size{S}, ::Type{Val{1}}) = SVector{S[1],T}
-default_similar_type{T,S}(::Type{T}, s::Size{S}, ::Type{Val{2}}) = SMatrix{S[1],S[2],T,prod(s)}
 default_similar_type{T,S,D}(::Type{T}, s::Size{S}, ::Type{Val{D}}) = SArray{Tuple{S...},T,D,prod(s)}
+
 
 # should mutable things stay mutable?
 #similar_type{SA<:Union{MVector,MMatrix,MArray},T,S}(::Type{SA},::Type{T},s::Size{S}) = mutable_similar_type(T,s,length_val(s))
 
-mutable_similar_type{T,S}(::Type{T}, s::Size{S}, ::Type{Val{0}}) = SizedArray{(),T,0,0}
-mutable_similar_type{T,S}(::Type{T}, s::Size{S}, ::Type{Val{1}}) = MVector{S[1],T}
-mutable_similar_type{T,S}(::Type{T}, s::Size{S}, ::Type{Val{2}}) = MMatrix{S[1],S[2],T,prod(s)}
 mutable_similar_type{T,S,D}(::Type{T}, s::Size{S}, ::Type{Val{D}}) = MArray{Tuple{S...},T,D,prod(s)}
 
 # Should `SizedArray` stay the same, and also take over an `Array`?

--- a/src/arraymath.jl
+++ b/src/arraymath.jl
@@ -122,7 +122,7 @@ end
 end
 
 # ambiguity with AbstractRNG and non-Float64... possibly an optimized form in Base?
-@inline rand!(rng::MersenneTwister, a::SA) where {SA <: StaticArray{Float64}} = _rand!(rng, Size(SA), a)
+@inline rand!(rng::MersenneTwister, a::SA) where {SA <: StaticArray{<:Any, Float64}} = _rand!(rng, Size(SA), a)
 
 @inline randn!(rng::AbstractRNG, a::SA) where {SA <: StaticArray} = _randn!(rng, Size(SA), a)
 @generated function _randn!(rng::AbstractRNG, ::Size{s}, a::SA) where {s, SA <: StaticArray}

--- a/src/deque.jl
+++ b/src/deque.jl
@@ -72,8 +72,8 @@ end
 
 # Immutable version of setindex!(). Seems similar in nature to the above, but
 # could also be justified to live in src/indexing.jl
-@inline setindex(a::StaticArray{T}, x::T, index::Int) where {T} = _setindex(Size(a), a, x, index)
-@generated function _setindex(::Size{s}, a::StaticArray{T}, x::T, index::Int) where {s, T}
+@inline setindex(a::StaticArray{<:Any,T}, x::T, index::Int) where {T} = _setindex(Size(a), a, x, index)
+@generated function _setindex(::Size{s}, a::StaticArray{<:Any,T}, x::T, index::Int) where {s, T}
     exprs = [:(ifelse($i == index, x, a[$i])) for i = 1:s[1]]
     return quote
         @_inline_meta

--- a/src/deque.jl
+++ b/src/deque.jl
@@ -72,7 +72,7 @@ end
 
 # Immutable version of setindex!(). Seems similar in nature to the above, but
 # could also be justified to live in src/indexing.jl
-@inline setindex(a::StaticArray{<:Any,T}, x::T, index::Int) where {T} = _setindex(Size(a), a, x, index)
+@inline setindex(a::StaticArray, x, index::Int) = _setindex(Size(a), a, convert(eltype(typeof(a)), x), index)
 @generated function _setindex(::Size{s}, a::StaticArray{<:Any,T}, x::T, index::Int) where {s, T}
     exprs = [:(ifelse($i == index, x, a[$i])) for i = 1:s[1]]
     return quote
@@ -83,8 +83,6 @@ end
         @inbounds return typeof(a)(tuple($(exprs...)))
     end
 end
-
-@propagate_inbounds setindex(a::StaticArray, x, index::Int) = setindex(a, convert(eltype(typeof(a)), x), index)
 
 # TODO proper multidimension boundscheck
 @propagate_inbounds setindex(a::StaticArray, x, inds::Int...) = setindex(a, x, sub2ind(size(typeof(a)), inds...))

--- a/src/det.jl
+++ b/src/det.jl
@@ -6,7 +6,7 @@
     @inbounds return A[1]*A[4] - A[3]*A[2]
 end
 
-@inline function _det(::Size{(2,2)}, A::StaticMatrix{<:Unsigned})
+@inline function _det(::Size{(2,2)}, A::StaticMatrix{<:Any, <:Any, <:Unsigned})
     @inbounds return Signed(A[1]*A[4]) - Signed(A[3]*A[2])
 end
 
@@ -17,7 +17,7 @@ end
     return vecdot(x0, cross(x1, x2))
 end
 
-@inline function _det(::Size{(3,3)}, A::StaticMatrix{<:Unsigned})
+@inline function _det(::Size{(3,3)}, A::StaticMatrix{<:Any, <:Any, <:Unsigned})
     @inbounds x0 = SVector(Signed(A[1]), Signed(A[2]), Signed(A[3]))
     @inbounds x1 = SVector(Signed(A[4]), Signed(A[5]), Signed(A[6]))
     @inbounds x2 = SVector(Signed(A[7]), Signed(A[8]), Signed(A[9]))

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -93,11 +93,11 @@ end
     end
 end
 
-@propagate_inbounds function getindex(a::StaticArray, inds::StaticArray{Int})
+@propagate_inbounds function getindex(a::StaticArray, inds::StaticArray{<:Any, Int})
     _getindex(a, Length(inds), inds)
 end
 
-@generated function _getindex(a::StaticArray, ::Length{L}, inds::StaticArray{Int}) where {L}
+@generated function _getindex(a::StaticArray, ::Length{L}, inds::StaticArray{<:Any, Int}) where {L}
     exprs = [:(a[inds[$i]]) for i = 1:L]
     return quote
         @_propagate_inbounds_meta
@@ -140,12 +140,12 @@ end
     end
 end
 
-@propagate_inbounds function setindex!(a::StaticArray, v, inds::StaticArray{Int})
+@propagate_inbounds function setindex!(a::StaticArray, v, inds::StaticArray{<:Any, Int})
     _setindex!(a, v, Length(inds), inds)
     return v
 end
 
-@generated function _setindex!(a::StaticArray, v, ::Length{L}, inds::StaticArray{Int}) where {L}
+@generated function _setindex!(a::StaticArray, v, ::Length{L}, inds::StaticArray{<:Any, Int}) where {L}
     exprs = [:(a[inds[$i]] = v) for i = 1:L]
     return quote
         @_propagate_inbounds_meta
@@ -153,7 +153,7 @@ end
     end
 end
 
-@generated function _setindex!(a::StaticArray, v::AbstractArray, ::Length{L}, inds::StaticArray{Int}) where {L}
+@generated function _setindex!(a::StaticArray, v::AbstractArray, ::Length{L}, inds::StaticArray{<:Any, Int}) where {L}
     exprs = [:(a[$i] = v[$i]) for i = 1:L]
     return quote
         @_propagate_inbounds_meta
@@ -164,7 +164,7 @@ end
     end
 end
 
-@generated function _setindex!(a::StaticArray, v::StaticArray, ::Length{L}, inds::StaticArray{Int}) where {L}
+@generated function _setindex!(a::StaticArray, v::StaticArray, ::Length{L}, inds::StaticArray{<:Any, Int}) where {L}
     exprs = [:(a[$i] = v[$i]) for i = 1:L]
     return quote
         @_propagate_inbounds_meta
@@ -181,42 +181,42 @@ end
 
 # getindex
 
-@propagate_inbounds function getindex(a::StaticArray, inds::Union{Int, StaticArray{Int}, Colon}...)
+@propagate_inbounds function getindex(a::StaticArray, inds::Union{Int, StaticArray{<:Any, Int}, Colon}...)
     _getindex(a, index_sizes(Size(a), inds...), inds)
 end
 
-# Hard to describe "Union{Int, StaticArray{Int}} with at least one StaticArray{Int}"
-# Here we require the first StaticArray{Int} to be within the first four dimensions
-@propagate_inbounds function getindex(a::AbstractArray, i1::StaticArray{Int}, inds::Union{Int, StaticArray{Int}}...)
+# Hard to describe "Union{Int, StaticArray{<:Any, Int}} with at least one StaticArray{<:Any, Int}"
+# Here we require the first StaticArray{<:Any, Int} to be within the first four dimensions
+@propagate_inbounds function getindex(a::AbstractArray, i1::StaticArray{<:Any, Int}, inds::Union{Int, StaticArray{<:Any, Int}}...)
     _getindex(a, index_sizes(i1, inds...), (i1, inds...))
 end
 
-@propagate_inbounds function getindex(a::AbstractArray, i1::Int, i2::StaticArray{Int}, inds::Union{Int, StaticArray{Int}}...)
+@propagate_inbounds function getindex(a::AbstractArray, i1::Int, i2::StaticArray{<:Any, Int}, inds::Union{Int, StaticArray{<:Any, Int}}...)
     _getindex(a, index_sizes(i1, i2, inds...), (i1, i2, inds...))
 end
 
-@propagate_inbounds function getindex(a::AbstractArray, i1::Int, i2::Int, i3::StaticArray{Int}, inds::Union{Int, StaticArray{Int}}...)
+@propagate_inbounds function getindex(a::AbstractArray, i1::Int, i2::Int, i3::StaticArray{<:Any, Int}, inds::Union{Int, StaticArray{<:Any, Int}}...)
     _getindex(a, index_sizes(i1, i2, i3, inds...), (i1, i2, i3, inds...))
 end
 
-@propagate_inbounds function getindex(a::AbstractArray, i1::Int, i2::Int, i3::Int, i4::StaticArray{Int}, inds::Union{Int, StaticArray{Int}}...)
+@propagate_inbounds function getindex(a::AbstractArray, i1::Int, i2::Int, i3::Int, i4::StaticArray{<:Any, Int}, inds::Union{Int, StaticArray{<:Any, Int}}...)
     _getindex(a, index_sizes(i1, i2, i3, i4, inds...), (i1, i2, i3, i4, inds...))
 end
 
 # Disambuguity methods for the above
-@propagate_inbounds function getindex(a::StaticArray, i1::StaticArray{Int}, inds::Union{Int, StaticArray{Int}}...)
+@propagate_inbounds function getindex(a::StaticArray, i1::StaticArray{<:Any, Int}, inds::Union{Int, StaticArray{<:Any, Int}}...)
     _getindex(a, index_sizes(i1, inds...), (i1, inds...))
 end
 
-@propagate_inbounds function getindex(a::StaticArray, i1::Int, i2::StaticArray{Int}, inds::Union{Int, StaticArray{Int}}...)
+@propagate_inbounds function getindex(a::StaticArray, i1::Int, i2::StaticArray{<:Any, Int}, inds::Union{Int, StaticArray{<:Any, Int}}...)
     _getindex(a, index_sizes(i1, i2, inds...), (i1, i2, inds...))
 end
 
-@propagate_inbounds function getindex(a::StaticArray, i1::Int, i2::Int, i3::StaticArray{Int}, inds::Union{Int, StaticArray{Int}}...)
+@propagate_inbounds function getindex(a::StaticArray, i1::Int, i2::Int, i3::StaticArray{<:Any, Int}, inds::Union{Int, StaticArray{<:Any, Int}}...)
     _getindex(a, index_sizes(i1, i2, i3, inds...), (i1, i2, i3, inds...))
 end
 
-@propagate_inbounds function getindex(a::StaticArray, i1::Int, i2::Int, i3::Int, i4::StaticArray{Int}, inds::Union{Int, StaticArray{Int}}...)
+@propagate_inbounds function getindex(a::StaticArray, i1::Int, i2::Int, i3::Int, i4::StaticArray{<:Any, Int}, inds::Union{Int, StaticArray{<:Any, Int}}...)
     _getindex(a, index_sizes(i1, i2, i3, i4, inds...), (i1, i2, i3, i4, inds...))
 end
 
@@ -258,67 +258,67 @@ end
 
 # setindex!
 
-@propagate_inbounds function setindex!(a::StaticArray, value, inds::Union{Int, StaticArray{Int}, Colon}...)
+@propagate_inbounds function setindex!(a::StaticArray, value, inds::Union{Int, StaticArray{<:Any, Int}, Colon}...)
     _setindex!(a, value, index_sizes(Size(a), inds...), inds)
 end
 
-# Hard to describe "Union{Int, StaticArray{Int}} with at least one StaticArray{Int}"
-# Here we require the first StaticArray{Int} to be within the first four dimensions
-@propagate_inbounds function setindex!(a::AbstractArray, value, i1::StaticArray{Int}, inds::Union{Int, StaticArray{Int}}...)
+# Hard to describe "Union{Int, StaticArray{<:Any, Int}} with at least one StaticArray{<:Any, Int}"
+# Here we require the first StaticArray{<:Any, Int} to be within the first four dimensions
+@propagate_inbounds function setindex!(a::AbstractArray, value, i1::StaticArray{<:Any, Int}, inds::Union{Int, StaticArray{<:Any, Int}}...)
     _setindex!(a, value, index_sizes(i1, inds...), (i1, inds...))
 end
 
-@propagate_inbounds function setindex!(a::AbstractArray, value, i1::Int, i2::StaticArray{Int}, inds::Union{Int, StaticArray{Int}}...)
+@propagate_inbounds function setindex!(a::AbstractArray, value, i1::Int, i2::StaticArray{<:Any, Int}, inds::Union{Int, StaticArray{<:Any, Int}}...)
     _setindex!(a, value, index_sizes(i1, i2, inds...), (i1, i2, inds...))
 end
 
-@propagate_inbounds function setindex!(a::AbstractArray, value, i1::Int, i2::Int, i3::StaticArray{Int}, inds::Union{Int, StaticArray{Int}}...)
+@propagate_inbounds function setindex!(a::AbstractArray, value, i1::Int, i2::Int, i3::StaticArray{<:Any, Int}, inds::Union{Int, StaticArray{<:Any, Int}}...)
     _setindex!(a, value, index_sizes(i1, i2, i3, inds...), (i1, i2, i3, inds...))
 end
 
-@propagate_inbounds function setindex!(a::AbstractArray, value, i1::Int, i2::Int, i3::Int, i4::StaticArray{Int}, inds::Union{Int, StaticArray{Int}}...)
+@propagate_inbounds function setindex!(a::AbstractArray, value, i1::Int, i2::Int, i3::Int, i4::StaticArray{<:Any, Int}, inds::Union{Int, StaticArray{<:Any, Int}}...)
     _setindex!(a, value, index_sizes(i1, i2, i3, i4, inds...), (i1, i2, i3, i4, inds...))
 end
 
 # Disambiguity methods for the above
-@propagate_inbounds function setindex!(a::StaticArray, value, i1::StaticArray{Int}, inds::Union{Int, StaticArray{Int}}...)
+@propagate_inbounds function setindex!(a::StaticArray, value, i1::StaticArray{<:Any, Int}, inds::Union{Int, StaticArray{<:Any, Int}}...)
     _setindex!(a, value, index_sizes(i1, inds...), (i1, inds...))
 end
 
-@propagate_inbounds function setindex!(a::StaticArray, value, i1::Int, i2::StaticArray{Int}, inds::Union{Int, StaticArray{Int}}...)
+@propagate_inbounds function setindex!(a::StaticArray, value, i1::Int, i2::StaticArray{<:Any, Int}, inds::Union{Int, StaticArray{<:Any, Int}}...)
     _setindex!(a, value, index_sizes(i1, i2, inds...), (i1, i2, inds...))
 end
 
-@propagate_inbounds function setindex!(a::StaticArray, value, i1::Int, i2::Int, i3::StaticArray{Int}, inds::Union{Int, StaticArray{Int}}...)
+@propagate_inbounds function setindex!(a::StaticArray, value, i1::Int, i2::Int, i3::StaticArray{<:Any, Int}, inds::Union{Int, StaticArray{<:Any, Int}}...)
     _setindex!(a, value, index_sizes(i1, i2, i3, inds...), (i1, i2, i3, inds...))
 end
 
-@propagate_inbounds function setindex!(a::StaticArray, value, i1::Int, i2::Int, i3::Int, i4::StaticArray{Int}, inds::Union{Int, StaticArray{Int}}...)
+@propagate_inbounds function setindex!(a::StaticArray, value, i1::Int, i2::Int, i3::Int, i4::StaticArray{<:Any, Int}, inds::Union{Int, StaticArray{<:Any, Int}}...)
     _setindex!(a, value, index_sizes(i1, i2, i3, i4, inds...), (i1, i2, i3, i4, inds...))
 end
 
 # disambiguities from Base
-@propagate_inbounds function setindex!(a::Array, value, i1::StaticVector{Int})
+@propagate_inbounds function setindex!(a::Array, value, i1::StaticVector{<:Any, Int})
     _setindex!(a, value, index_sizes(i1), (i1,))
 end
 
-@propagate_inbounds function setindex!(a::Array, value::AbstractArray, i1::StaticVector{Int})
+@propagate_inbounds function setindex!(a::Array, value::AbstractArray, i1::StaticVector{<:Any, Int})
     _setindex!(a, value, index_sizes(i1), (i1,))
 end
 
-@propagate_inbounds function setindex!(a::Array, value::AbstractArray, i1::StaticArray{Int}, inds::Union{Int, StaticArray{Int}}...)
+@propagate_inbounds function setindex!(a::Array, value::AbstractArray, i1::StaticArray{<:Any, Int}, inds::Union{Int, StaticArray{<:Any, Int}}...)
     _setindex!(a, value, index_sizes(i1, inds...), (i1, inds...))
 end
 
-@propagate_inbounds function setindex!(a::Array, value::AbstractArray, i1::Int, i2::StaticArray{Int}, inds::Union{Int, StaticArray{Int}}...)
+@propagate_inbounds function setindex!(a::Array, value::AbstractArray, i1::Int, i2::StaticArray{<:Any, Int}, inds::Union{Int, StaticArray{<:Any, Int}}...)
     _setindex!(a, value, index_sizes(i1, i2, inds...), (i1, i2, inds...))
 end
 
-@propagate_inbounds function setindex!(a::Array, value::AbstractArray, i1::Int, i2::Int, i3::StaticArray{Int}, inds::Union{Int, StaticArray{Int}}...)
+@propagate_inbounds function setindex!(a::Array, value::AbstractArray, i1::Int, i2::Int, i3::StaticArray{<:Any, Int}, inds::Union{Int, StaticArray{<:Any, Int}}...)
     _setindex!(a, value, index_sizes(i1, i2, i3, inds...), (i1, i2, i3, inds...))
 end
 
-@propagate_inbounds function setindex!(a::Array, value::AbstractArray, i1::Int, i2::Int, i3::Int, i4::StaticArray{Int}, inds::Union{Int, StaticArray{Int}}...)
+@propagate_inbounds function setindex!(a::Array, value::AbstractArray, i1::Int, i2::Int, i3::Int, i4::StaticArray{<:Any, Int}, inds::Union{Int, StaticArray{<:Any, Int}}...)
     _setindex!(a, value, index_sizes(i1, i2, i3, i4, inds...), (i1, i2, i3, i4, inds...))
 end
 

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -191,10 +191,10 @@ end
 @inline function _cross(::Size{(3,)}, a::StaticVector, b::StaticVector)
     @inbounds return similar_type(a, typeof(a[2]*b[3]-a[3]*b[2]))((a[2]*b[3]-a[3]*b[2], a[3]*b[1]-a[1]*b[3], a[1]*b[2]-a[2]*b[1]))
 end
-@inline function _cross(::Size{(2,)}, a::StaticVector{<:Unsigned}, b::StaticVector{<:Unsigned})
+@inline function _cross(::Size{(2,)}, a::StaticVector{<:Any, <:Unsigned}, b::StaticArray{<:Any, <:Unsigned})
     @inbounds return Signed(a[1]*b[2]) - Signed(a[2]*b[1])
 end
-@inline function _cross(::Size{(3,)}, a::StaticVector{<:Unsigned}, b::StaticVector{<:Unsigned})
+@inline function _cross(::Size{(3,)}, a::StaticArray{<:Any, <:Unsigned}, b::StaticArray{<:Any, <:Unsigned})
     @inbounds return similar_type(a, typeof(Signed(a[2]*b[3])-Signed(a[3]*b[2])))(((Signed(a[2]*b[3])-Signed(a[3]*b[2]), Signed(a[3]*b[1])-Signed(a[1]*b[3]), Signed(a[1]*b[2])-Signed(a[2]*b[1]))))
 end
 

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -191,10 +191,10 @@ end
 @inline function _cross(::Size{(3,)}, a::StaticVector, b::StaticVector)
     @inbounds return similar_type(a, typeof(a[2]*b[3]-a[3]*b[2]))((a[2]*b[3]-a[3]*b[2], a[3]*b[1]-a[1]*b[3], a[1]*b[2]-a[2]*b[1]))
 end
-@inline function _cross(::Size{(2,)}, a::StaticVector{<:Any, <:Unsigned}, b::StaticArray{<:Any, <:Unsigned})
+@inline function _cross(::Size{(2,)}, a::StaticVector{<:Any, <:Unsigned}, b::StaticVector{<:Any, <:Unsigned})
     @inbounds return Signed(a[1]*b[2]) - Signed(a[2]*b[1])
 end
-@inline function _cross(::Size{(3,)}, a::StaticArray{<:Any, <:Unsigned}, b::StaticArray{<:Any, <:Unsigned})
+@inline function _cross(::Size{(3,)}, a::StaticVector{<:Any, <:Unsigned}, b::StaticVector{<:Any, <:Unsigned})
     @inbounds return similar_type(a, typeof(Signed(a[2]*b[3])-Signed(a[3]*b[2])))(((Signed(a[2]*b[3])-Signed(a[3]*b[2]), Signed(a[3]*b[1])-Signed(a[1]*b[3]), Signed(a[1]*b[2])-Signed(a[2]*b[1]))))
 end
 

--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -167,14 +167,14 @@ end
 #######################
 
 # These are all similar in Base but not @inline'd
-@inline sum(a::StaticArray{T}) where {T} = reduce(+, zero(T), a)
-@inline prod(a::StaticArray{T}) where {T} = reduce(*, one(T), a)
-@inline count(a::StaticArray{Bool}) = reduce(+, 0, a)
-@inline all(a::StaticArray{Bool}) = reduce(&, true, a)  # non-branching versions
-@inline any(a::StaticArray{Bool}) = reduce(|, false, a) # (benchmarking needed)
+@inline sum(a::StaticArray{<:Any, T}) where {T} = reduce(+, zero(T), a)
+@inline prod(a::StaticArray{<:Any, T}) where {T} = reduce(*, one(T), a)
+@inline count(a::StaticArray{<:Any, Bool}) = reduce(+, 0, a)
+@inline all(a::StaticArray{<:Any, Bool}) = reduce(&, true, a)  # non-branching versions
+@inline any(a::StaticArray{<:Any, Bool}) = reduce(|, false, a) # (benchmarking needed)
 @inline mean(a::StaticArray) = sum(a) / length(a)
-@inline sumabs(a::StaticArray{T}) where {T} = mapreduce(abs, +, zero(T), a)
-@inline sumabs2(a::StaticArray{T}) where {T} = mapreduce(abs2, +, zero(T), a)
+@inline sumabs(a::StaticArray{<:Any, T}) where {T} = mapreduce(abs, +, zero(T), a)
+@inline sumabs2(a::StaticArray{<:Any, T}) where {T} = mapreduce(abs2, +, zero(T), a)
 @inline minimum(a::StaticArray) = reduce(min, a) # base has mapreduce(idenity, scalarmin, a)
 @inline maximum(a::StaticArray) = reduce(max, a) # base has mapreduce(idenity, scalarmax, a)
 @inline minimum(a::StaticArray, dim::Type{Val{D}}) where {D} = reducedim(min, a, dim)

--- a/src/matrix_multiply.jl
+++ b/src/matrix_multiply.jl
@@ -3,7 +3,7 @@ import Base: A_mul_B!, Ac_mul_B!, A_mul_Bc!, Ac_mul_Bc!, At_mul_B!, A_mul_Bt!, A
 
 import Base.LinAlg: BlasFloat
 
-const StaticVecOrMat{T} = Union{StaticVector{T}, StaticMatrix{T}}
+const StaticVecOrMat{T} = Union{StaticVector{<:Any, T}, StaticMatrix{<:Any, <:Any, T}}
 
 # Idea inspired by https://github.com/JuliaLang/julia/pull/18218
 promote_matprod{T1,T2}(::Type{T1}, ::Type{T2}) = typeof(zero(T1)*zero(T2) + zero(T1)*zero(T2))
@@ -46,7 +46,7 @@ promote_matprod{T1,T2}(::Type{T1}, ::Type{T2}) = typeof(zero(T1)*zero(T2) + zero
 
 # Implementations
 
-@generated function _A_mul_B(::Size{sa}, a::StaticMatrix{Ta}, b::AbstractVector{Tb}) where {sa, Ta, Tb}
+@generated function _A_mul_B(::Size{sa}, a::StaticMatrix{<:Any, <:Any, Ta}, b::AbstractVector{Tb}) where {sa, Ta, Tb}
     if sa[2] != 0
         exprs = [reduce((ex1,ex2) -> :(+($ex1,$ex2)), [:(a[$(sub2ind(sa, k, j))]*b[$j]) for j = 1:sa[2]]) for k = 1:sa[1]]
     else
@@ -63,7 +63,7 @@ promote_matprod{T1,T2}(::Type{T1}, ::Type{T2}) = typeof(zero(T1)*zero(T2) + zero
     end
 end
 
-@generated function _A_mul_B(::Size{sa}, ::Size{sb}, a::StaticMatrix{Ta}, b::StaticVector{Tb}) where {sa, sb, Ta, Tb}
+@generated function _A_mul_B(::Size{sa}, ::Size{sb}, a::StaticMatrix{<:Any, <:Any, Ta}, b::StaticVector{<:Any, Tb}) where {sa, sb, Ta, Tb}
     if sb[1] != sa[2]
         throw(DimensionMismatch("Tried to multiply arrays of size $sa and $sb"))
     end
@@ -82,7 +82,7 @@ end
 end
 
 # outer product
-@generated function _A_mul_B(::Size{sa}, ::Size{sb}, a::StaticVector{Ta}, b::RowVector{Tb, <:StaticVector}) where {sa, sb, Ta, Tb}
+@generated function _A_mul_B(::Size{sa}, ::Size{sb}, a::StaticVector{<: Any, Ta}, b::RowVector{Tb, <:StaticVector}) where {sa, sb, Ta, Tb}
     newsize = (sa[1], sb[2])
     exprs = [:(a[$i]*b[$j]) for i = 1:sa[1], j = 1:sb[2]]
 
@@ -93,7 +93,7 @@ end
     end
 end
 
-@generated function _A_mul_B(Sa::Size{sa}, Sb::Size{sb}, a::StaticMatrix{Ta}, b::StaticMatrix{Tb}) where {sa, sb, Ta, Tb}
+@generated function _A_mul_B(Sa::Size{sa}, Sb::Size{sb}, a::StaticMatrix{<:Any, <:Any, Ta}, b::StaticMatrix{<:Any, <:Any, Tb}) where {sa, sb, Ta, Tb}
     # Heuristic choice for amount of codegen
     if sa[1]*sa[2]*sb[2] <= 8*8*8
         return quote
@@ -142,7 +142,7 @@ end
     end
 end
 
-@generated function A_mul_B_unrolled(::Size{sa}, ::Size{sb}, a::StaticMatrix{Ta}, b::StaticMatrix{Tb}) where {sa, sb, Ta, Tb}
+@generated function A_mul_B_unrolled(::Size{sa}, ::Size{sb}, a::StaticMatrix{<:Any, <:Any, Ta}, b::StaticMatrix{<:Any, <:Any, Tb}) where {sa, sb, Ta, Tb}
     if sb[1] != sa[2]
         throw(DimensionMismatch("Tried to multiply arrays of size $sa and $sb"))
     end
@@ -163,7 +163,7 @@ end
 end
 
 
-@generated function A_mul_B_loop(::Size{sa}, ::Size{sb}, a::StaticMatrix{Ta}, b::StaticMatrix{Tb}) where {sa, sb, Ta, Tb}
+@generated function A_mul_B_loop(::Size{sa}, ::Size{sb}, a::StaticMatrix{<:Any, <:Any, Ta}, b::StaticMatrix{<:Any, <:Any, Tb}) where {sa, sb, Ta, Tb}
     if sb[1] != sa[2]
         throw(DimensionMismatch("Tried to multiply arrays of size $sa and $sb"))
     end
@@ -188,7 +188,7 @@ end
 
 # Concatenate a series of matrix-vector multiplications
 # Each function is N^2 not N^3 - aids in compile time.
-@generated function A_mul_B_unrolled_chunks(::Size{sa}, ::Size{sb}, a::StaticMatrix{Ta}, b::StaticMatrix{Tb}) where {sa, sb, Ta, Tb}
+@generated function A_mul_B_unrolled_chunks(::Size{sa}, ::Size{sb}, a::StaticMatrix{<:Any, <:Any, Ta}, b::StaticMatrix{<:Any, <:Any, Tb}) where {sa, sb, Ta, Tb}
     if sb[1] != sa[2]
         throw(DimensionMismatch("Tried to multiply arrays of size $sa and $sb"))
     end
@@ -212,7 +212,7 @@ end
     end
 end
 
-@generated function partly_unrolled_multiply(::Size{sa}, ::Size{sb}, a::StaticMatrix{Ta}, b::StaticVector{Tb}) where {sa, sb, Ta, Tb}
+@generated function partly_unrolled_multiply(::Size{sa}, ::Size{sb}, a::StaticMatrix{<:Any, <:Any, Ta}, b::StaticArray{<:Any, Tb}) where {sa, sb, Ta, Tb}
     if sa[2] != sb[1]
         throw(DimensionMismatch("Tried to multiply arrays of size $sa and $sb"))
     end
@@ -262,7 +262,7 @@ end
     end
 end
 
-@generated function _A_mul_B!(Sc::Size{sc}, c::StaticMatrix{Tc}, Sa::Size{sa}, Sb::Size{sb}, a::StaticMatrix{Ta}, b::StaticMatrix{Tb}) where {sa, sb, sc, Ta, Tb, Tc}
+@generated function _A_mul_B!(Sc::Size{sc}, c::StaticMatrix{<:Any, <:Any, Tc}, Sa::Size{sa}, Sb::Size{sb}, a::StaticMatrix{<:Any, <:Any, Ta}, b::StaticMatrix{<:Any, <:Any, Tb}) where {sa, sb, sc, Ta, Tb, Tc}
     can_blas = Tc == Ta && Tc == Tb && Tc <: BlasFloat
 
     if can_blas
@@ -303,7 +303,7 @@ end
 end
 
 
-@generated function A_mul_B_blas!(::Size{s}, c::StaticMatrix{T}, ::Size{sa}, ::Size{sb}, a::StaticMatrix{T}, b::StaticMatrix{T}) where {s,sa,sb, T <: BlasFloat}
+@generated function A_mul_B_blas!(::Size{s}, c::StaticMatrix{<:Any, <:Any, T}, ::Size{sa}, ::Size{sb}, a::StaticMatrix{<:Any, <:Any, T}, b::StaticMatrix{<:Any, <:Any, T}) where {s,sa,sb, T <: BlasFloat}
     if sb[1] != sa[2] || sa[1] != s[1] || sb[2] != s[2]
         throw(DimensionMismatch("Tried to multiply arrays of size $sa and $sb and assign to array of size $s"))
     end

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -1,18 +1,18 @@
-@inline (\)(a::StaticMatrix{T}, b::StaticVector{T}) where {T} = solve(Size(a), Size(b), a, b)
+@inline (\)(a::StaticMatrix{<:Any, <:Any, T}, b::StaticVector{<:Any, T}) where {T} = solve(Size(a), Size(b), a, b)
 
 # TODO: Ineffective but requires some infrastructure (e.g. LU or QR) to make efficient so we fall back on inv for now
 @inline solve(::Size, ::Size, a, b) = inv(a) * b
 
 @inline solve(::Size{(1,1)}, ::Size{(1,)}, a, b) = similar_type(b, typeof(b[1] \ a[1]))(b[1] \ a[1])
 
-@inline function solve(::Size{(2,2)}, ::Size{(2,)}, a::StaticMatrix{Ta}, b::StaticVector{Tb}) where {Ta, Tb}
+@inline function solve(::Size{(2,2)}, ::Size{(2,)}, a::StaticMatrix{<:Any, <:Any, Ta}, b::StaticVector{<:Any, Tb}) where {Ta, Tb}
     d = det(a)
     T = typeof((one(Ta)*zero(Tb) + one(Ta)*zero(Tb))/d)
     @inbounds return similar_type(b, T)((a[2,2]*b[1] - a[1,2]*b[2])/d,
                                         (a[1,1]*b[2] - a[2,1]*b[1])/d)
 end
 
-@inline function solve(::Size{(3,3)}, ::Size{(3,)}, a::StaticMatrix{Ta}, b::StaticVector{Tb}) where {Ta, Tb}
+@inline function solve(::Size{(3,3)}, ::Size{(3,)}, a::StaticMatrix{<:Any, <:Any, Ta}, b::StaticVector{<:Any, Tb}) where {Ta, Tb}
     d = det(a)
     T = typeof((one(Ta)*zero(Tb) + one(Ta)*zero(Tb))/d)
     @inbounds return similar_type(b, T)(

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -1,6 +1,6 @@
 @inline (\)(a::StaticMatrix{<:Any, <:Any, T}, b::StaticVector{<:Any, T}) where {T} = solve(Size(a), Size(b), a, b)
 
-# TODO: Ineffective but requires some infrastructure (e.g. LU or QR) to make efficient so we fall back on inv for now
+# TODO: Ineffecient but requires some infrastructure (e.g. LU or QR) to make efficient so we fall back on inv for now
 @inline solve(::Size, ::Size, a, b) = inv(a) * b
 
 @inline solve(::Size{(1,1)}, ::Size{(1,)}, a, b) = similar_type(b, typeof(b[1] \ a[1]))(b[1] \ a[1])

--- a/test/FieldVector.jl
+++ b/test/FieldVector.jl
@@ -1,7 +1,7 @@
 @testset "FieldVector" begin
     @testset "Immutable Point3D" begin
         eval(quote
-            immutable Point3D <: FieldVector{Float64}
+            immutable Point3D <: FieldVector{3, Float64}
                 x::Float64
                 y::Float64
                 z::Float64
@@ -37,7 +37,7 @@
 
     @testset "Mutable Point2D" begin
         eval(quote
-            type Point2D{T} <: FieldVector{T}
+            type Point2D{T} <: FieldVector{2, T}
                 x::T
                 y::T
             end

--- a/test/SUnitRange.jl
+++ b/test/SUnitRange.jl
@@ -1,0 +1,6 @@
+@testset "SUnitRange" begin
+    @test length(StaticArrays.SUnitRange(1,3)) === 3
+    @test length(StaticArrays.SUnitRange(1,-10)) === 0
+
+    @test StaticArrays.SUnitRange(2,4)[2] === 3
+end

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -62,7 +62,7 @@
 
     @testset "reshape" begin
         @test @inferred(reshape(SVector(1,2,3,4), Size(2,2))) === SMatrix{2,2}(1,2,3,4)
-        @test @inferred(reshape([1,2,3,4], Size(2,2)))::SizedArray{(2,2),Int,2,1} == [1 3; 2 4]
+        @test @inferred(reshape([1,2,3,4], Size(2,2)))::SizedArray{Tuple{2,2},Int,2,1} == [1 3; 2 4]
 
         @test @inferred(vec(SMatrix{2, 2}([1 2; 3 4])))::SVector{4,Int} == [1, 3, 2, 4]
     end

--- a/test/custom_types.jl
+++ b/test/custom_types.jl
@@ -1,6 +1,6 @@
 @testset "Custom types" begin
     # Issue 123
-    @eval (struct MyType{N, T} <: StaticVector{T}
+    @eval (struct MyType{N, T} <: StaticVector{N, T}
         data::NTuple{N, T}
     end)
     @test (MyType(3, 4) isa MyType{2, Int})

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,7 +21,7 @@ using Base.Test
     include("matrix_multiply.jl")
     include("det.jl")
     include("inv.jl")
-    include("solve.jl")
+    #include("solve.jl") # Strange inference / world-age error
     include("eigen.jl")
     include("deque.jl")
     #include("fixed_size_arrays.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,7 +21,7 @@ using Base.Test
     include("matrix_multiply.jl")
     include("det.jl")
     include("inv.jl")
-    #include("solve.jl") # Strange inference / world-age error
+    include("solve.jl") # Strange inference / world-age error
     include("eigen.jl")
     include("deque.jl")
     #include("fixed_size_arrays.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,6 +10,7 @@ using Base.Test
     include("MArray.jl")
     include("FieldVector.jl")
     include("Scalar.jl")
+    include("SUnitRange.jl")
     include("custom_types.jl")
 
     include("core.jl")

--- a/test/solve.jl
+++ b/test/solve.jl
@@ -1,11 +1,27 @@
 @testset "Solving linear system" begin
 
-    @testset "Problem size: $n x $n. Matrix type: $m. Element type: $elty" for n in (1,2,3,4),
+    # I see an inference error in the combined testset below. I can't reproduce
+    # at the REPL or in a function for individual n, etc... speculatively, it
+    # might be reusing A, b with different types in the same (non-toplevel)
+    # scope, for which I've come accross inference bugs in the past.
+
+    for n in (1,2,3,4),
+            (m, v) in ((SMatrix{n,n}, SVector{n}), (MMatrix{n,n}, MVector{n})),
+                elty in (Float64, Int)
+
+        eval(quote
+            A = $elty.(rand(-99:2:99,$n,$n))
+            b = A*ones($elty,$n)
+            @test $m(A)\$v(b) ≈ A\b
+        end)
+    end
+
+    #=@testset "Problem size: $n x $n. Matrix type: $m. Element type: $elty" for n in (1,2,3,4),
             (m, v) in ((SMatrix{n,n}, SVector{n}), (MMatrix{n,n}, MVector{n})),
                 elty in (Float64, Int)
 
         A = elty.(rand(-99:2:99,n,n))
         b = A*ones(elty,n)
         @test m(A)\v(b) ≈ A\b
-    end
+    end =#
 end


### PR DESCRIPTION
This is a continuation of #127 whereby we add a `Tuple{...}` size descriptor to the abstract `StaticArray` type.

I'm previewing this WIP to get feedback on the interface, such as whether we want `StaticArray{Size, T, N}`, or have the dimensions after `T`, or after `N`. Any comments appreciated, otherwise I'll carry on.