### PR TITLE
overload Base.setindex

### DIFF
--- a/src/deque.jl
+++ b/src/deque.jl
@@ -72,6 +72,7 @@ end
 
 # Immutable version of setindex!(). Seems similar in nature to the above, but
 # could also be justified to live in src/indexing.jl
+import Base: setindex
 @inline setindex(a::StaticArray, x, index::Int) = _setindex(Size(a), a, convert(eltype(typeof(a)), x), index)
 @generated function _setindex(::Size{s}, a::StaticArray{<:Any,T}, x::T, index::Int) where {s, T}
     exprs = [:(ifelse($i == index, x, a[$i])) for i = 1:s[1]]


### PR DESCRIPTION
There is already a `setindex` function in `Base`, we should overload it.
It would allow to remove [this hack](https://github.com/jw3126/Setfield.jl/blob/41afdcf7e63d2f46a173661387049a31df730f4c/src/Setfield.jl).