### PR TITLE
Workaround inference problem in round.(Int,v)

### DIFF
--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -111,6 +111,12 @@ end
     end
 end
 
+if VERSION < v"0.7.0-DEV"
+# Workaround for #329
+@inline function Base.broadcast(f, ::Type{T}, a::StaticArray) where {T}
+    map(x->f(T,x), a)
+end
+end
 
 ################
 ## broadcast! ##

--- a/test/mapreduce.jl
+++ b/test/mapreduce.jl
@@ -111,7 +111,9 @@
 
         @test_throws DimensionMismatch broadcast(+, v1, @SMatrix [4 3 2 1; 5 6 7 8])
 
-        @test @inferred(broadcast(convert, Float64, v1)) == convert(Vector{Float64}, [2,4,6,8])
+        @test @inferred(broadcast(convert, Float64, v1)) === SVector{4,Float64}(2,4,6,8)
+        # issue 329
+        @test @inferred(broadcast(round, Int, SVector(1.0,2.0))) === SVector{2,Int}(1,2)
 
         @test @inferred(broadcast(-, v1)) === map(-, v1)
 


### PR DESCRIPTION
Addresses the same problem as #330 but in a more minimal way.  Fixes #329 .

julia-0.6 doesn't seem to do constant propagation of `Type`s in quite
the way which would be required to get good efficiency for broadcasting
`round`.

Insert a minimal workaround for this particularly common case.

