### PR TITLE
use 0.6.0-pre for minimum julia version in REQUIRE

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,1 @@
-julia 0.6-
+julia 0.6.0-pre


### PR DESCRIPTION
`abstract type` won't work on early 0.6.0-dev versions,
so better to stick with the julia-0.5-compatible versions of the package there