### PR TITLE
`rand!` for `@SArray`s copies gracefully.

### DIFF
--- a/src/arraymath.jl
+++ b/src/arraymath.jl
@@ -111,6 +111,7 @@ end
     end
 end
 
+@inline rand!(rng::AbstractRNG, ::SA) where {SA <: SArray} = rand(rng, SA)
 @inline rand!(rng::AbstractRNG, a::SA) where {SA <: StaticArray} = _rand!(rng, Size(SA), a)
 @generated function _rand!(rng::AbstractRNG, ::Size{s}, a::SA) where {s, SA <: StaticArray}
     exprs = [:(a[$i] = rand(rng, eltype(SA))) for i = 1:prod(s)]
@@ -124,7 +125,10 @@ end
 # ambiguity with AbstractRNG and non-Float64... possibly an optimized form in Base?
 @inline rand!(rng::MersenneTwister, a::SA) where {SA <: StaticArray{<:Any, Float64}} = _rand!(rng, Size(SA), a)
 @inline rand!(rng::MersenneTwister, a::SA) where {SA <: StaticArray{<:Tuple, Float64, <:Any}} = _rand!(rng, Size(SA), a)
+@inline rand!(rng::MersenneTwister, a::SA) where {SA <: SArray{<:Tuple,Float64}} = _rand(rng, Size(SA), SA)
 
+
+@inline randn!(rng::AbstractRNG, ::SA) where {SA <: SArray} = randn(rng, SA)
 @inline randn!(rng::AbstractRNG, a::SA) where {SA <: StaticArray} = _randn!(rng, Size(SA), a)
 @generated function _randn!(rng::AbstractRNG, ::Size{s}, a::SA) where {s, SA <: StaticArray}
     exprs = [:(a[$i] = randn(rng, eltype(SA))) for i = 1:prod(s)]

--- a/test/arraymath.jl
+++ b/test/arraymath.jl
@@ -54,5 +54,17 @@
         rand!(m, 1:2)
         check = ((m .>= 1) .& (m .<= 2))
         @test all(check)
+
+        m = @SMatrix [0. 0.; 0. 0.]
+        m2 = rand!(m)
+        check = ((m2 .< 1.) .& (m2 .> 0.))
+        @test all(check)
+    end
+
+    @testset "randn!()" begin # smoke test
+        m = @SMatrix [0. 0.; 0. 0.]
+        m2 = randn!(m)
+        @test typeof(m2) == typeof(m)
+        @test m2 != m     
     end
 end


### PR DESCRIPTION
This is a possible way to alleviate the change in #297, using our earlier conclusion that `!` says a methods may modify if it feels like, but does not have to.