### PR TITLE
fix a method ambiguity error in unsafe_convert for FieldVectors

### DIFF
--- a/src/FieldVector.jl
+++ b/src/FieldVector.jl
@@ -24,7 +24,5 @@ abstract type FieldVector{N, T} <: StaticVector{N, T} end
 
 # See #53
 Base.cconvert{T}(::Type{Ptr{T}}, v::FieldVector) = Base.RefValue(v)
-Base.unsafe_convert{T, FV <: FieldVector}(::Type{Ptr{T}}, m::Base.RefValue{FV}) =
-    _unsafe_convert(Ptr{T}, eltype(FV), m)
-_unsafe_convert{T, FV <: FieldVector}(::Type{Ptr{T}}, ::Type{T}, m::Base.RefValue{FV}) =
-         Ptr{T}(Base.unsafe_convert(Ptr{FV}, m))
+Base.unsafe_convert(::Type{Ptr{T}}, m::Base.RefValue{FV}) where {N,T,FV<:FieldVector{N,T}} =
+    Ptr{T}(Base.unsafe_convert(Ptr{FV}, m))

--- a/src/FieldVector.jl
+++ b/src/FieldVector.jl
@@ -23,6 +23,6 @@ abstract type FieldVector{N, T} <: StaticVector{N, T} end
 @propagate_inbounds setindex!(v::FieldVector, x, i::Int) = setfield!(v, i, x)
 
 # See #53
-Base.cconvert{T}(::Type{Ptr{T}}, v::FieldVector) = Base.RefValue(v)
+Base.cconvert(::Type{<:Ptr}, v::FieldVector) = Base.RefValue(v)
 Base.unsafe_convert(::Type{Ptr{T}}, m::Base.RefValue{FV}) where {N,T,FV<:FieldVector{N,T}} =
     Ptr{T}(Base.unsafe_convert(Ptr{FV}, m))


### PR DESCRIPTION
I'm not 100% sure this change is correct, but without it I see a method ambiguity error when trying to pass a `FieldVector` through `ccall`:

```
  MethodError: Base.unsafe_convert(::Type{Ptr{LibHealpix.UnitVector}}, ::Base.RefValue{LibHealpix.UnitVector}) is ambiguous. Candidates:
    unsafe_convert(::Type{Ptr{T}}, m::Base.RefValue{FV}) where {T, FV<:StaticArrays.FieldVector} in StaticArrays at /home/michael/.julia/v0.6/StaticArrays/src/FieldVector.jl:27
    unsafe_convert(P::Type{Ptr{T}}, b::Base.RefValue{T}) where T in Base at refpointer.jl:56
```

where `LibHealpix.UnitVector <: FieldVector{3, Float64}`.