### PR TITLE
Add simple forward and backward substitution to solve triangular systems

### DIFF
--- a/src/solve.jl
+++ b/src/solve.jl
@@ -1,9 +1,13 @@
 @inline (\)(a::StaticMatrix{<:Any, <:Any, T}, b::StaticVector{<:Any, T}) where {T} = solve(Size(a), Size(b), a, b)
+@inline (\)(a::Union{UpperTriangular{T, S}, LowerTriangular{T, S}} where {S<:StaticMatrix{<:Any, <:Any, T}}, b::StaticVector{<:Any, T}) where {T} = solve(Size(a.data), Size(b), a, b)
+@inline (\)(a::Union{UpperTriangular{T, S}, LowerTriangular{T, S}} where {S<:StaticMatrix{<:Any, <:Any, T}}, b::StaticMatrix{<:Any, <:Any, T}) where {T} = solve(Size(a.data), Size(b), a, b)
 
 # TODO: Ineffecient but requires some infrastructure (e.g. LU or QR) to make efficient so we fall back on inv for now
 @inline solve(::Size, ::Size, a, b) = inv(a) * b
 
-@inline solve(::Size{(1,1)}, ::Size{(1,)}, a, b) = similar_type(b, typeof(b[1] \ a[1]))(b[1] \ a[1])
+@inline function solve(::Size{(1,1)}, ::Size{(1,)}, a::StaticMatrix{<:Any, <:Any, Ta}, b::StaticVector{<:Any, Tb}) where {Ta, Tb}
+    @inbounds return similar_type(b, typeof(b[1] \ a[1]))(b[1] \ a[1])
+end
 
 @inline function solve(::Size{(2,2)}, ::Size{(2,)}, a::StaticMatrix{<:Any, <:Any, Ta}, b::StaticVector{<:Any, Tb}) where {Ta, Tb}
     d = det(a)
@@ -25,4 +29,68 @@ end
         ((a[2,1]*a[3,2] - a[2,2]*a[3,1])*b[1] +
             (a[1,2]*a[3,1] - a[1,1]*a[3,2])*b[2] +
             (a[1,1]*a[2,2] - a[1,2]*a[2,1])*b[3]) / d )
+end
+
+@generated function solve(::Size{sa}, ::Size{sb}, a::UpperTriangular{Ta, Sa} where {Sa<:StaticMatrix{<:Any, <:Any, Ta}}, b::StaticVector{<:Any, Tb}) where {sa, sb, Ta, Tb}
+    if sa[1] != sb[1]
+        throw(DimensionMismatch("right hand side b needs first dimension of size $(sa[1]), has size $(sb[1])"))
+    end
+
+    x = [Symbol("x$k") for k = 1:sb[1]]
+    expr = [:($(x[i]) = $(reduce((ex1, ex2) -> :(-($ex1,$ex2)), [j == i ? :(b[$j]) : :(a[$i, $j]*$(x[j])) for j = i:sa[1]]))/a[$i, $i]) for i = sb[1]:-1:1]
+
+    quote
+      @_inline_meta
+      T = typeof((zero(Ta)*zero(Tb) + zero(Ta)*zero(Tb))/one(Ta))
+      @inbounds $(Expr(:block, expr...))
+      @inbounds return similar_type(b, T)(tuple($(x...)))
+    end
+end
+
+@generated function solve(::Size{sa}, ::Size{sb}, a::UpperTriangular{Ta, Sa} where {Sa<:StaticMatrix{<:Any, <:Any, Ta}}, b::StaticMatrix{<:Any, <:Any, Tb}) where {sa, sb, Ta, Tb}
+    if sa[1] != sb[1]
+        throw(DimensionMismatch("right hand side b needs first dimension of size $(sa[1]), has size $(sb[1])"))
+    end
+
+    x = [Symbol("x$k1$k2") for k1 = 1:sb[1], k2 = 1:sb[2]]
+    expr = [:($(x[k1, k2]) = $(reduce((ex1, ex2) -> :(-($ex1,$ex2)), [j == k1 ? :(b[$j, $k2]) : :(a[$k1, $j]*$(x[j, k2])) for j = k1:sa[1]]))/a[$k1, $k1]) for k1 = sb[1]:-1:1, k2 = 1:sb[2]]
+
+    quote
+      @_inline_meta
+      T = typeof((zero(Ta)*zero(Tb) + zero(Ta)*zero(Tb))/one(Ta))
+      @inbounds $(Expr(:block, expr...))
+      @inbounds return similar_type(b, T)(tuple($(x...)))
+    end
+end
+
+@generated function solve(::Size{sa}, ::Size{sb}, a::LowerTriangular{Ta, Sa} where {Sa<:StaticMatrix{<:Any, <:Any, Ta}}, b::StaticVector{<:Any, Tb}) where {sa, sb, Ta, Tb}
+    if sa[1] != sb[1]
+        throw(DimensionMismatch("right hand side b needs first dimension of size $(sa[1]), has size $(sb[1])"))
+    end
+
+    x = [Symbol("x$k") for k = 1:sb[1]]
+    expr = [:($(x[i]) = $(reduce((ex1, ex2) -> :(-($ex1,$ex2)), [j == i ? :(b[$j]) : :(a[$i, $j]*$(x[j])) for j = i:-1:1]))/a[$i, $i]) for i = 1:sb[1]]
+
+    quote
+      @_inline_meta
+      T = typeof((zero(Ta)*zero(Tb) + zero(Ta)*zero(Tb))/one(Ta))
+      @inbounds $(Expr(:block, expr...))
+      @inbounds return similar_type(b, T)(tuple($(x...)))
+    end
+end
+
+@generated function solve(::Size{sa}, ::Size{sb}, a::LowerTriangular{Ta, Sa} where {Sa<:StaticMatrix{<:Any, <:Any, Ta}}, b::StaticMatrix{<:Any, <:Any, Tb}) where {sa, sb, Ta, Tb}
+    if sa[1] != sb[1]
+        throw(DimensionMismatch("right hand side b needs first dimension of size $(sa[1]), has size $(sb[1])"))
+    end
+
+    x = [Symbol("x$k1$k2") for k1 = 1:sb[1], k2 = 1:sb[2]]
+    expr = [:($(x[k1, k2]) = $(reduce((ex1, ex2) -> :(-($ex1,$ex2)), [j == k1 ? :(b[$j, $k2]) : :(a[$k1, $j]*$(x[j, k2])) for j = k1:-1:1]))/a[$k1, $k1]) for k1 = 1:sb[1], k2 = 1:sb[2]]
+
+    quote
+      @_inline_meta
+      T = typeof((zero(Ta)*zero(Tb) + zero(Ta)*zero(Tb))/one(Ta))
+      @inbounds $(Expr(:block, expr...))
+      @inbounds return similar_type(b, T)(tuple($(x...)))
+    end
 end

--- a/test/solve.jl
+++ b/test/solve.jl
@@ -25,3 +25,20 @@
         @test m(A)\v(b) ≈ A\b
     end =#
 end
+
+@testset "Solving triangular system" begin
+    for n in (1,2,3,4),
+          (t1, uplo1) in ((UpperTriangular, :U),
+                          (LowerTriangular, :L)),
+            (m, v, u) in ((SMatrix{n, n}, SVector{n}, SMatrix{n, 2}), (MMatrix{n,n}, MVector{n}, SMatrix{n, 2})),
+                elty in (Float32, Float64, Int)
+
+        eval(quote
+            A = $(t1)($elty == Int ? rand(1:7, $n, $n) : convert(Matrix{$elty}, randn($n, $n)) |> t -> chol(t't) |> t -> $(uplo1 == :U) ? t : ctranspose(t))
+            b = convert(Matrix{$elty}, A*ones($n, 2))
+            SA = $t1($m(A.data))
+            @test SA \ $v(b[:, 1]) ≈ A \ b[:, 1]
+            @test SA \ $u(b) ≈ A \ b
+        end)
+    end
+end

--- a/test/solve.jl
+++ b/test/solve.jl
@@ -27,18 +27,28 @@
 end
 
 @testset "Solving triangular system" begin
-    for n in (1,2,3,4),
-          (t1, uplo1) in ((UpperTriangular, :U),
-                          (LowerTriangular, :L)),
-            (m, v, u) in ((SMatrix{n, n}, SVector{n}, SMatrix{n, 2}), (MMatrix{n,n}, MVector{n}, SMatrix{n, 2})),
-                elty in (Float32, Float64, Int)
+    for n in (1, 2, 3, 4),
+          (t, uplo) in ((UpperTriangular, :U),
+                        (LowerTriangular, :L)),
+              (m, v, u) in ((SMatrix{n,n}, SVector{n}, SMatrix{n, 2}),
+                            (MMatrix{n,n}, MVector{n}, SMatrix{n, 2})),
+                  eltya in (Float32, Float64, BigFloat, Complex64, Complex128, Complex{BigFloat}, Int),
+                      eltyb in (Float32, Float64, BigFloat, Complex64, Complex128, Complex{BigFloat})
 
         eval(quote
-            A = $(t1)($elty == Int ? rand(1:7, $n, $n) : convert(Matrix{$elty}, randn($n, $n)) |> t -> chol(t't) |> t -> $(uplo1 == :U) ? t : ctranspose(t))
-            b = convert(Matrix{$elty}, A*ones($n, 2))
-            SA = $t1($m(A.data))
-            @test SA \ $v(b[:, 1]) ≈ A \ b[:, 1]
-            @test SA \ $u(b) ≈ A \ b
+            A = $t($eltya == Int ? rand(1:7, $n, $n) : convert(Matrix{$eltya}, ($eltya <: Complex ? complex.(randn($n, $n), randn($n, $n)) : randn($n, $n)) |> z -> chol(z'z) |> z -> $(uplo == :U) ? z : ctranspose(z)))
+            b = convert(Matrix{$eltyb}, $eltya <: Complex ? real(A)*ones($n, 2) : A*ones($n, 2))
+            SA = $t($m(A.data))
+            Sx = SA \ $v(b[:, 1])
+            x = A \ b[:, 1]
+            @test typeof(Sx) <: StaticVector # test not falling back to Base
+            @test Sx ≈ x
+            @test eltype(Sx) == eltype(x)
+            SX = SA \ $u(b)
+            X = A \ b
+            @test typeof(SX) <: StaticMatrix # test not falling back to Base
+            @test SX ≈ X
+            @test eltype(SX) == eltype(X)
         end)
     end
 end

--- a/test/solve.jl
+++ b/test/solve.jl
@@ -28,27 +28,25 @@ end
 
 @testset "Solving triangular system" begin
     for n in (1, 2, 3, 4),
-          (t, uplo) in ((UpperTriangular, :U),
-                        (LowerTriangular, :L)),
-              (m, v, u) in ((SMatrix{n,n}, SVector{n}, SMatrix{n, 2}),
-                            (MMatrix{n,n}, MVector{n}, SMatrix{n, 2})),
-                  eltya in (Float32, Float64, BigFloat, Complex64, Complex128, Complex{BigFloat}, Int),
-                      eltyb in (Float32, Float64, BigFloat, Complex64, Complex128, Complex{BigFloat})
+        (t, uplo) in ((UpperTriangular, :U),
+                      (LowerTriangular, :L)),
+            (m, v, u) in ((SMatrix{n,n}, SVector{n}, SMatrix{n,2}),
+                          (MMatrix{n,n}, MVector{n}, SMatrix{n,2})),
+                eltya in (Float32, Float64, BigFloat, Complex64, Complex128, Complex{BigFloat}, Int),
+                    eltyb in (Float32, Float64, BigFloat, Complex64, Complex128, Complex{BigFloat})
 
-        eval(quote
-            A = $t($eltya == Int ? rand(1:7, $n, $n) : convert(Matrix{$eltya}, ($eltya <: Complex ? complex.(randn($n, $n), randn($n, $n)) : randn($n, $n)) |> z -> chol(z'z) |> z -> $(uplo == :U) ? z : ctranspose(z)))
-            b = convert(Matrix{$eltyb}, $eltya <: Complex ? real(A)*ones($n, 2) : A*ones($n, 2))
-            SA = $t($m(A.data))
-            Sx = SA \ $v(b[:, 1])
-            x = A \ b[:, 1]
-            @test typeof(Sx) <: StaticVector # test not falling back to Base
-            @test Sx ≈ x
-            @test eltype(Sx) == eltype(x)
-            SX = SA \ $u(b)
-            X = A \ b
-            @test typeof(SX) <: StaticMatrix # test not falling back to Base
-            @test SX ≈ X
-            @test eltype(SX) == eltype(X)
-        end)
+        A = t(eltya == Int ? rand(1:7, n, n) : convert(Matrix{eltya}, (eltya <: Complex ? complex.(randn(n,n), randn(n,n)) : randn(n,n)) |> z -> chol(z'z) |> z -> uplo == :U ? z : ctranspose(z)))
+        b = convert(Matrix{eltyb}, eltya <: Complex ? real(A)*ones(n,2) : A*ones(n,2))
+        SA = t(m(A.data))
+        Sx = SA \ v(b[:, 1])
+        x = A \ b[:, 1]
+        @test Sx isa StaticVector # test not falling back to Base
+        @test Sx ≈ x
+        @test eltype(Sx) == eltype(x)
+        SX = SA \ u(b)
+        X = A \ b
+        @test SX isa StaticMatrix # test not falling back to Base
+        @test SX ≈ X
+        @test eltype(SX) == eltype(X)
     end
 end


### PR DESCRIPTION
Firstly, thanks for great package.

I needed to solve some triangular systems with static arrays and thought that you might find a pull request useful. Below are a couple of quick benchmarks. I'm not sure how you decide on your huristics so I haven't added any fall backs to the methods in Base yet.

```julia
A = randn(n, n) |> t -> chol(t't);
b = A*ones(n, 2);
SA = UpperTriangular(SMatrix{n, n}(A.data));
Sb = SMatrix{n, 2}(b);
```
For `n=3` the results for `@benchmark A \ b` are:
BenchmarkTools.Trial: 
memory estimate:  144 bytes
allocs estimate:  2
minimum time:     261.064 ns (0.00% GC)
median time:      270.437 ns (0.00% GC)
mean time:        284.320 ns (3.11% GC)
maximum time:     4.887 μs (89.11% GC)
samples:          10000
evals/sample:     343

And the results for `@benchmark SA \ Sb` are:
BenchmarkTools.Trial: 
memory estimate:  64 bytes
allocs estimate:  1
minimum time:     60.341 ns (0.00% GC)
median time:      62.549 ns (0.00% GC)
mean time:        67.918 ns (5.45% GC)
maximum time:     1.611 μs (93.13% GC)
samples:          10000
evals/sample:     982
