### PR TITLE
Fixes for mul! on Julia 0.7

### DIFF
--- a/src/matrix_multiply.jl
+++ b/src/matrix_multiply.jl
@@ -28,7 +28,7 @@ const StaticVecOrMat{T} = Union{StaticVector{<:Any, T}, StaticMatrix{<:Any, <:An
     @inline At_mul_Bt!(dest::StaticVecOrMat, A::StaticVecOrMat, B::StaticVecOrMat) = mul!(dest, transpose(A), transpose(B))
     @inline At_mul_B!(dest::StaticVecOrMat, A::StaticVecOrMat, B::StaticVecOrMat) = mul!(dest, transpose(A), B)
 else
-    import LinearAlgebra: BlasFloat, matprod
+    import LinearAlgebra: BlasFloat, matprod, mul!
 end
 
 


### PR DESCRIPTION
The first commit fixes deprecations in `ccall` to BLAS `gemm`. Without it, I'm getting a segfault---might be some problem with the deprecations in Julia?

The second commit imports `LinearAlgebra.mul!` so that the definitions extend it instead of defining a new function.