### PR TITLE
Fix broadcast! with non-static arrays

### DIFF
--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -114,7 +114,9 @@ end
 ## broadcast! ##
 ################
 
-@inline function broadcast_c!(f, ::Type{StaticArray}, ::Type, dest, as...)
+# TODO: This signature could be relaxed to (::Any, ::Type{StaticArray}, ::Type, ...), though
+# we'd need to rework how _broadcast!() and broadcast_sizes() interact with normal AbstractArray.
+@inline function broadcast_c!(f, ::Type{StaticArray}, ::Type{StaticArray}, dest, as...)
     _broadcast!(f, Size(dest), dest, broadcast_sizes(as...), as...)
 end
 

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -128,6 +128,11 @@ end
         A = @MMatrix([1 0]); @test @inferred(broadcast!(+, A, A, 2)) == @MMatrix [3 2]
     end
 
+    @testset "broadcast! with mixtures of SArray and Array" begin
+        a = zeros(MVector{2}); @test @inferred(broadcast!(+, a, [1,2])) == [1,2]
+        a = zeros(MMatrix{2,3}); @test @inferred(broadcast!(+, a, [1,2])) == [1 1 1; 2 2 2]
+    end
+
     @testset "eltype after broadcast" begin
         # test cases issue #198
         let a = SVector{4, Number}(2, 2.0, 4//2, 2+0im)


### PR DESCRIPTION
I'm not sure I have time for a full fix right now, so here's a lazy one which at least addresses the bug by falling back to the Base implementation for mixtures of static and non-static arrays.

Fixes #249 