### PR TITLE
Make `broadcast` signature compatible with `Base`.

### DIFF
--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -4,8 +4,8 @@
 
 # TODO: bad codegen for `broadcast(-, SVector(1,2,3))`
 
-@propagate_inbounds function broadcast(f, a::Union{Number, StaticArray}, b::Union{Number, StaticArray}...)
-    _broadcast(f, broadcast_sizes(a, b...), a, b...)
+@propagate_inbounds function broadcast(f, a::Union{Number, StaticArray}...)
+    _broadcast(f, broadcast_sizes(a...), a...)
 end
 
 @inline broadcast_sizes(a...) = _broadcast_sizes((), a...)


### PR DESCRIPTION
A recent PR made some other signatures not define the zero-input version of certain functions where they are not defined in Base. In this case, this seems somewhat unnecessary since there is already a `broadcast(f, ::Number...)` method in `Base`.

The alternative is to define `broadcast(f, ::Number)` method here to remove the ambiguity. This seems like type piracy...

See #132.