### PR TITLE
Enforce usage of `similar_type` for matrix multiplication

### DIFF
--- a/src/matrix_multiply.jl
+++ b/src/matrix_multiply.jl
@@ -102,7 +102,7 @@ end
 
     if s == sb
         if T == Tb
-            newtype = b
+            newtype = similar_type(b)
         else
             newtype = similar_type(b, T)
         end
@@ -141,7 +141,7 @@ end
 
     if s == sb
         if T == Tb
-            newtype = b
+            newtype = similar_type(b)
         else
             newtype = similar_type(b, T)
         end
@@ -237,7 +237,7 @@ end
 
     if s == sB
         if T == TB
-            newtype = B
+            newtype = similar_type(B)
         else
             newtype = similar_type(B, T)
         end
@@ -334,7 +334,7 @@ end
     # TODO think about which to be similar to
     if s == sB
         if T == TB
-            newtype = B
+            newtype = similar_type(B)
         else
             newtype = similar_type(B, T)
         end
@@ -375,7 +375,7 @@ end
     # TODO think about which to be similar to
     if s == sB
         if T == TB
-            newtype = B
+            newtype = similar_type(B)
         else
             newtype = similar_type(B, T)
         end
@@ -420,7 +420,7 @@ end
     # TODO think about which to be similar to
     if s == sB
         if T == TB
-            newtype = B
+            newtype = similar_type(B)
         else
             newtype = similar_type(B, T)
         end
@@ -463,7 +463,7 @@ end
 
     if s == sb
         if T == Tb
-            newtype = b
+            newtype = similar_type(b)
         else
             newtype = similar_type(b, T)
         end

--- a/test/matrix_multiply.jl
+++ b/test/matrix_multiply.jl
@@ -18,11 +18,11 @@
 
         m3 = @SArray [1 2; 3 4]
         v5 = @SArray [1, 2]
-        @test m3*v5 === @SArray [5, 11]
+        @test m3*v5 === @SVector [5, 11]
 
         m4 = @MArray [1 2; 3 4]
         v6 = @MArray [1, 2]
-        @test (m4*v6)::MArray == @MArray [5, 11]
+        @test (m4*v6)::MVector == @MVector [5, 11]
 
         m5 = @SMatrix [1.0 2.0; 3.0 4.0]
         v7 = [1.0, 2.0]
@@ -62,11 +62,11 @@
 
         m = @SArray [1 2; 3 4]
         n = @SArray [2 3; 4 5]
-        @test m*n === @SArray [10 13; 22 29]
+        @test m*n === @SMatrix [10 13; 22 29]
 
         m = @MArray [1 2; 3 4]
         n = @MArray [2 3; 4 5]
-        @test (m*n)::MArray == @MArray [10 13; 22 29]
+        @test (m*n)::MMatrix == @MMatrix [10 13; 22 29]
 
         # Alternative methods used between 8 < n <= 14 and n > 14
         m_array = rand(1:10, 10, 10)


### PR DESCRIPTION
Fixes https://github.com/FugroRoames/CoordinateTransformations.jl/issues/28.