### PR TITLE
Fix several broadcast issues (fixes #197, #199, #200, #242)

### DIFF
--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -103,7 +103,7 @@ end
     end
 
     eltype_exprs = [t <: AbstractArray ? :($(eltype(t))) : :($t) for t ∈ a]
-    newtype_expr = :(Core.Inference.return_type(f, Tuple{$(eltype_exprs...)}))
+    newtype_expr = prod(newsize) > 0 ? :(Base.promote_op(f, $(eltype_exprs...))) : :(Union{})
 
     return quote
         @_inline_meta

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -103,7 +103,7 @@ end
     end
 
     eltype_exprs = [t <: AbstractArray ? :($(eltype(t))) : :($t) for t ∈ a]
-    newtype_expr = prod(newsize) > 0 ? :(Base.promote_op(f, $(eltype_exprs...))) : :(Union{})
+    newtype_expr = :(Core.Inference.return_type(f, Tuple{$(eltype_exprs...)}))
 
     return quote
         @_inline_meta

--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -235,7 +235,7 @@ end
 @generated function _diff(::Size{S}, a::StaticArray, ::Type{Val{D}}) where {S,D}
     N = length(S)
     Snew = ([n==D ? S[n]-1 : S[n] for n = 1:N]...)
-    T = Core.Inference.return_type(-, Tuple{eltype(a),eltype(a)})
+    T = typeof(one(eltype(a)) - one(eltype(a)))
 
     exprs = Array{Expr}(Snew)
     itr = [1:n for n = Snew]

--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -17,7 +17,7 @@ end
         exprs[i] = :(f($(tmp...)))
     end
     eltypes = [eltype(a[j]) for j ∈ 1:length(a)] # presumably, `eltype` is "hyperpure"?
-    newT = :(Core.Inference.return_type(f, Tuple{$(eltypes...)}))
+    newT = :(Base.promote_op(f, $(eltypes...)))
     return quote
         @_inline_meta
         @inbounds return similar_type(typeof(_first(a...)), $newT, Size(S))(tuple($(exprs...)))

--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -17,7 +17,7 @@ end
         exprs[i] = :(f($(tmp...)))
     end
     eltypes = [eltype(a[j]) for j ∈ 1:length(a)] # presumably, `eltype` is "hyperpure"?
-    newT = :(Base.promote_op(f, $(eltypes...)))
+    newT = :(Core.Inference.return_type(f, Tuple{$(eltypes...)}))
     return quote
         @_inline_meta
         @inbounds return similar_type(typeof(_first(a...)), $newT, Size(S))(tuple($(exprs...)))
@@ -105,7 +105,7 @@ end
     N = length(S)
     Snew = ([n==D ? 1 : S[n] for n = 1:N]...)
     T0 = eltype(a)
-    T = :((T1 = Base.promote_op(f, $T0); Base.promote_op(op, T1, T1)))
+    T = :((T1 = Core.Inference.return_type(f, Tuple{$T0}); Core.Inference.return_type(op, Tuple{T1,T1})))
 
     exprs = Array{Expr}(Snew)
     itr = [1:n for n ∈ Snew]
@@ -235,7 +235,7 @@ end
 @generated function _diff(::Size{S}, a::StaticArray, ::Type{Val{D}}) where {S,D}
     N = length(S)
     Snew = ([n==D ? S[n]-1 : S[n] for n = 1:N]...)
-    T = Base.promote_op(-, eltype(a), eltype(a))
+    T = Core.Inference.return_type(-, Tuple{eltype(a),eltype(a)})
 
     exprs = Array{Expr}(Snew)
     itr = [1:n for n = Snew]

--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -17,7 +17,7 @@ end
         exprs[i] = :(f($(tmp...)))
     end
     eltypes = [eltype(a[j]) for j ∈ 1:length(a)] # presumably, `eltype` is "hyperpure"?
-    newT = :(Base.promote_op(f, $(eltypes...)))
+    newT = :(Core.Inference.return_type(f, Tuple{$(eltypes...)}))
     return quote
         @_inline_meta
         @inbounds return similar_type(typeof(_first(a...)), $newT, Size(S))(tuple($(exprs...)))

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -45,16 +45,16 @@ end
     @testset "2x2 StaticMatrix with 1x2 StaticMatrix" begin
         m1 = @SMatrix [1 2; 3 4]
         m2 = @SMatrix [1 4]
-        @test_broken @inferred(broadcast(+, m1, m2)) === @SMatrix [2 6; 4 8] #197
-        @test_broken @inferred(m1 .+ m2) === @SMatrix [2 6; 4 8] #197
+        @test @inferred(broadcast(+, m1, m2)) === @SMatrix [2 6; 4 8] #197
+        @test @inferred(m1 .+ m2) === @SMatrix [2 6; 4 8] #197
         @test @inferred(m2 .+ m1) === @SMatrix [2 6; 4 8]
-        @test_broken @inferred(m1 .* m2) === @SMatrix [1 8; 3 16] #197
+        @test @inferred(m1 .* m2) === @SMatrix [1 8; 3 16] #197
         @test @inferred(m2 .* m1) === @SMatrix [1 8; 3 16]
-        @test_broken @inferred(m1 ./ m2) === @SMatrix [1 1/2; 3 1] #197
+        @test @inferred(m1 ./ m2) === @SMatrix [1 1/2; 3 1] #197
         @test @inferred(m2 ./ m1) === @SMatrix [1 2; 1/3 1]
-        @test_broken @inferred(m1 .- m2) === @SMatrix [0 -2; 2 0] #197
+        @test @inferred(m1 .- m2) === @SMatrix [0 -2; 2 0] #197
         @test @inferred(m2 .- m1) === @SMatrix [0 2; -2 0]
-        @test_broken @inferred(m1 .^ m2) === @SMatrix [1 16; 1 256] #197
+        @test @inferred(m1 .^ m2) === @SMatrix [1 16; 3 256] #197
     end
 
     @testset "1x2 StaticMatrix with StaticVector" begin
@@ -62,15 +62,15 @@ end
         v = SVector(1, 4)
         @test @inferred(broadcast(+, m, v)) === @SMatrix [2 3; 5 6]
         @test @inferred(m .+ v) === @SMatrix [2 3; 5 6]
-        @test_broken @inferred(v .+ m) === @SMatrix [2 3; 5 6] #197
+        @test @inferred(v .+ m) === @SMatrix [2 3; 5 6] #197
         @test @inferred(m .* v) === @SMatrix [1 2; 4 8]
-        @test_broken @inferred(v .* m) === @SMatrix [1 2; 4 8] #197
+        @test @inferred(v .* m) === @SMatrix [1 2; 4 8] #197
         @test @inferred(m ./ v) === @SMatrix [1 2; 1/4 1/2]
-        @test_broken @inferred(v ./ m) === @SMatrix [1 1/2; 4 2] #197
+        @test @inferred(v ./ m) === @SMatrix [1 1/2; 4 2] #197
         @test @inferred(m .- v) === @SMatrix [0 1; -3 -2]
-        @test_broken @inferred(v .- m) === @SMatrix [0 -1; 3 2] #197
+        @test @inferred(v .- m) === @SMatrix [0 -1; 3 2] #197
         @test @inferred(m .^ v) === @SMatrix [1 2; 1 16]
-        @test_broken @inferred(v .^ m) === @SMatrix [1 1; 4 16] #197
+        @test @inferred(v .^ m) === @SMatrix [1 1; 4 16] #197
     end
 
     @testset "StaticVector with StaticVector" begin
@@ -89,9 +89,9 @@ end
         @test @inferred(v2 .^ v1) === SVector(1, 16)
         # test case issue #199
         @test @inferred(SVector(1) .+ SVector()) === SVector()
-        @test_broken @inferred(SVector() .+ SVector(1)) === SVector()
+        @test @inferred(SVector() .+ SVector(1)) === SVector()
         # test case issue #200
-        @test_broken @inferred(v1 .+ v2') === @SMatrix [2 5; 3 5]
+        @test @inferred(v1 .+ v2') === @SMatrix [2 5; 3 6]
     end
 
     @testset "StaticVector with Scalar" begin

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -148,10 +148,10 @@ end
             @test eltype(a / 2) == Real
         end
         let a = SVector{3, Real}(2, 2.0, 4//2)
-            @test eltype(a + 2.0) == Real
-            @test eltype(a - 2.0) == Real
-            @test eltype(a * 2.0) == Real
-            @test eltype(a / 2.0) == Real
+            @test_broken eltype(a + 2.0) == Float64
+            @test_broken eltype(a - 2.0) == Float64
+            @test_broken eltype(a * 2.0) == Float64
+            @test_broken eltype(a / 2.0) == Float64
         end
         let a = broadcast(Float32, SVector(3, 4, 5))
             @test eltype(a) == Float32

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -43,34 +43,36 @@ end
     end
 
     @testset "2x2 StaticMatrix with 1x2 StaticMatrix" begin
+        # Issues #197, #242: broadcast between SArray and row-like SMatrix
         m1 = @SMatrix [1 2; 3 4]
         m2 = @SMatrix [1 4]
-        @test @inferred(broadcast(+, m1, m2)) === @SMatrix [2 6; 4 8] #197
-        @test @inferred(m1 .+ m2) === @SMatrix [2 6; 4 8] #197
+        @test @inferred(broadcast(+, m1, m2)) === @SMatrix [2 6; 4 8]
+        @test @inferred(m1 .+ m2) === @SMatrix [2 6; 4 8]
         @test @inferred(m2 .+ m1) === @SMatrix [2 6; 4 8]
-        @test @inferred(m1 .* m2) === @SMatrix [1 8; 3 16] #197
+        @test @inferred(m1 .* m2) === @SMatrix [1 8; 3 16]
         @test @inferred(m2 .* m1) === @SMatrix [1 8; 3 16]
-        @test @inferred(m1 ./ m2) === @SMatrix [1 1/2; 3 1] #197
+        @test @inferred(m1 ./ m2) === @SMatrix [1 1/2; 3 1]
         @test @inferred(m2 ./ m1) === @SMatrix [1 2; 1/3 1]
-        @test @inferred(m1 .- m2) === @SMatrix [0 -2; 2 0] #197
+        @test @inferred(m1 .- m2) === @SMatrix [0 -2; 2 0]
         @test @inferred(m2 .- m1) === @SMatrix [0 2; -2 0]
-        @test @inferred(m1 .^ m2) === @SMatrix [1 16; 3 256] #197
+        @test @inferred(m1 .^ m2) === @SMatrix [1 16; 3 256]
     end
 
     @testset "1x2 StaticMatrix with StaticVector" begin
+        # Issues #197, #242: broadcast between SVector and row-like SMatrix
         m = @SMatrix [1 2]
         v = SVector(1, 4)
         @test @inferred(broadcast(+, m, v)) === @SMatrix [2 3; 5 6]
         @test @inferred(m .+ v) === @SMatrix [2 3; 5 6]
-        @test @inferred(v .+ m) === @SMatrix [2 3; 5 6] #197
+        @test @inferred(v .+ m) === @SMatrix [2 3; 5 6]
         @test @inferred(m .* v) === @SMatrix [1 2; 4 8]
-        @test @inferred(v .* m) === @SMatrix [1 2; 4 8] #197
+        @test @inferred(v .* m) === @SMatrix [1 2; 4 8]
         @test @inferred(m ./ v) === @SMatrix [1 2; 1/4 1/2]
-        @test @inferred(v ./ m) === @SMatrix [1 1/2; 4 2] #197
+        @test @inferred(v ./ m) === @SMatrix [1 1/2; 4 2]
         @test @inferred(m .- v) === @SMatrix [0 1; -3 -2]
-        @test @inferred(v .- m) === @SMatrix [0 -1; 3 2] #197
+        @test @inferred(v .- m) === @SMatrix [0 -1; 3 2]
         @test @inferred(m .^ v) === @SMatrix [1 2; 1 16]
-        @test @inferred(v .^ m) === @SMatrix [1 1; 4 16] #197
+        @test @inferred(v .^ m) === @SMatrix [1 1; 4 16]
     end
 
     @testset "StaticVector with StaticVector" begin
@@ -87,10 +89,10 @@ end
         @test @inferred(v2 .- v1) === SVector(0, 2)
         @test @inferred(v1 .^ v2) === SVector(1, 16)
         @test @inferred(v2 .^ v1) === SVector(1, 16)
-        # test case issue #199
+        # Issue #199: broadcast with empty SArray
         @test @inferred(SVector(1) .+ SVector()) === SVector()
         @test @inferred(SVector() .+ SVector(1)) === SVector()
-        # test case issue #200
+        # Issue #200: broadcast with RowVector
         @test @inferred(v1 .+ v2') === @SMatrix [2 5; 3 6]
     end
 

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -136,16 +136,16 @@ end
     @testset "eltype after broadcast" begin
         # test cases issue #198
         let a = SVector{4, Number}(2, 2.0, 4//2, 2+0im)
-            @test eltype(a + 2) == Number
-            @test eltype(a - 2) == Number
-            @test eltype(a * 2) == Number
-            @test eltype(a / 2) == Number
+            @test_broken eltype(a + 2) == Number
+            @test_broken eltype(a - 2) == Number
+            @test_broken eltype(a * 2) == Number
+            @test_broken eltype(a / 2) == Number
         end
         let a = SVector{3, Real}(2, 2.0, 4//2)
-            @test eltype(a + 2) == Real
-            @test eltype(a - 2) == Real
-            @test eltype(a * 2) == Real
-            @test eltype(a / 2) == Real
+            @test_broken eltype(a + 2) == Real
+            @test_broken eltype(a - 2) == Real
+            @test_broken eltype(a * 2) == Real
+            @test_broken eltype(a / 2) == Real
         end
         let a = SVector{3, Real}(2, 2.0, 4//2)
             @test_broken eltype(a + 2.0) == Float64

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -136,22 +136,22 @@ end
     @testset "eltype after broadcast" begin
         # test cases issue #198
         let a = SVector{4, Number}(2, 2.0, 4//2, 2+0im)
-            @test_broken eltype(a + 2) == Number
-            @test_broken eltype(a - 2) == Number
-            @test_broken eltype(a * 2) == Number
-            @test_broken eltype(a / 2) == Number
+            @test eltype(a + 2) == Number
+            @test eltype(a - 2) == Number
+            @test eltype(a * 2) == Number
+            @test eltype(a / 2) == Number
         end
         let a = SVector{3, Real}(2, 2.0, 4//2)
-            @test_broken eltype(a + 2) == Real
-            @test_broken eltype(a - 2) == Real
-            @test_broken eltype(a * 2) == Real
-            @test_broken eltype(a / 2) == Real
+            @test eltype(a + 2) == Real
+            @test eltype(a - 2) == Real
+            @test eltype(a * 2) == Real
+            @test eltype(a / 2) == Real
         end
         let a = SVector{3, Real}(2, 2.0, 4//2)
-            @test_broken eltype(a + 2.0) == Float64
-            @test_broken eltype(a - 2.0) == Float64
-            @test_broken eltype(a * 2.0) == Float64
-            @test_broken eltype(a / 2.0) == Float64
+            @test eltype(a + 2.0) == Real
+            @test eltype(a - 2.0) == Real
+            @test eltype(a * 2.0) == Real
+            @test eltype(a / 2.0) == Real
         end
         let a = broadcast(Float32, SVector(3, 4, 5))
             @test eltype(a) == Float32


### PR DESCRIPTION
This PR fixes several issues raised for `broadcast` on `SArray`.  Specifically, 
- it broadcasts properly between `SArray` and `RowVec{<:Any,SVector}` to generate an `Sarray` (fixing #197, #200, #242), and
- it also produces a result consistent with `Base`'s for zero-length `SArary` (fixing #199).
- Additionally, it replaces `Base.promote_op` with `Core.Inference.returnt_type`, because the former infers a wrong return type of an operation when the input arguments of the operation are abstract (see https://discourse.julialang.org/t/alternatives-to-base-promote-op-op-type-for-op-type/5289/6).