### PR TITLE
Anonymous FieldVector macros

### DIFF
--- a/src/FieldVector.jl
+++ b/src/FieldVector.jl
@@ -26,3 +26,73 @@ abstract type FieldVector{N, T} <: StaticVector{N, T} end
 Base.cconvert(::Type{<:Ptr}, v::FieldVector) = Base.RefValue(v)
 Base.unsafe_convert(::Type{Ptr{T}}, m::Base.RefValue{FV}) where {N,T,FV<:FieldVector{N,T}} =
     Ptr{T}(Base.unsafe_convert(Ptr{FV}, m))
+
+# Anonymous FieldVector Macros
+
+"""
+    @FVector Type Names
+    @FVector Type Names Values
+
+Creates an anonymous immutable `FieldVector` with names determined from the `Names`
+vector and values determined from the `Values` vector (if no values are provided,
+it defaults to not setting the values like `similar`). All of the values are converted
+to the type of the `Type` input.
+
+For example:
+
+    a = @FVector Float64 [a,b,c]
+    b = @FVector Float64 [a,b,c] [1,2,3]
+"""
+macro FVector(T,_names,vals=nothing)
+    names = Symbol.(_names.args)
+    type_name = gensym(:FVector)
+    construction_call = vals==nothing ?
+    quote
+        ($(type_name))()
+    end : quote
+        ($(type_name))($(vals)...)
+    end
+
+    quote
+        struct $(type_name) <: FieldVector{$(length(names)),$T}
+            $((:($n::$(T)) for n in names)...)
+            $(type_name)() = new()
+            $(type_name)($((:($n) for n in names)...)) = new($((:($n) for n in names)...))
+        end
+        $(esc(construction_call))
+    end
+end
+
+"""
+    @MFVector Type Names
+    @MFVector Type Names Values
+
+Creates an anonymous immutable `FieldVector` with names determined from the `Names`
+vector and values determined from the `Values` vector (if no values are provided,
+it defaults to not setting the values like `similar`). All of the values are converted
+to the type of the `Type` input.
+
+For example:
+
+    a = @MFVector Float64 [a,b,c]
+    b = @MFVector Float64 [a,b,c] [1,2,3]
+"""
+macro MFVector(T,_names,vals=nothing)
+    names = Symbol.(_names.args)
+    type_name = gensym(:MFVector)
+    construction_call = vals==nothing ?
+    quote
+        ($(type_name))()
+    end : quote
+        ($(type_name))($(vals)...)
+    end
+
+    quote
+        mutable struct $(type_name) <: FieldVector{$(length(names)),$T}
+            $((:($n::$(T)) for n in names)...)
+            $(type_name)() = new()
+            $(type_name)($((:($n) for n in names)...)) = new($((:($n) for n in names)...))
+        end
+        $(esc(construction_call))
+    end
+end

--- a/src/StaticArrays.jl
+++ b/src/StaticArrays.jl
@@ -29,6 +29,7 @@ export Size, Length
 
 export @SVector, @SMatrix, @SArray
 export @MVector, @MMatrix, @MArray
+export @FVector, @MFVector
 
 export similar_type
 export push, pop, shift, unshift, insert, deleteat, setindex

--- a/test/anonymous_FVector.jl
+++ b/test/anonymous_FVector.jl
@@ -1,0 +1,16 @@
+using StaticArrays
+using Base.Test
+
+a = @FVector Float64 [a,b,c]
+b = @FVector Float64 [a,b,c] [1,2,3]
+
+c = @MFVector Float64 [a,b,c]
+d = @MFVector Float64 [a,b,c] [1,2,3]
+
+@test_throws ErrorException fill!(a,1)
+@test typeof(b) <: FieldVector{3,Float64}
+b.+b
+c.=2d
+@test c == [2,4,6]
+@test typeof(c) <: FieldVector{3,Float64}
+c.+d


### PR DESCRIPTION
Allows the user to define `FieldVector`s in a much simplified syntax:

```julia
b = @FVector Float64 [a,b,c] [1,2,3]
d = @MFVector Float64 [a,b,c] [1,2,3]
```

`b` is mutable and `d` is not. Allows for an uninitialized version as well.