### PR TITLE
Fix default constructor for SizedArray

### DIFF
--- a/src/SizedArray.jl
+++ b/src/SizedArray.jl
@@ -20,7 +20,7 @@ immutable SizedArray{S <: Tuple, T, N, M} <: StaticArray{S, T, N}
     end
 
     function (::Type{SizedArray{S, T, N, M}}){S, T, N, M}()
-        new{S, T, N, M}(Array{T, M}(S))
+        new{S, T, N, M}(Array{T, M}(S.parameters...))
     end
 end
 

--- a/test/SizedArray.jl
+++ b/test/SizedArray.jl
@@ -1,0 +1,15 @@
+@testset "SizedArray" begin
+    @testset "Inner Constructors" begin
+        @test SizedArray{Tuple{2}, Int, 1}([3, 4]).data == [3, 4]
+        @test SizedArray{Tuple{2, 2}, Int, 2}(collect(3:6)).data == collect(3:6)
+        @test size(SizedArray{Tuple{4, 5}, Int, 2}().data) == (4, 5)
+        @test size(SizedArray{Tuple{4, 5}, Int}().data) == (4, 5)
+
+        # Bad input
+        @test_throws Exception SArray{Tuple{1},Int,1}([2 3])
+
+        # Bad parameters
+        @test_throws Exception SizedArray{Tuple{1},Int,2}()
+        @test_throws Exception SArray{Tuple{3, 4},Int,1}()
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,6 +11,7 @@ using Base.Test
     include("FieldVector.jl")
     include("Scalar.jl")
     include("SUnitRange.jl")
+    include("SizedArray.jl")
     include("custom_types.jl")
 
     include("core.jl")


### PR DESCRIPTION
I ran into this problem working on a project that uses StaticArrays. I don't know the StaticArrays
codebase at all, so this may be wrong, but it has solved the problem for me.

Before this patch:

```
julia> StaticArrays.SizedMatrix{Tuple{2,2}, Float64}()
ERROR: MethodError: Cannot `convert` an object of type Type{Tuple{2,2}} to an object of type Array{Float64,2}
This may have arisen from a call to the constructor Array{Float64,2}(...),
since type constructors fall back to convert methods.
Stacktrace:
 [1] Type at /home/steve/.julia/v0.6/StaticArrays/src/SizedArray.jl:23 [inlined]
 [2] StaticArrays.SizedArray{Tuple{2,2},Float64,2,M} where M() at /home/steve/.julia/v0.6/StaticArrays/src/SizedArray.jl:31
```

After this patch:

```
julia> StaticArrays.SizedMatrix{Tuple{2,2}, Float64}()
2×2 StaticArrays.SizedArray{Tuple{2,2},Float64,2,2}:
 6.91502e-310  6.91504e-310
 6.91504e-310  0.0
```

My julia:

```
   _       _ _(_)_     |  A fresh approach to technical computing
  (_)     | (_) (_)    |  Documentation: https://docs.julialang.org
   _ _   _| |_  __ _   |  Type "?help" for help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 0.6.0-pre.beta.338 (2017-04-26 15:52 UTC)
 _/ |\__'_|_|_|\__'_|  |  Commit 8e12b77 (2 days old master)
|__/                   |  x86_64-pc-linux-gnu
```

Let me know if I can provide any other info or help :). Thanks!