### PR TITLE
Bugfix for Tuple(::Scalar)

### DIFF
--- a/src/MMatrix.jl
+++ b/src/MMatrix.jl
@@ -99,8 +99,6 @@ end
     return val
 end
 
-@inline Tuple(v::MMatrix) = v.data
-
 macro MMatrix(ex)
     if !isa(ex, Expr)
         error("Bad input for @MMatrix")

--- a/src/MVector.jl
+++ b/src/MVector.jl
@@ -53,8 +53,6 @@ end
     return val
 end
 
-@inline Tuple(v::MVector) = v.data
-
 macro MVector(ex)
     if isa(ex, Expr) && ex.head == :vect
         return esc(Expr(:call, MVector{length(ex.args)}, Expr(:tuple, ex.args...)))

--- a/src/SMatrix.jl
+++ b/src/SMatrix.jl
@@ -72,8 +72,6 @@ function getindex(v::SMatrix, i::Int)
     v.data[i]
 end
 
-@inline Tuple(v::SMatrix) = v.data
-
 macro SMatrix(ex)
     if !isa(ex, Expr)
         error("Bad input for @SMatrix")

--- a/src/SVector.jl
+++ b/src/SVector.jl
@@ -37,8 +37,6 @@ show(io::IO, ::Type{SVector{N, T}}) where {N, T} = print(io, "SVector{$N,$T}")
     v.data[i]
 end
 
-@inline Tuple(v::SVector) = v.data
-
 # Converting a CartesianIndex to an SVector
 convert(::Type{SVector}, I::CartesianIndex) = SVector(I.I)
 convert{N}(::Type{SVector{N}}, I::CartesianIndex{N}) = SVector{N}(I.I)

--- a/src/Scalar.jl
+++ b/src/Scalar.jl
@@ -21,8 +21,6 @@ getindex(v::Scalar) = v.data[1]
     v.data[1]
 end
 
-@inline Tuple(v::Scalar) = (v.data,)
-
 # A lot more compact than the default array show
 Base.show(io::IO, ::MIME"text/plain", x::Scalar{T}) where {T} = print(io, "Scalar{$T}(", x.data, ")")
 


### PR DESCRIPTION
Remove most Tuple conversion functions now that most types have become
subtypes of SArray / MArray.  The scalar version of these was buggy.

Should fix test failures in #175 and #161