### PR TITLE
Fix `map` for Julia v0.7

### DIFF
--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -6,8 +6,14 @@
 
 # The following type signature for map() matches any list of AbstractArrays,
 # provided at least one is a static array.
-@inline function map(f, as::Union{SA,AbstractArray}...) where {SA<:StaticArray}
-    _map(f, same_size(as...), as...)
+if VERSION > v"0.7.0-"
+    @inline function map(f, as::Union{SA,AbstractArray}...) where {SA<:StaticArray}
+        _map(f, same_size(as...), as...)
+    end
+else
+    @inline function map(f, as::StaticArray)
+        _map(f, same_size(as...), as...)
+    end
 end
 
 @generated function _map(f, ::Size{S}, a::AbstractArray...) where {S}

--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -6,7 +6,7 @@
 
 # The following type signature for map() matches any list of AbstractArrays,
 # provided at least one is a static array.
-if VERSION > v"0.7.0-"
+if VERSION < v"0.7.0-"
     @inline function map(f, as::Union{SA,AbstractArray}...) where {SA<:StaticArray}
         _map(f, same_size(as...), as...)
     end

--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -11,8 +11,8 @@ if VERSION < v"0.7.0-"
         _map(f, same_size(as...), as...)
     end
 else
-    @inline function map(f, as::StaticArray)
-        _map(f, same_size(as...), as...)
+    @inline function map(f, a1::StaticArray, as::AbstractArray...)
+        _map(f, same_size(a1, as...), a1, as...)
     end
 end
 


### PR DESCRIPTION
This works around a redefinition of `map` for all `AbstractArray` that occurs on v0.7 but not v0.6.

The newly-missed optimization opportunities are probably pretty rare in practice.