### PR TITLE
Integrate StaticArrays with julia 0.6 broadcast

### DIFF
--- a/test/Scalar.jl
+++ b/test/Scalar.jl
@@ -1,3 +1,5 @@
+using StaticArrays, Base.Test
+
 @testset "Scalar" begin
     @test Scalar(2) .* [1, 2, 3] == [2, 4, 6]
     @test Scalar([1 2; 3 4]) .+ [[1 1; 1 1], [2 2; 2 2]] == [[2 3; 4 5], [3 4; 5 6]]

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -146,10 +146,10 @@ end
 
     @testset "" begin
         # Issue #239 - broadcast with non-numeric element types
-        @eval @enum Axis X Y Z
-        @testinf (SVector(X,Y,Z) .== X) == SVector(true,false,false)
-        mv = MVector(X,Y,Z)
-        @testinf broadcast!(identity, mv, X) == MVector(X,X,X)
-        @test mv == SVector(X,X,X)
+        @eval @enum Axis aX aY aZ
+        @testinf (SVector(aX,aY,aZ) .== aX) == SVector(true,false,false)
+        mv = MVector(aX,aY,aZ)
+        @testinf broadcast!(identity, mv, aX) == MVector(aX,aX,aX)
+        @test mv == SVector(aX,aX,aX)
     end
 end

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -144,7 +144,7 @@ end
         end
     end
 
-    @testset "" begin
+    @testset "broadcast general scalars" begin
         # Issue #239 - broadcast with non-numeric element types
         @eval @enum Axis aX aY aZ
         @testinf (SVector(aX,aY,aZ) .== aX) == SVector(true,false,false)

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -1,3 +1,7 @@
+using StaticArrays, Base.Test
+
+include("testutil.jl")
+
 @testset "Broadcast sizes" begin
     @test @inferred(StaticArrays.broadcast_sizes(1, 1, 1)) === (Size(), Size(), Size())
     for t in (SVector{2}, MVector{2}, SMatrix{2, 2}, MMatrix{2, 2})
@@ -138,5 +142,14 @@ end
         let a = broadcast(Float32, SVector(3, 4, 5))
             @test eltype(a) == Float32
         end
+    end
+
+    @testset "" begin
+        # Issue #239 - broadcast with non-numeric element types
+        @eval @enum Axis X Y Z
+        @testinf (SVector(X,Y,Z) .== X) == SVector(true,false,false)
+        mv = MVector(X,Y,Z)
+        @testinf broadcast!(identity, mv, X) == MVector(X,X,X)
+        @test mv == SVector(X,X,X)
     end
 end


### PR DESCRIPTION
Generalize broadcast to follow the julia-0.6 rules for defining which
values are scalars.

I haven't bothered to implement `promote_containertype` for a combination of `Tuple` and `StaticArray` yet because it's a bit more work and it seems a little questionable that people would even use this combination rather than just using `StaticVector`.

Fixes #239 