### PR TITLE
Inferrably construct leaf types

### DIFF
--- a/src/SArray.jl
+++ b/src/SArray.jl
@@ -1,6 +1,6 @@
 """
-    SArray{S, T, L}(x::NTuple{L, T})
-    SArray{S, T, L}(x1, x2, x3, ...)
+    sa = SArray{S, T, L}(x::NTuple{L, T})
+    sa = SArray{S, T, L}(x1, x2, x3, ...)
 
 Construct a statically-sized array `SArray`. Since this type is immutable, the data must be
 provided upon construction and cannot be mutated later. The `S` parameter is a Tuple-type
@@ -9,7 +9,7 @@ array. The `L` parameter is the `length` of the array and is always equal to `pr
 Constructors may drop the `L` and `T` parameters if they are inferrable from the input
 (e.g. `L` is always inferrable from `S`).
 
-    SArray{S}(a::Array)
+    sa = SArray{S}(a::Array)
 
 Construct a statically-sized array of dimensions `S` (expressed as a `Tuple{...}`) using
 the data from `a`. The `S` parameter is mandatory since the size of `a` is unknown to the
@@ -51,6 +51,22 @@ end
 end
 
 @inline SArray(a::StaticArray) = SArray{size_tuple(a)}(Tuple(a)) # TODO fixme
+
+
+"""
+    SA = SArray(s::Size, ::Type{T})
+
+Inferrably construct a concrete (leaf) `SArray` type with the given
+[Size](@ref) `s` and element type `T`.
+
+# Example
+
+```julia
+julia> SArray(Size(3,2,5), Float64)
+StaticArrays.SArray{Tuple{3,2,5},Float64,3,30}
+```
+"""
+SArray{S,T}(s::Size{S}, ::Type{T}) = SArray{Tuple{S...}, T, length(s), prod(s)}
 
 # Simplified show for the type
 show(io::IO, ::Type{SArray{S, T, N}}) where {S, T, N} = print(io, "SArray{$S,$T,$N}")

--- a/test/SArray.jl
+++ b/test/SArray.jl
@@ -61,6 +61,18 @@
         @test @SArray([1 for x = SVector(1,2), y = SVector(1,2,3)]) == ones(2,3)
     end
 
+    @testset "Leaftypes" begin
+        leaf1{N}(::NTuple{N,Bool}) = Vector{SArray(Size(N), Float64)}(0)
+        leaf2{N}(::NTuple{N,Bool}) = Vector{SArray(Size(N,N), Float32)}(0)
+        leaf3{N}(::NTuple{N,Bool}) = Vector{SArray(Size(N,N,N), Int)}(0)
+        @test isa(@inferred(leaf1((true, true))), Vector{SArray{Tuple{2}, Float64, 1, 2}})
+        @test isa(@inferred(leaf1((true, true, true))), Vector{SArray{Tuple{3}, Float64, 1, 3}})
+        @test isa(@inferred(leaf2((true, true))), Vector{SArray{Tuple{2,2}, Float32, 2, 4}})
+        @test isa(@inferred(leaf2((true, true, true))), Vector{SArray{Tuple{3,3}, Float32, 2, 9}})
+        @test isa(@inferred(leaf3((true, true))), Vector{SArray{Tuple{2,2,2}, Int, 3, 8}})
+        @test isa(@inferred(leaf3((true, true, true))), Vector{SArray{Tuple{3,3,3}, Int, 3, 27}})
+    end
+
     @testset "Methods" begin
         m = @SArray [11 13; 12 14]
 


### PR DESCRIPTION
I just transitioned a large internal project from FixedSizeArrays->StaticArrays. I may have missed it, but the one bit of functionality I found lacking was the ability to easily & inferrably create a leaftype. I use this facility to allocate `Array{SA}` where `SA <: StaticArray` gets constructed from other type parameters. The `leaf2` test illustrates how you might inferrably create an empty vector of NxN SMatrix with eltype Float32, given any function argument that gives you access to `N` as a type parameter:

```julia
leaf2{N}(::NTuple{N,Bool}) = Vector{SArray(Size(N,N), Float32)}(0)
```

It's just one line of code, but documenting and testing it seems to be the main thing here.

Again, maybe there's already a different way to do this, so if I missed it please do let me know.