### PR TITLE
Add @boundscheck annotation to bounds check in convert method

### DIFF
--- a/src/convert.jl
+++ b/src/convert.jl
@@ -14,7 +14,7 @@
 end
 
 @inline function convert(::Type{SA}, a::AbstractArray) where {SA <: StaticArray}
-    if length(a) != length(SA)
+    @boundscheck if length(a) != length(SA)
         error("Dimension mismatch. Expected input array of length $(length(SA)), got length $(length(a))")
     end
 


### PR DESCRIPTION
Benchmark code:
```julia
using StaticArrays, BenchmarkTools
@benchmark convert(SMatrix{3, 3, Float64, 9}, x) setup = (x = rand(3, 3))
```
With `julia -O3 --check-bounds=no`, minimum benchmark time goes from  5.456 ns to 2.302 ns.
