### PR TITLE
Add matrix exponential for 1x1 and 2x2, and fallback to Base (fixes #159)

### DIFF
--- a/src/StaticArrays.jl
+++ b/src/StaticArrays.jl
@@ -6,8 +6,8 @@ import Base: @pure, @propagate_inbounds, getindex, setindex!, size, similar,
              length, convert, promote_op, map, map!, reduce, reducedim,
              mapreduce, broadcast, broadcast!, conj, transpose, ctranspose,
              hcat, vcat, ones, zeros, eye, one, cross, vecdot, reshape, fill,
-             fill!, det, inv, eig, eigvals, trace, vecnorm, norm, dot, diagm,
-             sum, diff, prod, count, any, all, sumabs, sumabs2, minimum,
+             fill!, det, inv, eig, eigvals, expm, trace, vecnorm, norm, dot,
+             diagm, sum, diff, prod, count, any, all, sumabs, sumabs2, minimum,
              maximum, extrema, mean, copy, read, read!, write
 
 export StaticScalar, StaticArray, StaticVector, StaticMatrix
@@ -49,6 +49,7 @@ include("deque.jl")
 include("det.jl")
 include("inv.jl")
 include("eigen.jl")
+include("expm.jl")
 include("cholesky.jl")
 include("io.jl")
 

--- a/src/expm.jl
+++ b/src/expm.jl
@@ -1,64 +1,51 @@
 @inline expm(A::StaticMatrix) = _expm(Size(A), A)
 
-@generated function _expm(::Size{(1,1)}, A::StaticMatrix)
-    @assert size(A) == (1,1)
-    T = promote_type(typeof(sqrt(one(eltype(A)))), Float32)
+@inline function _expm(::Size{(1,1)}, A::StaticMatrix)
+    T = promote_type(typeof(exp(zero(eltype(A)))), Float32)
     newtype = similar_type(A,T)
 
-    quote
-        $(Expr(:meta, :inline))
-        ($newtype)((exp(A[1]), ))
-    end
+    (newtype)((exp(A[1]), ))
 end
 
-@generated function _expm{S<:Real}(::Size{(2,2)}, A::StaticMatrix{S})
-    @assert size(A) == (2,2)
-    T = promote_type(typeof(sqrt(one(eltype(A)))), Float32)
+@inline function _expm{S<:Real}(::Size{(2,2)}, A::StaticMatrix{S})
+    T = promote_type(typeof(exp(zero(eltype(A)))), Float32)
     newtype = similar_type(A,T)
 
-    quote
-        $(Expr(:meta, :inline))
+    @inbounds a = A[1]
+    @inbounds c = A[2]
+    @inbounds b = A[3]
+    @inbounds d = A[4]
 
-        @inbounds a = A[1]
-        @inbounds c = A[2]
-        @inbounds b = A[3]
-        @inbounds d = A[4]
+    v = (a-d)^2 + 4*b*c
 
-        v = (a-d)^2 + 4*b*c
-
-        # if v == 0
-        z1::$T = 1.0
-        z2::$T = 0.5
-
-        if v > 0
-          z = sqrt(v)
-          z1 = cosh(z / 2)
-          z2 = sinh(z / 2) / z
-        elseif v < 0
-          z = sqrt(-v)
-          z1 = cos(z / 2)
-          z2 = sin(z / 2) / z
-        end
-
-        r = exp((a + d) / 2)
-        m11 = r * (z1 + (a - d) * z2)
-        m12 = r * 2b * z2
-        m21 = r * 2c * z2
-        m22 = r * (z1 - (a - d) * z2)
-
-        ($newtype)((m11, m21, m12, m22))
+    if v > 0
+        z = sqrt(v)
+        z1 = cosh(z / 2)
+        z2 = sinh(z / 2) / z
+    elseif v < 0
+        z = sqrt(-v)
+        z1 = cos(z / 2)
+        z2 = sin(z / 2) / z
+    else # if v == 0
+        z1 = T(1.0)
+        z2 = T(0.5)
     end
+
+    r = exp((a + d) / 2)
+    m11 = r * (z1 + (a - d) * z2)
+    m12 = r * 2b * z2
+    m21 = r * 2c * z2
+    m22 = r * (z1 - (a - d) * z2)
+
+    (newtype)((m11, m21, m12, m22))
 end
 
 # TODO add complex valued expm
 # TODO add special case for 3x3 matrices
 
-@generated function _expm(::Size, A::StaticArray)
-  T = promote_type(typeof(sqrt(one(eltype(A)))), Float32)
-  newtype = similar_type(A,T)
+@inline function _expm(s::Size, A::StaticArray)
+    T = promote_type(typeof(exp(zero(eltype(A)))), Float32)
+    newtype = similar_type(A,T)
 
-  quote
-      $(Expr(:meta, :inline))
-      ($newtype)(Base.expm(Array(A)))
-  end
+    s(Base.expm(Array(A)))
 end

--- a/src/expm.jl
+++ b/src/expm.jl
@@ -43,9 +43,4 @@ end
 # TODO add complex valued expm
 # TODO add special case for 3x3 matrices
 
-@inline function _expm(s::Size, A::StaticArray)
-    T = promote_type(typeof(exp(zero(eltype(A)))), Float32)
-    newtype = similar_type(A,T)
-
-    s(Base.expm(Array(A)))
-end
+@inline _expm(s::Size, A::StaticArray) = s(Base.expm(Array(A)))

--- a/src/expm.jl
+++ b/src/expm.jl
@@ -11,7 +11,7 @@
     end
 end
 
-@generated function _expm{T<:Real}(::Size{(2,2)}, A::StaticMatrix{T})
+@generated function _expm{S<:Real}(::Size{(2,2)}, A::StaticMatrix{S})
     @assert size(A) == (2,2)
     T = promote_type(typeof(sqrt(one(eltype(A)))), Float32)
     newtype = similar_type(A,T)

--- a/src/expm.jl
+++ b/src/expm.jl
@@ -1,14 +1,14 @@
 @inline expm(A::StaticMatrix) = _expm(Size(A), A)
 
 @inline function _expm(::Size{(1,1)}, A::StaticMatrix)
-    T = promote_type(typeof(exp(zero(eltype(A)))), Float32)
+    T = typeof(exp(zero(eltype(A))))
     newtype = similar_type(A,T)
 
     (newtype)((exp(A[1]), ))
 end
 
 @inline function _expm{S<:Real}(::Size{(2,2)}, A::StaticMatrix{S})
-    T = promote_type(typeof(exp(zero(eltype(A)))), Float32)
+    T = typeof(exp(zero(eltype(A))))
     newtype = similar_type(A,T)
 
     @inbounds a = A[1]

--- a/src/expm.jl
+++ b/src/expm.jl
@@ -7,7 +7,7 @@
     (newtype)((exp(A[1]), ))
 end
 
-@inline function _expm(::Size{(2,2)}, A::StaticMatrix{<:Any,<:Any,<:Real})
+@inline function _expm{S<:Real}(::Size{(2,2)}, A::StaticMatrix{S})
     T = typeof(exp(zero(eltype(A))))
     newtype = similar_type(A,T)
 

--- a/src/expm.jl
+++ b/src/expm.jl
@@ -7,7 +7,7 @@
     (newtype)((exp(A[1]), ))
 end
 
-@inline function _expm{S<:Real}(::Size{(2,2)}, A::StaticMatrix{S})
+@inline function _expm(::Size{(2,2)}, A::StaticMatrix{<:Any,<:Any,<:Real})
     T = typeof(exp(zero(eltype(A))))
     newtype = similar_type(A,T)
 

--- a/src/expm.jl
+++ b/src/expm.jl
@@ -20,8 +20,8 @@ end
         $(Expr(:meta, :inline))
 
         @inbounds a = A[1]
-        @inbounds b = A[3]
         @inbounds c = A[2]
+        @inbounds b = A[3]
         @inbounds d = A[4]
 
         v = (a-d)^2 + 4*b*c
@@ -35,9 +35,9 @@ end
           z1 = cosh(z / 2)
           z2 = sinh(z / 2) / z
         elseif v < 0
-          z = sqrt(Complex(v))
-          z1 = real(cosh(z / 2))
-          z2 = real(sinh(z / 2) / z)
+          z = sqrt(-v)
+          z1 = cos(z / 2)
+          z2 = sin(z / 2) / z
         end
 
         r = exp((a + d) / 2)

--- a/src/expm.jl
+++ b/src/expm.jl
@@ -1,0 +1,64 @@
+@inline expm(A::StaticMatrix) = _expm(Size(A), A)
+
+@generated function _expm(::Size{(1,1)}, A::StaticMatrix)
+    @assert size(A) == (1,1)
+    T = promote_type(typeof(sqrt(one(eltype(A)))), Float32)
+    newtype = similar_type(A,T)
+
+    quote
+        $(Expr(:meta, :inline))
+        ($newtype)((exp(A[1]), ))
+    end
+end
+
+@generated function _expm{T<:Real}(::Size{(2,2)}, A::StaticMatrix{T})
+    @assert size(A) == (2,2)
+    T = promote_type(typeof(sqrt(one(eltype(A)))), Float32)
+    newtype = similar_type(A,T)
+
+    quote
+        $(Expr(:meta, :inline))
+
+        @inbounds a = A[1]
+        @inbounds b = A[3]
+        @inbounds c = A[2]
+        @inbounds d = A[4]
+
+        v = (a-d)^2 + 4*b*c
+
+        # if v == 0
+        z1::$T = 1.0
+        z2::$T = 0.5
+
+        if v > 0
+          z = sqrt(v)
+          z1 = cosh(z / 2)
+          z2 = sinh(z / 2) / z
+        elseif v < 0
+          z = sqrt(Complex(v))
+          z1 = real(cosh(z / 2))
+          z2 = real(sinh(z / 2) / z)
+        end
+
+        r = exp((a + d) / 2)
+        m11 = r * (z1 + (a - d) * z2)
+        m12 = r * 2b * z2
+        m21 = r * 2c * z2
+        m22 = r * (z1 - (a - d) * z2)
+
+        ($newtype)((m11, m21, m12, m22))
+    end
+end
+
+# TODO add complex valued expm
+# TODO add special case for 3x3 matrices
+
+@generated function _expm(::Size, A::StaticArray)
+  T = promote_type(typeof(sqrt(one(eltype(A)))), Float32)
+  newtype = similar_type(A,T)
+
+  quote
+      $(Expr(:meta, :inline))
+      ($newtype)(Base.expm(Array(A)))
+  end
+end

--- a/test/expm.jl
+++ b/test/expm.jl
@@ -1,0 +1,7 @@
+@testset "Matrix exponential" begin
+    @test expm(@SMatrix [2])::SMatrix ≈ SMatrix{1,1}(expm(2))
+    @test expm(@SMatrix [5 2; -2 1])::SMatrix ≈ expm([5 2; -2 1])
+    @test expm(@SMatrix [4 2; -2 1])::SMatrix ≈ expm([4 2; -2 1])
+    @test expm(@SMatrix [4 2; 2 1])::SMatrix ≈ expm([4 2; 2 1])
+    @test expm(@SMatrix [1 2 0; 2 1 0; 0 0 1])::SMatrix ≈ expm([1 2 0; 2 1 0; 0 0 1])
+end

--- a/test/expm.jl
+++ b/test/expm.jl
@@ -3,5 +3,5 @@
     @test expm(@SMatrix [5 2; -2 1])::SMatrix ≈ expm([5 2; -2 1])
     @test expm(@SMatrix [4 2; -2 1])::SMatrix ≈ expm([4 2; -2 1])
     @test expm(@SMatrix [4 2; 2 1])::SMatrix ≈ expm([4 2; 2 1])
-    @test expm(@SMatrix [1 2 0; 2 1 0; 0 0 1])::SMatrix ≈ expm([1 2 0; 2 1 0; 0 0 1])
+    @test expm(@SMatrix [1 2 0; 2 1 0; 0 0 1])::SizedArray{(3,3)} ≈ expm([1 2 0; 2 1 0; 0 0 1])
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,6 +22,7 @@ using Base.Test
     include("inv.jl")
     include("solve.jl")
     include("eigen.jl")
+    include("expm.jl")
     include("deque.jl")
     include("io.jl")
 


### PR DESCRIPTION
I have only tried this in julia v0.5, which is why the PR is to the julia-0.5 branch. You could probably cherry pick it to master.

Note: On my computer this gives a speedup of over 300x

```julia
a = randn(SMatrix{2,2})
b = Array(a)

@benchmark expm(a)
# BenchmarkTools.Trial:
#  memory estimate:  48 bytes
#  allocs estimate:  1
#  --------------
#  minimum time:     57.861 ns (0.00% GC)
#  median time:      58.580 ns (0.00% GC)
#  mean time:        65.692 ns (8.97% GC)
#  maximum time:     3.145 μs (96.47% GC)
#  --------------
#  samples:          10000
#  evals/sample:     983
@benchmark expm(b)
# BenchmarkTools.Trial:
#  memory estimate:  5.67 KiB
#  allocs estimate:  76
#  --------------
#  minimum time:     15.294 μs (0.00% GC)
#  median time:      18.114 μs (0.00% GC)
#  mean time:        19.030 μs (4.38% GC)
#  maximum time:     4.279 ms (98.87% GC)
#  --------------
#  samples:          10000
#  evals/sample:     1
```