### PR TITLE
WIP: allow block matrix inversion

### DIFF
--- a/src/inv.jl
+++ b/src/inv.jl
@@ -9,7 +9,7 @@ end
 
 @inline function _inv(::Size{(2,2)}, A)
     newtype = similar_type(A)
-    idet = 1/det(A)
+    idet = inv(det(A))
     @inbounds return newtype((A[4]*idet, -(A[2]*idet), -(A[3]*idet), A[1]*idet))
 end
 
@@ -31,7 +31,7 @@ end
 end
 
 @inline function _inv(::Size{(4,4)}, A)
-    idet = 1/det(A)
+    idet = inv(det(A))
     B =  @SMatrix [
         (A[2,3]*A[3,4]*A[4,2] - A[2,4]*A[3,3]*A[4,2] + A[2,4]*A[3,2]*A[4,3] - A[2,2]*A[3,4]*A[4,3] - A[2,3]*A[3,2]*A[4,4] + A[2,2]*A[3,3]*A[4,4]) * idet
         (A[2,4]*A[3,3]*A[4,1] - A[2,3]*A[3,4]*A[4,1] - A[2,4]*A[3,1]*A[4,3] + A[2,1]*A[3,4]*A[4,3] + A[2,3]*A[3,1]*A[4,4] - A[2,1]*A[3,3]*A[4,4]) * idet


### PR DESCRIPTION
This allows inverse to work if the entries of the SMatrix are themselves matrix-like, and therefore more naturally have inv(A) defined rather than 1/A. 

I'm not totally sure there's anything in Base for which this actually works, but I think its a pretty reasonable thing to have (I have some cases in my code, e.g.). Its pretty easy to create an example type for which this matters from Base.Diagonal if you just give it, 

```
import Base: one, zero
one(::Type{Diagonal{T}}) where {T} = Diagonal(Vector{T}(0))
zero(::Type{Diagonal{T}}) where {T} = Diagonal(Vector{T}(0))
```

then the following works after this PR (but otherwise did not since https://github.com/JuliaArrays/StaticArrays.jl/commit/3fbb8547b8e64604fbc005e13132b4a275ba2477):

```
julia> inv(@SMatrix [Diagonal([2.]) Diagonal([0.]); Diagonal([0.]) Diagonal([2.])])
2×2 StaticArrays.SArray{Tuple{2,2},Diagonal{Float64},2,4}:
 [0.5]   [-0.0]
 [-0.0]  [0.5] 
```

