### PR TITLE
Speed up conversion to StaticArray

### DIFF
--- a/src/convert.jl
+++ b/src/convert.jl
@@ -13,9 +13,13 @@
     unroll_tuple(a, Length(a))
 end
 
+@noinline function dimension_mismatch_fail(SA::Type, a::AbstractArray)
+    error("Dimension mismatch. Expected input array of length $(length(SA)), got length $(length(a))")
+end
+
 @inline function convert(::Type{SA}, a::AbstractArray) where {SA <: StaticArray}
     @boundscheck if length(a) != length(SA)
-        error("Dimension mismatch. Expected input array of length $(length(SA)), got length $(length(a))")
+        dimension_mismatch_fail(SA, a)
     end
 
     return SA(unroll_tuple(a, Length(SA)))


### PR DESCRIPTION
Use `@noinline` trick (see e.g. https://github.com/JuliaLang/julia/pull/23088#issuecomment-320279238) to speed up `convert(::Type{SA}, a::AbstractArray)` when bounds checks are turned on.

Benchmark:
```julia
using StaticArrays, BenchmarkTools
@benchmark SMatrix{4, 4}(a) setup = a = rand(4, 4)
```

On master:
```
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     14.114 ns (0.00% GC)
  median time:      14.392 ns (0.00% GC)
  mean time:        14.547 ns (0.00% GC)
  maximum time:     43.770 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     998
```
On this branch:
```
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     11.982 ns (0.00% GC)
  median time:      12.057 ns (0.00% GC)
  mean time:        12.222 ns (0.00% GC)
  maximum time:     37.088 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     999
```