### PR TITLE
Specialise chol for SDiagonal and support static block matrices

### DIFF
--- a/src/SDiagonal.jl
+++ b/src/SDiagonal.jl
@@ -82,10 +82,16 @@ function logdet(D::SDiagonal{N,T}) where {N,T<:Complex} #Make sure branch cut is
 end
 
 eye(::Type{SDiagonal{N,T}}) where {N,T} = SDiagonal(ones(SVector{N,T}))
+one(::Type{SDiagonal{N,T}}) where {N,T} = SDiagonal(ones(SVector{N,T}))
+one(::SDiagonal{N,T}) where {N,T} = SDiagonal(ones(SVector{N,T}))
+Base.zero(::SDiagonal{N,T}) where {N,T} = SDiagonal(zeros(SVector{N,T}))
 
 expm(D::SDiagonal) = SDiagonal(exp.(D.diag))
 logm(D::SDiagonal) = SDiagonal(log.(D.diag))
 sqrtm(D::SDiagonal) = SDiagonal(sqrt.(D.diag))
+Base.chol(D::SDiagonal) = SDiagonal(Base.chol.(D.diag))
+Base.LinAlg._chol!(D::SDiagonal, ::Type{UpperTriangular}) = chol(D)
+
 
 \(D::SDiagonal, B::StaticMatrix) = scalem(1 ./ D.diag, B)
 /(B::StaticMatrix, D::SDiagonal) = scalem(1 ./ D.diag, B)

--- a/src/cholesky.jl
+++ b/src/cholesky.jl
@@ -7,6 +7,8 @@ end
 @inline function Base.chol(A::Base.LinAlg.RealHermSymComplexHerm{<:Real, <:StaticMatrix})
     _chol(Size(A), A.data)
 end
+@inline Base.LinAlg._chol!(A::StaticMatrix, ::Type{UpperTriangular}) = chol(A)
+
 
 @generated function _chol(::Size{(1,1)}, A::StaticMatrix)
     @assert size(A) == (1,1)

--- a/test/SDiagonal.jl
+++ b/test/SDiagonal.jl
@@ -23,12 +23,9 @@
         @test StaticArrays.scalem(@SMatrix([1 1 1;1 1 1; 1 1 1]), @SVector [1,2,3]) === @SArray [1 2 3; 1 2 3; 1 2 3]
         @test StaticArrays.scalem(@SVector([1,2,3]),@SMatrix [1 1 1;1 1 1; 1 1 1])' === @SArray [1 2 3; 1 2 3; 1 2 3]
     
-        m = SDiagonal(@SVector [11, 12, 13, 14])
+        m = SDiagonal(@SVector [11, 12, 13, 14])  
         
-    
-        
-        @test diag(m) === m.diag
-        
+        @test diag(m) === m.diag 
      
         m2 = diagm([11, 12, 13, 14])
      
@@ -39,8 +36,11 @@
         @test logm(m) == logm(m2)
         @test expm(m) == expm(m2)
         @test sqrtm(m) == sqrtm(m2)
-     
+        @test chol(m) == chol(m2)
         
+        @test chol(reshape([1.0*m, 0.0*m, 0.0*m, 1.0*m], 2, 2)) == 
+            reshape([chol(1.0*m), 0.0*m, 0.0*m, chol(1.0*m)], 2, 2)
+
         @test isimmutable(m) == true
 
         @test m[1,1] === 11

--- a/test/chol.jl
+++ b/test/chol.jl
@@ -32,4 +32,11 @@
         @test chol(m) ≈ chol(m_a)
         @test chol(Hermitian(m)) ≈ chol(m_a)
     end
+    @testset "static blockmatrix" for i = 1:10
+        m_a = randn(3,3)
+        m_a = m_a*m_a'
+        m = SMatrix{3,3}(m_a)
+        @test chol(reshape([m, 0m, 0m, m], 2, 2)) == 
+            reshape([chol(m), 0m, 0m, chol(m)], 2, 2)
+    end
 end


### PR DESCRIPTION
The second part is done by hooking into `Base.LinAlg._chol!`, which is imho the right way to do it but makes it necessary to keep track on base in this regard.