### PR TITLE
Fix Array{T}(uninitialized,...) deprecations

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
 julia 0.6.0
-Compat 0.32
+Compat 0.39

--- a/src/SizedArray.jl
+++ b/src/SizedArray.jl
@@ -20,7 +20,7 @@ struct SizedArray{S <: Tuple, T, N, M} <: StaticArray{S, T, N}
     end
 
     function SizedArray{S, T, N, M}() where {S, T, N, M}
-        new{S, T, N, M}(Array{T, M}(S.parameters...))
+        @compat new{S, T, N, M}(Array{T, M}(uninitialized, S.parameters...))
     end
 end
 

--- a/src/SizedArray.jl
+++ b/src/SizedArray.jl
@@ -20,7 +20,7 @@ struct SizedArray{S <: Tuple, T, N, M} <: StaticArray{S, T, N}
     end
 
     function SizedArray{S, T, N, M}() where {S, T, N, M}
-        @compat new{S, T, N, M}(Array{T, M}(uninitialized, S.parameters...))
+        new{S, T, N, M}(Array{T, M}(uninitialized, S.parameters...))
     end
 end
 

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -77,7 +77,7 @@ end
     end
     newsize = tuple(newsize...)
 
-    @compat exprs = Array{Expr}(uninitialized, newsize)
+    exprs = Array{Expr}(uninitialized, newsize)
     more = prod(newsize) > 0
     current_ind = ones(Int, length(newsize))
 

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -77,7 +77,7 @@ end
     end
     newsize = tuple(newsize...)
 
-    exprs = Array{Expr}(newsize)
+    @compat exprs = Array{Expr}(uninitialized, newsize)
     more = prod(newsize) > 0
     current_ind = ones(Int, length(newsize))
 

--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -17,7 +17,7 @@ else
 end
 
 @generated function _map(f, ::Size{S}, a::AbstractArray...) where {S}
-    exprs = Vector{Expr}(prod(S))
+    @compat exprs = Vector{Expr}(uninitialized, prod(S))
     for i ∈ 1:prod(S)
         tmp = [:(a[$j][$i]) for j ∈ 1:length(a)]
         exprs[i] = :(f($(tmp...)))

--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -17,7 +17,7 @@ else
 end
 
 @generated function _map(f, ::Size{S}, a::AbstractArray...) where {S}
-    @compat exprs = Vector{Expr}(uninitialized, prod(S))
+    exprs = Vector{Expr}(uninitialized, prod(S))
     for i ∈ 1:prod(S)
         tmp = [:(a[$j][$i]) for j ∈ 1:length(a)]
         exprs[i] = :(f($(tmp...)))

--- a/test/Scalar.jl
+++ b/test/Scalar.jl
@@ -8,7 +8,7 @@ using StaticArrays, Base.Test
     @test Scalar(2)[] == 2
     @test Tuple(Scalar(2)) == (2,)
     @test Tuple(convert(Scalar{Float64}, [2.0])) == (2.0,)
-    @compat a = Array{Float64, 0}(uninitialized)
+    a = Array{Float64, 0}(uninitialized)
     a[] = 2
     @test Scalar(a)[] == 2
 end

--- a/test/Scalar.jl
+++ b/test/Scalar.jl
@@ -8,7 +8,7 @@ using StaticArrays, Base.Test
     @test Scalar(2)[] == 2
     @test Tuple(Scalar(2)) == (2,)
     @test Tuple(convert(Scalar{Float64}, [2.0])) == (2.0,)
-    a = Array{Float64, 0}()
+    @compat a = Array{Float64, 0}(uninitialized)
     a[] = 2
     @test Scalar(a)[] == 2
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,5 @@
 using StaticArrays
 using Base.Test
-using Compat 
 
 # We generate a lot of matrices using rand(), but unit tests should be
 # deterministic. Therefore seed the RNG here (and further down, to avoid test

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using StaticArrays
 using Base.Test
+using Compat 
 
 # We generate a lot of matrices using rand(), but unit tests should be
 # deterministic. Therefore seed the RNG here (and further down, to avoid test


### PR DESCRIPTION
With `@compat` decorations.