### PR TITLE
Remove final explicit uses of Inference.return_type

### DIFF
--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -102,12 +102,10 @@ end
         end
     end
 
-    eltype_exprs = [t <: AbstractArray ? :($(eltype(t))) : :($t) for t ∈ a]
-    newtype_expr = :(Core.Inference.return_type(f, Tuple{$(eltype_exprs...)}))
-
     return quote
         @_inline_meta
-        @inbounds return similar_type($first_staticarray, $newtype_expr, Size($newsize))(tuple($(exprs...)))
+        elements = tuple($(exprs...))
+        @inbounds return similar_type($first_staticarray, eltype(elements), Size($newsize))(elements)
     end
 end
 

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -105,7 +105,7 @@ end
     return quote
         @_inline_meta
         elements = tuple($(exprs...))
-        @inbounds return similar_type($first_staticarray, eltype(elements), Size($newsize))(elements)
+        @inbounds return similar_type($first_staticarray, promote_tuple_eltype(elements), Size($newsize))(elements)
     end
 end
 

--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -25,7 +25,7 @@ end
     return quote
         @_inline_meta
         elements = tuple($(exprs...))
-        @inbounds return similar_type(typeof(_first(a...)), eltype(elements), Size(S))(elements)
+        @inbounds return similar_type(typeof(_first(a...)), promote_tuple_eltype(elements), Size(S))(elements)
     end
 end
 
@@ -126,7 +126,7 @@ end
     return quote
         @_inline_meta
         elements = tuple($(exprs...))
-        @inbounds return similar_type(a, eltype(elements), Size($Snew))(elements)
+        @inbounds return similar_type(a, promote_tuple_eltype(elements), Size($Snew))(elements)
     end
 end
 

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -134,16 +134,16 @@ end
     @testset "eltype after broadcast" begin
         # test cases issue #198
         let a = SVector{4, Number}(2, 2.0, 4//2, 2+0im)
-            @test eltype(a + 2) == Number
-            @test eltype(a - 2) == Number
-            @test eltype(a * 2) == Number
-            @test eltype(a / 2) == Number
+            @test_broken eltype(a + 2) == Number
+            @test_broken eltype(a - 2) == Number
+            @test_broken eltype(a * 2) == Number
+            @test_broken eltype(a / 2) == Number
         end
         let a = SVector{3, Real}(2, 2.0, 4//2)
-            @test eltype(a + 2) == Real
-            @test eltype(a - 2) == Real
-            @test eltype(a * 2) == Real
-            @test eltype(a / 2) == Real
+            @test_broken eltype(a + 2) == Real
+            @test_broken eltype(a - 2) == Real
+            @test_broken eltype(a * 2) == Real
+            @test_broken eltype(a / 2) == Real
         end
         let a = SVector{3, Real}(2, 2.0, 4//2)
             @test eltype(a + 2.0) == Float64

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -134,22 +134,22 @@ end
     @testset "eltype after broadcast" begin
         # test cases issue #198
         let a = SVector{4, Number}(2, 2.0, 4//2, 2+0im)
-            @test_broken eltype(a + 2) == Number
-            @test_broken eltype(a - 2) == Number
-            @test_broken eltype(a * 2) == Number
-            @test_broken eltype(a / 2) == Number
+            @test eltype(a + 2) == Number
+            @test eltype(a - 2) == Number
+            @test eltype(a * 2) == Number
+            @test eltype(a / 2) == Number
         end
         let a = SVector{3, Real}(2, 2.0, 4//2)
-            @test_broken eltype(a + 2) == Real
-            @test_broken eltype(a - 2) == Real
-            @test_broken eltype(a * 2) == Real
-            @test_broken eltype(a / 2) == Real
+            @test eltype(a + 2) == Real
+            @test eltype(a - 2) == Real
+            @test eltype(a * 2) == Real
+            @test eltype(a / 2) == Real
         end
         let a = SVector{3, Real}(2, 2.0, 4//2)
-            @test_broken eltype(a + 2.0) == Float64
-            @test_broken eltype(a - 2.0) == Float64
-            @test_broken eltype(a * 2.0) == Float64
-            @test_broken eltype(a / 2.0) == Float64
+            @test eltype(a + 2.0) == Float64
+            @test eltype(a - 2.0) == Float64
+            @test eltype(a * 2.0) == Float64
+            @test eltype(a / 2.0) == Float64
         end
         let a = broadcast(Float32, SVector(3, 4, 5))
             @test eltype(a) == Float32


### PR DESCRIPTION
With this approach based on the eltype of tuple of computed elements, we get the correct dynamic result independently of whether inference can infer the return type.

This fixes #198, and partially addresses #329.

With the addition of a workaround hack to override a very specific version of `broadcast` in a very specific way it also fixes #329.