### PR TITLE
Implement diag() with Val as second argument

### DIFF
--- a/src/StaticArrays.jl
+++ b/src/StaticArrays.jl
@@ -8,7 +8,7 @@ import Base: getindex, setindex!, size, similar, vec, show,
              length, convert, promote_op, promote_rule, map, map!, reduce, reducedim, mapreducedim,
              mapreduce, broadcast, broadcast!, conj, transpose, ctranspose,
              hcat, vcat, ones, zeros, eye, one, cross, vecdot, reshape, fill,
-             fill!, det, inv, eig, eigvals, expm, sqrtm, trace, vecnorm, norm, dot, diagm,
+             fill!, det, inv, eig, eigvals, expm, sqrtm, trace, vecnorm, norm, dot, diagm, diag,
              sum, diff, prod, count, any, all, minimum,
              maximum, extrema, mean, copy, rand, randn, randexp, rand!, randn!,
              randexp!, normalize, normalize!, read, read!, write

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -40,6 +40,12 @@
         @test @inferred(diagm(SVector(1,2))) === @SMatrix [1 0; 0 2]
     end
 
+    @testset "diag()" begin
+        @test @inferred(diag(@SMatrix([0 1; 2 3]))) === SVector(0, 3)
+        @test @inferred(diag(@SMatrix([0 1 2; 3 4 5]), Val{1})) === SVector(1, 5)
+        @test @inferred(diag(@SMatrix([0 1; 2 3; 4 5]), Val{-1})) === SVector(2, 5)
+    end
+
     @testset "one() and zero()" begin
         @test @inferred(one(SMatrix{2,2,Int})) === @SMatrix [1 0; 0 1]
         @test @inferred(one(SMatrix{2,2})) === @SMatrix [1.0 0.0; 0.0 1.0]


### PR DESCRIPTION
This PR implements a type-stable `diag` function for `SMatrix`.  Specifically, for `A::SMatrix`, 

- `diag(A)` returns the main diagonal of `A` as `SVector`.
- `diag(A, Val{k})` returns the `k`th diagonal of `A` as `SVector`.  (The contents of the result are the same as `diag(A, k)`, but the resulting type is `SVector` instead of `Vector`.)

The PR also adds simple tests on the newly implemented `diag`.