### PR TITLE
RFC: Fix "Indexing empty arrays" tests for Julia 0.7

### DIFF
--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -154,12 +154,12 @@
     end
 
     @testset "Indexing empty arrays" begin
-        @test size(SVector{0}()[:]) == (0,)
-        @test size(SMatrix{0,0}()[:,:]) == (0,0)
-        @test size(SMatrix{5,0}()[1,:]) == (0,)
-        @test size(SMatrix{5,0}()[:,:]) == (5,0)
-        @test size(SMatrix{0,5}()[:,1]) == (0,)
-        @test size(SMatrix{0,5}()[:,:]) == (0,5)
+        @test size(SVector{0,Float64}()[:]) == (0,)
+        @test size(SMatrix{0,0,Float64}()[:,:]) == (0,0)
+        @test size(SMatrix{5,0,Float64}()[1,:]) == (0,)
+        @test size(SMatrix{5,0,Float64}()[:,:]) == (5,0)
+        @test size(SMatrix{0,5,Float64}()[:,1]) == (0,)
+        @test size(SMatrix{0,5,Float64}()[:,:]) == (0,5)
 
         @test (zeros(0)[SVector{0,Int}()] = 0) == 0
         @test (zeros(0,2)[SVector{0,Int}(),SVector(1)] = 0) == 0


### PR DESCRIPTION
Creating an empty `SArray` without specifying the element type leads to an element type of `Union{}` on Julia 0.6, but fails on Julia 0.7. Hence, the tests now explicitly define their element type.

Alternatively (hence RFC), we could define constructors for the empty case that default to an element type of `Union{}` to keep the 0.6 behavior on 0.7. Not sure how useful/desirable that is, but it would allow e.g. `SVector(x...)` to work even if `x` happens to be empty.