### PR TITLE
Remove pre from minimum version

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,1 @@
-julia 0.6.0-pre
+julia 0.6.0


### PR DESCRIPTION
CI no longer tests the pre-releases, so it should require v0.6 instead.