### PR TITLE
Add `Base.dataids(::SArray)`

### DIFF
--- a/src/MArray.jl
+++ b/src/MArray.jl
@@ -110,6 +110,10 @@ end
 
 @inline Tuple(v::MArray) = v.data
 
+if isdefined(Base, :dataids) # v0.7-
+    Base.dataids(ma::MArray) = (UInt(pointer(ma)),)
+end
+
 @inline function Base.unsafe_convert(::Type{Ptr{T}}, a::MArray{S,T}) where {S,T}
     Base.unsafe_convert(Ptr{T}, pointer_from_objref(a))
 end

--- a/src/SArray.jl
+++ b/src/SArray.jl
@@ -72,6 +72,10 @@ end
 
 @inline Tuple(v::SArray) = v.data
 
+if isdefined(Base, :dataids) # v0.7-
+    Base.dataids(::SArray) = ()
+end
+
 # See #53
 Base.cconvert(::Type{Ptr{T}}, a::SArray) where {T} = Base.RefValue(a)
 Base.unsafe_convert(::Type{Ptr{T}}, a::Base.RefValue{SArray{S,T,D,L}}) where {S,T,D,L} =

--- a/src/SizedArray.jl
+++ b/src/SizedArray.jl
@@ -72,6 +72,9 @@ SizedMatrix{S1,S2,T,M} = SizedArray{Tuple{S1,S2},T,2,M}
 @inline (::Type{SizedMatrix{S1,S2}})(a::Array{T,M}) where {S1,S2,T,M} = SizedArray{Tuple{S1,S2},T,2,M}(a)
 @inline (::Type{SizedMatrix{S1,S2}})(x::NTuple{L,T}) where {S1,S2,T,L} = SizedArray{Tuple{S1,S2},T,2,2}(x)
 
+if isdefined(Base, :dataids) # v0.7-
+    Base.dataids(sa::SizedArray) = Base.dataids(sa.data)
+end
 
 """
     Size(dims)(array)

--- a/test/MArray.jl
+++ b/test/MArray.jl
@@ -121,6 +121,12 @@
         @test size(typeof(m), 2) === 2
 
         @test length(m) === 4
+
+        if isdefined(Base, :mightalias) # v0.7-
+            @test Base.mightalias(m, m)
+            @test !Base.mightalias(m, copy(m))
+            @test Base.mightalias(m, view(m, :, 1))
+        end
     end
 
     @testset "setindex!" begin

--- a/test/SArray.jl
+++ b/test/SArray.jl
@@ -117,6 +117,10 @@
         @test length(m) === 4
 
         @test_throws Exception m[1] = 1
+
+        if isdefined(Base, :dataids) # v0.7-
+            @test Base.dataids(m) === ()
+        end
     end
 
     @testset "promotion" begin

--- a/test/SizedArray.jl
+++ b/test/SizedArray.jl
@@ -60,6 +60,22 @@
     sa[1] = 2
     @test sa.data == [2, 4]
 
+    if isdefined(Base, :mightalias) # v0.7-
+        @testset "aliasing" begin
+            a1 = rand(4)
+            a2 = copy(a1)
+            sa1 = SizedVector{4}(a1)
+            sa2 = SizedVector{4}(a2)
+            @test Base.mightalias(a1, sa1)
+            @test Base.mightalias(sa1, SizedVector{4}(a1))
+            @test !Base.mightalias(a2, sa1)
+            @test !Base.mightalias(sa1, SizedVector{4}(a2))
+            @test Base.mightalias(sa1, view(sa1, 1:2))
+            @test Base.mightalias(a1, view(sa1, 1:2))
+            @test Base.mightalias(sa1, view(a1, 1:2))
+        end
+    end
+
     @testset "back to Array" begin
         @test Array(SizedArray{Tuple{2}, Int, 1}([3, 4])) == [3, 4]
         @test Array{Int}(SizedArray{Tuple{2}, Int, 1}([3, 4])) == [3, 4]


### PR DESCRIPTION
An `SArray` can never alias anything, so it is safe to return an empty tuple here and prevent the aliasing detection machinery from doing unnecessary work.