### PR TITLE
Make map() take mixtures of StaticArray and AbstractArray

### DIFF
--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -1,7 +1,11 @@
+@inline _first(a1, as...) = a1
+
 ################
 ## map / map! ##
 ################
 
+# The following type signature for map() matches any list of AbstractArrays,
+# provided at least one is a static array.
 @inline function map(f, as::Union{SA,AbstractArray}...) where {SA<:StaticArray}
     _map(f, same_size(as...), as...)
 end
@@ -16,7 +20,7 @@ end
     newT = :(Core.Inference.return_type(f, Tuple{$(eltypes...)}))
     return quote
         @_inline_meta
-        @inbounds return similar_type(typeof(_first_static(a...)), $newT, Size(S))(tuple($(exprs...)))
+        @inbounds return similar_type(typeof(_first(a...)), $newT, Size(S))(tuple($(exprs...)))
     end
 end
 

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -108,11 +108,6 @@ Length(::Type{SA}) where {SA <: StaticArray} = Length(Size(SA))
 
 
 """
-Static or runtime size of an array
-"""
-const SRSize = Union{Size,Tuple{Vararg{Int}}}
-
-"""
 Return either the statically known Size() or runtime size()
 """
 @inline _size(a) = size(a)
@@ -125,12 +120,12 @@ Return either the statically known Size() or runtime size()
 
 # Returns the common Size of the inputs (or else throws a DimensionMismatch)
 @inline same_size(as...) = _same_size(_first_static_size(as...), as...)
-@inline function _same_size(s::SRSize, a1, as...)
+@inline function _same_size(s::Size, a1, as...)
     if s == _size(a1)
         return _same_size(s, as...)
     else
         throw(DimensionMismatch("Dimensions must match. Got inputs with $s and $(_size(a1))."))
     end
 end
-@inline _same_size(s::SRSize) = s
+@inline _same_size(s::Size) = s
 

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -17,11 +17,10 @@
         v3 = [2,4,6,8]
         v4 = [4,3,2,1]
 
-        # We broke "inferrable" sizes of AbstractVectors for vector+vector, matrix*vector, etc...
-        @test_broken @inferred(v1 + v4) === @SVector [6, 7, 8, 9]
-        @test_broken @inferred(v3 + v2) === @SVector [6, 7, 8, 9]
-        @test_broken @inferred(v1 - v4) === @SVector [-2, 1, 4, 7]
-        @test_broken @inferred(v3 - v2) === @SVector [-2, 1, 4, 7]
+        @test @inferred(v1 + v4) === @SVector [6, 7, 8, 9]
+        @test @inferred(v3 + v2) === @SVector [6, 7, 8, 9]
+        @test @inferred(v1 - v4) === @SVector [-2, 1, 4, 7]
+        @test @inferred(v3 - v2) === @SVector [-2, 1, 4, 7]
     end
 
     @testset "Interaction with `UniformScaling`" begin

--- a/test/mapreduce.jl
+++ b/test/mapreduce.jl
@@ -9,8 +9,8 @@
 
         @test @inferred(map(-, v1)) === @SVector [-2, -4, -6, -8]
         @test @inferred(map(+, v1, v2)) === @SVector [6, 7, 8, 9]
-        @test_broken @inferred(map(+, normal_v1, v2)) === @SVector [6, 7, 8, 9]
-        @test_broken @inferred(map(+, v1, normal_v2)) === @SVector [6, 7, 8, 9]
+        @test @inferred(map(+, normal_v1, v2)) === @SVector [6, 7, 8, 9]
+        @test @inferred(map(+, v1, normal_v2)) === @SVector [6, 7, 8, 9]
 
         map!(+, mv, v1, v2)
         @test mv == @MVector [6, 7, 8, 9]


### PR DESCRIPTION
This allows StaticArray/AbstractArray linear algebra + and - to return a static array.

Here the versions of `map()` only support StaticArray up to the second argument for mixtures of StaticArray and AbstractArray.  Dealing with the ambiguities for longer argument lists becomes increasingly annoying!

I also upgraded `same_size` to work with mixtures of static and abstract arrays, and put it into traits.jl as it seemed to fit there.

Still todo is to fix matrix*vec to be size inferrable with a smatrix input, but that could be a separate PR.