### PR TITLE
make matprod inference consistent with Base

### DIFF
--- a/test/matrix_multiply.jl
+++ b/test/matrix_multiply.jl
@@ -55,6 +55,7 @@
         @test @inferred(v*m) === @SMatrix [1 2 3 4; 2 4 6 8]
 
         # block matrices
+        m = @SMatrix [1 2; 3 4]
         bm = @SMatrix [m m; m m]
         bv = @SVector [v,v]
         @test_broken (bv'*bm)'::SVector{2,SVector{2,Int}} == @SVector [[14,20],[14,20]]

--- a/test/matrix_multiply.jl
+++ b/test/matrix_multiply.jl
@@ -11,6 +11,11 @@
         @test isa(x, SVector{2,CartesianIndex{2}})
         @test x == @SVector [CartesianIndex((7,5)), CartesianIndex((15,13))]
 
+        # block matrices
+        bm = @SMatrix [m m; m m]
+        bv = @SVector [v,v]
+        @test (bm*bv)::SVector{2,SVector{2,Int}} == @SVector [[10,22],[10,22]]
+
         # inner product
         @test @inferred(v'*v) === 5
 
@@ -49,6 +54,11 @@
         v = @SVector [1, 2]
         @test @inferred(v*m) === @SMatrix [1 2 3 4; 2 4 6 8]
 
+        # block matrices
+        bm = @SMatrix [m m; m m]
+        bv = @SVector [v,v]
+        @test_broken (bv'*bm)'::SVector{2,SVector{2,Int}} == @SVector [[14,20],[14,20]]
+
         # Outer product
         v2 = SVector(1, 2)
         v3 = SVector(3, 4)
@@ -86,6 +96,11 @@
         m = @MArray [1 2; 3 4]
         n = @MArray [2 3; 4 5]
         @test (m*n) == @SMatrix [10 13; 22 29]
+        
+        # block matrices
+        bm = @SMatrix [m m; m m]
+        bm2 = @SMatrix [14 20; 30 44]
+        @test (bm*bm)::SMatrix{2,2,SMatrix{2,2,Int,4}} == @SMatrix [bm2 bm2; bm2 bm2]
 
         # Alternative methods used between 8 < n <= 14 and n > 14
         m_array = rand(1:10, 10, 10)


### PR DESCRIPTION
This makes matrix multiply infer the type of the result in the same way Base does. One immediate result is that block matrix multiplication now works, 

```julia
julia> m=[1 2; 3 4]
2×2 Array{Int64,2}:
 1  2
 3  4
julia> bm = @SMatrix [m m; m m]
2×2 StaticArrays.SArray{Tuple{2,2},Array{Int64,2},2,4}:
 [1 2; 3 4]  [1 2; 3 4]
 [1 2; 3 4]  [1 2; 3 4]
julia> bm * bm
2×2 StaticArrays.SArray{Tuple{2,2},Array{Int64,2},2,4}:
 [14 20; 30 44]  [14 20; 30 44]
 [14 20; 30 44]  [14 20; 30 44]
```
whereas before it was 
```julia
julia> bm * bm
ERROR: MethodError: no method matching zero(::Type{Array{Int64,2}})
Closest candidates are:
  zero(::Type{Base.LibGit2.GitHash}) at libgit2/oid.jl:106
  zero(::Type{Base.Pkg.Resolve.VersionWeights.VWPreBuildItem}) at pkg/resolve/versionweight.jl:82
  zero(::Type{Base.Pkg.Resolve.VersionWeights.VWPreBuild}) at pkg/resolve/versionweight.jl:124
  ...
Stacktrace:
 [1] macro expansion at /home/marius/.julia/v0.6/StaticArrays/src/matrix_multiply.jl:174 [inlined]
 [2] A_mul_B_unrolled at /home/marius/.julia/v0.6/StaticArrays/src/matrix_multiply.jl:160 [inlined]
 [3] macro expansion at /home/marius/.julia/v0.6/StaticArrays/src/matrix_multiply.jl:115 [inlined]
 [4] _A_mul_B at /home/marius/.julia/v0.6/StaticArrays/src/matrix_multiply.jl:112 [inlined]
 [5] *(::StaticArrays.SArray{Tuple{2,2},Array{Int64,2},2,4}, ::StaticArrays.SArray{Tuple{2,2},Array{Int64,2},2,4}) at /home/marius/.julia/v0.6/StaticArrays/src/matrix_multiply.jl:36

```
