### PR TITLE
remove sumabs and sumabs2

### DIFF
--- a/src/StaticArrays.jl
+++ b/src/StaticArrays.jl
@@ -9,7 +9,7 @@ import Base: getindex, setindex!, size, similar, vec, show,
              mapreduce, broadcast, broadcast!, conj, transpose, ctranspose,
              hcat, vcat, ones, zeros, eye, one, cross, vecdot, reshape, fill,
              fill!, det, inv, eig, eigvals, expm, trace, vecnorm, norm, dot, diagm,
-             sum, diff, prod, count, any, all, sumabs, sumabs2, minimum,
+             sum, diff, prod, count, any, all, minimum,
              maximum, extrema, mean, copy, rand, randn, randexp, rand!, randn!,
              randexp!, normalize, normalize!, read, read!, write
 

--- a/src/eigen.jl
+++ b/src/eigen.jl
@@ -278,16 +278,16 @@ end
     r₁ = SVector(a11 - eig1, a12, a13)
     r₂ = SVector(conj(a12), a22 - eig1, a23)
     r₃ = SVector(conj(a13), conj(a23), a33 - eig1)
-    n₁ = sumabs2(r₁)
-    n₂ = sumabs2(r₂)
-    n₃ = sumabs2(r₃)
+    n₁ = sum(abs2, r₁)
+    n₂ = sum(abs2, r₂)
+    n₃ = sum(abs2, r₃)
 
     r₁₂ = r₁ × r₂
     r₂₃ = r₂ × r₃
     r₃₁ = r₃ × r₁
-    n₁₂ = sumabs2(r₁₂)
-    n₂₃ = sumabs2(r₂₃)
-    n₃₁ = sumabs2(r₃₁)
+    n₁₂ = sum(abs2, r₁₂)
+    n₂₃ = sum(abs2, r₂₃)
+    n₃₁ = sum(abs2, r₃₁)
 
     # we want best angle so we put all norms on same footing
     # (cheaper to multiply by third nᵢ rather than divide by the two involved)

--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -174,8 +174,6 @@ end
 @inline all(a::StaticArray{<:Any, Bool}) = reduce(&, true, a)  # non-branching versions
 @inline any(a::StaticArray{<:Any, Bool}) = reduce(|, false, a) # (benchmarking needed)
 @inline mean(a::StaticArray) = sum(a) / length(a)
-@inline sumabs(a::StaticArray{<:Any, T}) where {T} = mapreduce(abs, +, zero(T), a)
-@inline sumabs2(a::StaticArray{<:Any, T}) where {T} = mapreduce(abs2, +, zero(T), a)
 @inline minimum(a::StaticArray) = reduce(min, a) # base has mapreduce(idenity, scalarmin, a)
 @inline maximum(a::StaticArray) = reduce(max, a) # base has mapreduce(idenity, scalarmax, a)
 @inline minimum(a::StaticArray, dim::Type{Val{D}}) where {D} = reducedim(min, a, dim)

--- a/test/eigen.jl
+++ b/test/eigen.jl
@@ -27,13 +27,13 @@
         @test vals::SVector ≈ vals_a
         @test eigvals(m) ≈ vals
         @test (vecs*diagm(vals)*vecs')::SMatrix ≈ m
-        
+
         (vals, vecs) = eig(Hermitian(m))
         @test vals::SVector ≈ vals_a
         @test eigvals(Hermitian(m)) ≈ vals
         @test eigvals(Hermitian(m, :L)) ≈ vals
         @test (vecs*diagm(vals)*vecs')::SMatrix ≈ m
-        
+
         m_d = randn(SVector{2}); m = diagm(m_d)
         (vals, vecs) = eig(Hermitian(m))
         @test vals::SVector ≈ sort(m_d)
@@ -60,10 +60,10 @@
         @test eigvals(Hermitian(m)) ≈ vals
         @test eigvals(Hermitian(m, :L)) ≈ vals
         @test (vecs*diagm(vals)*vecs')::SMatrix ≈ m
-       
+
         (vals, vecs) = eig(Symmetric(m, :L))
         @test vals::SVector ≈ vals_a
-        
+
         m_d = randn(SVector{3}); m = diagm(m_d)
         (vals, vecs) = eig(Hermitian(m))
         @test vals::SVector ≈ sort(m_d)
@@ -77,28 +77,30 @@
         # Rank 1
         v = randn(SVector{3,Float64})
         m = v*v'
+        vv = sum(abs2, v)
         vals, vecs = eig(m)::Tuple{SVector,SMatrix}
 
         @test vecs'*vecs ≈ eye(SMatrix{3,3,Float64})
-        @test vals ≈ SVector(0.0, 0.0, sumabs2(v))
+        @test vals ≈ SVector(0.0, 0.0, vv)
         @test eigvals(m) ≈ vals
 
         # Rank 2
         v2 = randn(SVector{3,Float64})
-        v2 -= dot(v,v2)*v/sumabs2(v)
+        v2 -= dot(v,v2)*v/(vv)
+        v2v2 = sum(abs2, v2)
         m += v2*v2'
         vals, vecs = eig(m)::Tuple{SVector,SMatrix}
 
         @test vecs'*vecs ≈ eye(SMatrix{3,3,Float64})
-        if sumabs2(v) < sumabs2(v2)
-            @test vals ≈ SVector(0.0, sumabs2(v), sumabs2(v2))
+        if vv < v2v2
+            @test vals ≈ SVector(0.0, vv, v2v2)
         else
-            @test vals ≈ SVector(0.0, sumabs2(v2), sumabs2(v))
+            @test vals ≈ SVector(0.0, v2v2, vv)
         end
         @test eigvals(m) ≈ vals
 
         # Degeneracy (2 large)
-        m = -99*(v*v')/sumabs2(v) + 100*eye(SMatrix{3,3,Float64})
+        m = -99*(v*v')/vv + 100*eye(SMatrix{3,3,Float64})
         vals, vecs = eig(m)::Tuple{SVector,SMatrix}
 
         @test vecs'*vecs ≈ eye(SMatrix{3,3,Float64})
@@ -106,7 +108,7 @@
         @test eigvals(m) ≈ vals
 
         # Degeneracy (2 small)
-        m = (v*v')/sumabs2(v) + 1e-2*eye(SMatrix{3,3,Float64})
+        m = (v*v')/vv + 1e-2*eye(SMatrix{3,3,Float64})
         vals, vecs = eig(m)::Tuple{SVector,SMatrix}
 
         @test vecs'*vecs ≈ eye(SMatrix{3,3,Float64})
@@ -141,7 +143,7 @@
         @test vecs*diagm(vals)*vecs' ≈ m
         @test eigvals(m) ≈ vals
     end
-    
+
     @testset "4×4" for i = 1:100
         m_a = randn(4,4)
         m_a = m_a*m_a'
@@ -159,7 +161,7 @@
         @test eigvals(Hermitian(m)) ≈ vals
         @test eigvals(Hermitian(m, :L)) ≈ vals
         @test (vecs*diagm(vals)*vecs')::SMatrix ≈ m
-       
+
         (vals, vecs) = eig(Symmetric(m, :L))
         @test vals::SVector ≈ vals_a
         m_d = randn(SVector{4}); m = diagm(m_d)


### PR DESCRIPTION
`sumabs` and `sumabs2` are deprecated. But since they are still exported from `base/deprecated.jl` nothing complained. The deprecation from base will work for this (if anyone relied on it):

```julia
julia> v = randn(SVector{3,Float64});

julia> sumabs2(v)
WARNING: sumabs2(x) is deprecated, use sum(abs2, x) instead.
Stacktrace:
 [1] depwarn(::String, ::Symbol) at ./deprecated.jl:64
 [2] sumabs2(::SVector{3,Float64}) at ./deprecated.jl:51
 [3] eval(::Module, ::Any) at ./boot.jl:235
 [4] eval_user_input(::Any, ::Base.REPL.REPLBackend) at ./REPL.jl:66
 [5] macro expansion at ./REPL.jl:97 [inlined]
 [6] (::Base.REPL.##1#2{Base.REPL.REPLBackend})() at ./event.jl:73
while loading no file, in expression starting on line 0
1.3744999105444324
```