### PR TITLE
Test for fix to impure promote_tuple_eltype

### DIFF
--- a/src/util.jl
+++ b/src/util.jl
@@ -14,7 +14,7 @@ end
 
 # Base gives up on tuples for promote_eltype... (TODO can we improve Base?)
 @generated function promote_tuple_eltype{T <: Tuple}(::Union{T,Type{T}})
-    types = []
+    t = Union{}
     for i = 1:length(T.parameters)
         tmp = T.parameters[i]
         if tmp <: Vararg
@@ -27,7 +27,6 @@ end
         $t
     end
 end
-
 
 # The ::Tuple variants exist to make sure that anything that calls with a tuple
 # instead of a Tuple gets through to the constructor, so the user gets a nice

--- a/src/util.jl
+++ b/src/util.jl
@@ -14,19 +14,20 @@ end
 
 # Base gives up on tuples for promote_eltype... (TODO can we improve Base?)
 @generated function promote_tuple_eltype{T <: Tuple}(::Union{T,Type{T}})
-    t = Union{}
+    types = []
     for i = 1:length(T.parameters)
         tmp = T.parameters[i]
         if tmp <: Vararg
             tmp = tmp.parameters[1]
         end
-        t = promote_type(t, tmp)
+        push!(types, tmp)
     end
     return quote
         $(Expr(:meta,:pure))
-        $t
+        $(Expr(:call, :promote_type, types...))
     end
 end
+
 
 # The ::Tuple variants exist to make sure that anything that calls with a tuple
 # instead of a Tuple gets through to the constructor, so the user gets a nice

--- a/test/promotion.jl
+++ b/test/promotion.jl
@@ -1,0 +1,19 @@
+# Test for https://github.com/JuliaArrays/StaticArrays.jl/issues/228
+module PromotionTest
+    struct Foo
+        x::Int
+    end
+
+    struct Bar{S}
+        x::Int
+    end
+
+    Base.promote_rule(::Type{Bar{S1}}, ::Type{Bar{S2}}) where {S1, S2} = Foo
+end
+
+@testset "test for side-effects of promote_tuple_eltype" begin
+    b1 = PromotionTest.Bar{:x}(1)
+    b2 = PromotionTest.Bar{:y}(2)
+    @test @inferred(StaticArrays.promote_tuple_eltype((b1, b2))) == PromotionTest.Foo
+    @test promote_type(typeof(b1), typeof(b2)) == PromotionTest.Foo
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,6 +13,7 @@ using Base.Test
     include("SUnitRange.jl")
     include("SizedArray.jl")
     include("custom_types.jl")
+    include("promotion.jl")
 
     include("core.jl")
     include("abstractarray.jl")


### PR DESCRIPTION
~~This fixes #228 by changing `promote_tuple_eltype` and moving the call to `promote_type` into the generated expression instead of the generator body. The generated function now just exists to set up the call to promote_type rather than execute it.~~

~~I've also added a simple test for this issue. I *think* that this should work just as well as the old code, since everything still seems to infer just fine, but I could be wrong.~~

Edit: the fix came in with c089124 so this just adds a regression test