### PR TITLE
Reinstate StaticMatrix * AbstractVector -> StaticVector

### DIFF
--- a/test/matrix_multiply.jl
+++ b/test/matrix_multiply.jl
@@ -16,7 +16,7 @@
         @test @inferred(v*v') === @SMatrix [1 2; 2 4]
 
         v3 = [1, 2]
-        @test_broken m*v3 === @SVector [5, 11]
+        @test m*v3 === @SVector [5, 11]
 
         m2 = @MMatrix [1 2; 3 4]
         v4 = @MVector [1, 2]
@@ -32,11 +32,11 @@
 
         m5 = @SMatrix [1.0 2.0; 3.0 4.0]
         v7 = [1.0, 2.0]
-        @test_broken (m5*v7)::SVector ≈ @SVector [5.0, 11.0]
+        @test (m5*v7)::SVector ≈ @SVector [5.0, 11.0]
 
         m6 = @SMatrix Float32[1.0 2.0; 3.0 4.0]
         v8 = Float64[1.0, 2.0]
-        @test_broken (m6*v8)::SVector{2,Float64} ≈ @SVector [5.0, 11.0]
+        @test (m6*v8)::SVector{2,Float64} ≈ @SVector [5.0, 11.0]
 
     end
 


### PR DESCRIPTION
This was present prior to the big 0.6 rewrite, and should be reinstated for convenience as the output can be size inferred.  This PR is a bit copy-and-paste-ish, though not a lot worse than what's there already, I guess.

This is an associated fix for #131