### PR TITLE
Import `eye` from `LinearAlgebra` on julia 0.7

### DIFF
--- a/src/StaticArrays.jl
+++ b/src/StaticArrays.jl
@@ -35,7 +35,7 @@ else
     import Base: sqrt, exp, log
 
     using LinearAlgebra
-    import LinearAlgebra: transpose, adjoint, vecdot, eig, eigvals, eigfact, lyap, trace,
+    import LinearAlgebra: transpose, adjoint, eye, vecdot, eig, eigvals, eigfact, lyap, trace,
                           kron, diag, vecnorm, norm, dot, diagm, lu, svd, svdvals, svdfact,
                           factorize, ishermitian, issymmetric, isposdef, normalize,
                           normalize!, Eigen, det, logdet, cross, diff, qr


### PR DESCRIPTION
This was necessary for my code to work on julia master, since `eye` has been moved to `LinearAlgebra`.

Of course, it leaves me wondering whether any other imports have been missed.