### PR TITLE
Improve cholesky factorization

### DIFF
--- a/src/cholesky.jl
+++ b/src/cholesky.jl
@@ -1,54 +1,118 @@
-# Generic Cholesky decomposition for fixed-size matrices, mostly unrolled
-@inline function Base.chol(A::StaticMatrix)
+import Base: chol, cholfact, \
+
+@inline _chol(A::StaticMatrix{<:Any,<:Any,T}, ::Type{UpperTriangular}) where {T} = _chol(Size(A), A, UpperTriangular)
+@inline _chol(A::StaticMatrix{<:Any,<:Any,T}, ::Type{LowerTriangular}) where {T} = _chol(Size(A), A, LowerTriangular)
+
+@generated function _chol(::Size{s}, A::StaticMatrix{<:Any,<:Any,T}, ::Type{UpperTriangular}) where {s, T}
+    if s[1] != s[2]
+        error("matrix must be square")
+    end
+    n = s[1]
+    TX = promote_type(typeof(chol(one(T), UpperTriangular)), Float32)
+
+    X = [Symbol("X_$(i)_$(j)") for i = 1:n, j = 1:n]
+    init = [:($(X[i,j]) = A[$(sub2ind(s,i,j))]) for i = 1:n, j = 1:n]
+
+    code = quote end
+    for k = 1:n
+        ex = :($(X[k,k]))
+        for i = 1:k-1
+            ex = :($ex - $(X[i,k])'*$(X[i,k]))
+        end
+        push!(code.args, quote $(X[k,k]), info = _chol($ex, UpperTriangular) end)
+        push!(code.args, :(info == 0 || return UpperTriangular(similar_type(A, $TX)(tuple($(X...)))), info))
+        if k < n
+            push!(code.args, :(XkkInv = inv($(X[k,k])')))
+        end
+        for j = k + 1:n
+            ex = :($(X[k,j]))
+            for i = 1:k-1
+                ex = :($ex - $(X[i,k])'*$(X[i,j]))
+            end
+            push!(code.args, :($(X[k,j]) = XkkInv*$ex))
+        end
+    end
+
+    quote
+        @_inline_meta
+        @inbounds $(Expr(:block, init...))
+        @inbounds $code
+        @inbounds return UpperTriangular(similar_type(A, $TX)(tuple($(X...)))), convert(Base.LinAlg.BlasInt, 0)
+    end
+end
+
+@generated function _chol(::Size{s}, A::StaticMatrix{<:Any, <:Any, T}, ::Type{LowerTriangular}) where {s, T}
+    if s[1] != s[2]
+        error("matrix must be square")
+    end
+
+    n = s[1]
+    TX = promote_type(typeof(chol(one(T), LowerTriangular)), Float32)
+
+    X = [Symbol("X_$(i)_$(j)") for i = 1:n, j = 1:n]
+    init = [:($(X[i,j]) = A[$(sub2ind(s,i,j))]) for i = 1:n, j = 1:n]
+
+    code = quote end
+    for k = 1:n
+        ex = :($(X[k,k]))
+        for i = 1:k-1
+            ex = :($ex - $(X[k,i])*$(X[k,i])')
+        end
+        push!(code.args, quote $(X[k,k]), info = _chol($ex, LowerTriangular) end)
+        push!(code.args, :(info == 0 || return LowerTriangular(similar_type(A, $TX)(tuple($(X...)))), info))
+        if k < n
+            push!(code.args, :(XkkInv = inv($(X[k,k])')))
+        end
+        for j = 1:k-1
+            for i = k+1:n
+                push!(code.args, :($(X[i,k]) -= $(X[i,j])*$(X[k,j])'))
+            end
+        end
+        for i = k+1:n
+            push!(code.args, :($(X[i,k]) *= XkkInv))
+        end
+    end
+
+    quote
+        @_inline_meta
+        @inbounds $(Expr(:block, init...))
+        @inbounds $code
+        @inbounds return LowerTriangular(similar_type(A, $TX)(tuple($(X...)))), convert(Base.LinAlg.BlasInt, 0)
+    end
+end
+
+## Numbers
+_chol(x::Number, uplo) = Base.LinAlg._chol!(x, uplo)
+
+@inline function chol(A::Base.LinAlg.RealHermSymComplexHerm{<:Real,<:StaticMatrix})
+    C, info = _chol(Size(A), A.uplo == 'U' ? A.data : ctranspose(A.data), UpperTriangular)
+    Base.LinAlg.@assertposdef C info
+end
+
+@inline function chol(A::StaticMatrix)
     ishermitian(A) || Base.LinAlg.non_hermitian_error("chol")
-    _chol(Size(A), A)
+    return chol(Hermitian(A))
 end
 
-@inline function Base.chol(A::Base.LinAlg.RealHermSymComplexHerm{<:Real, <:StaticMatrix})
-    _chol(Size(A), A.data)
-end
-
-@generated function _chol(::Size{(1,1)}, A::StaticMatrix)
-    @assert size(A) == (1,1)
-    T = promote_type(typeof(sqrt(one(eltype(A)))), Float32)
-    newtype = similar_type(A,T)
-
-    quote
-        $(Expr(:meta, :inline))
-        ($newtype)((sqrt(A[1]), ))
+function cholfact(A::Base.LinAlg.RealHermSymComplexHerm{<:Real,<:StaticMatrix}, ::Type{Val{false}}=Val{false})
+    if A.uplo == 'U'
+        CU, info = _chol(Size(A), A.data, UpperTriangular)
+        Base.LinAlg.Cholesky(CU.data, 'U', info)
+    else
+        CL, info = _chol(Size(A), A.data, LowerTriangular)
+        Base.LinAlg.Cholesky(CL.data, 'L', info)
     end
 end
 
-@generated function _chol(::Size{(2,2)}, A::StaticMatrix)
-    @assert size(A) == (2,2)
-    T = promote_type(typeof(sqrt(one(eltype(A)))), Float32)
-    newtype = similar_type(A,T)
-
-    quote
-        $(Expr(:meta, :inline))
-        @inbounds a = sqrt(A[1])
-        @inbounds b = A[3] / a
-        @inbounds c = sqrt(A[4] - b'*b)
-        ($newtype)((a, $(zero(T)), b, c))
-    end
+@inline function cholfact(A::StaticMatrix, ::Type{Val{false}}=Val{false})
+    ishermitian(A) || Base.LinAlg.non_hermitian_error("cholfact")
+    cholfact(Hermitian(A), Val{false})
 end
 
-@generated function _chol(::Size{(3,3)}, A::StaticMatrix)
-    @assert size(A) == (3,3)
-    T = promote_type(typeof(sqrt(one(eltype(A)))), Float32)
-    newtype = similar_type(A,T)
-
-    quote
-        $(Expr(:meta, :inline))
-        @inbounds a11 = sqrt(A[1])
-        @inbounds a12 = A[4] / a11
-        @inbounds a22 = sqrt(A[5] - a12'*a12)
-        @inbounds a13 = A[7] / a11
-        @inbounds a23 = (A[8] - a12'*a13) / a22
-        @inbounds a33 = sqrt(A[9] - a13'*a13 - a23'*a23)
-        ($newtype)((a11, $(zero(T)), $(zero(T)), a12, a22, $(zero(T)), a13, a23, a33))
+function \(C::Base.LinAlg.Cholesky{<:Any,<:StaticMatrix}, B::StaticVecOrMat)
+    if C.uplo == 'L'
+        return LowerTriangular(C.factors)' \ (LowerTriangular(C.factors) \ B)
+    else
+        return UpperTriangular(C.factors) \ (UpperTriangular(C.factors)' \ B)
     end
 end
-
-# Otherwise default algorithm returning wrapped SizedArray
-@inline _chol(s::Size, A::StaticArray) = s(full(chol(Hermitian(Array(A)))))

--- a/test/chol.jl
+++ b/test/chol.jl
@@ -33,3 +33,51 @@
         @test chol(Hermitian(m)) ≈ chol(m_a)
     end
 end
+
+@testset "Cholesky decomposition" begin
+    @testset "eltype <: Real" begin
+        for n = (1, 2, 3, 4)
+            A = randn(n,n) |> t -> t't
+            @test chol(SMatrix{n,n}(A)) ≈ chol(A)
+            CU = cholfact(Symmetric(A))
+            SCU = cholfact(Symmetric(SMatrix{n,n}(A)))
+            @test SCU.uplo == CU.uplo
+            @test SCU.factors ≈ CU.factors
+            CL = cholfact(Symmetric(A, :L))
+            SCL = cholfact(Symmetric(SMatrix{n,n}(A), :L))
+            @test SCL.uplo == CL.uplo
+            @test SCL.factors ≈ CL.factors
+        end
+    end
+
+    @testset "eltype <: Complex" begin
+        for n = (1, 2, 3, 4)
+            A = complex.(randn(n,n), randn(n,n)) |> t -> t't
+            @test chol(SMatrix{n,n}(A)) ≈ chol(A)
+            CU = cholfact(Hermitian(A))
+            SCU = cholfact(Hermitian(SMatrix{n,n}(A)))
+            @test SCU.uplo == CU.uplo
+            @test SCU.factors ≈ CU.factors
+            CL = cholfact(Hermitian(A, :L))
+            SCL = cholfact(Hermitian(SMatrix{n,n}(A), :L))
+            @test SCL.uplo == CL.uplo
+            @test SCL.factors ≈ CL.factors
+        end
+    end
+
+    @testset "Throw if non-Hermitian" begin
+        R = randn(4,4)
+        C = complex.(R, R)
+        for A in (R, C)
+            @test_throws ArgumentError cholfact(A)
+            @test_throws ArgumentError chol(A)
+        end
+    end
+end
+
+@testset "Solve linear system" begin
+    A = @SMatrix [4. 12. -16.; 12. 37. -43.; -16. -43. 98.]
+    B = @SVector [0., 6., 39.]
+    C = cholfact(A)
+    @test @inferred(C \ B) === ones(SVector{3})
+end


### PR DESCRIPTION
This PR extends the `chol` to higher dimensions, adds a `cholfact` method and a `\` based on the triangular solvers in #222. Also, `chol` will now return an `UpperTriangular` fixing #194.

The `Cholesky` struct in Base changed in v0.7 so I've targeted this later version with this PR. I'm not sure how to get this working on v0.6 and v0.7 simultaneously.

I've kept the old tests for the time being (just to show that everything is consistent) but these should be removed when everything is ready to be merged.