### PR TITLE
Support Val{k} as second argument in diagm

### DIFF
--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -40,8 +40,8 @@ using StaticArrays, Base.Test
 
     @testset "diagm()" begin
         @test @inferred(diagm(SVector(1,2))) === @SMatrix [1 0; 0 2]
-        @test @inferred(diagm(SVector(1,2,3), Val{2})) == diagm([1,2,3], 2)
-        @test @inferred(diagm(SVector(1,2,3), Val{-2})) == diagm([1,2,3], -2)
+        @test @inferred(diagm(SVector(1,2,3), Val{2}))::SMatrix == diagm([1,2,3], 2)
+        @test @inferred(diagm(SVector(1,2,3), Val{-2}))::SMatrix == diagm([1,2,3], -2)
     end
 
     @testset "diag()" begin

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -40,6 +40,8 @@ using StaticArrays, Base.Test
 
     @testset "diagm()" begin
         @test @inferred(diagm(SVector(1,2))) === @SMatrix [1 0; 0 2]
+        @test @inferred(diagm(SVector(1,2,3), Val{2})) == diagm([1,2,3], 2)
+        @test @inferred(diagm(SVector(1,2,3), Val{-2})) == diagm([1,2,3], -2)
     end
 
     @testset "diag()" begin


### PR DESCRIPTION
This PR implements `diagm(::SVector, ::Type{Val{k}})`, which type-stably creates a matrix with a specified `k`th super-or sub-diagonal.  Previously there was only `diagm(::SVector)` without the second argument.