### PR TITLE
Improve/fix multiplication involving one AbstractTriangular{<:Any,<:StaticMatrix}

### DIFF
--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -56,7 +56,11 @@ end
 # Transpose, conjugate, etc
 @inline conj(a::StaticArray) = map(conj, a)
 @inline transpose(m::StaticMatrix) = _transpose(Size(m), m)
-# note: transpose of StaticVector is a Adjoint, handled by Base
+# note: transpose of StaticVector is a Transpose, handled by Base
+if VERSION >= v"0.7-"
+    @inline transpose(a::Adjoint{<:Any,<:Union{StaticVector,StaticMatrix}}) = conj(a.parent)
+    @inline transpose(a::Adjoint{<:Real,<:Union{StaticVector,StaticMatrix}}) = a.parent
+end
 
 @generated function _transpose(::Size{S}, m::StaticMatrix) where {S}
     Snew = (S[2], S[1])
@@ -70,6 +74,10 @@ end
 end
 
 @inline adjoint(m::StaticMatrix) = _adjoint(Size(m), m)
+if VERSION >= v"0.7-"
+    @inline adjoint(a::Transpose{<:Any,<:Union{StaticVector,StaticMatrix}}) = conj(a.parent)
+    @inline adjoint(a::Transpose{<:Real,<:Union{StaticVector,StaticMatrix}}) = a.parent
+end
 
 @generated function _adjoint(::Size{S}, m::StaticMatrix) where {S}
     Snew = (S[2], S[1])

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -1,38 +1,66 @@
-import Base: *, Ac_mul_B, At_mul_B, A_mul_Bc, A_mul_Bt, At_mul_Bt, Ac_mul_Bc
-import Base: \, Ac_ldiv_B, At_ldiv_B
-
 @inline Size(A::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}) = Size(A.data)
 
-# TODO add specialized op(AbstractTriangular, AbstractTriangular) methods
-# TODO add A*_rdiv_B* methods
-@inline *(A::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}, B::StaticVecOrMat) = _A_mul_B(Size(A), Size(B), A, B)
-@inline *(A::StaticMatrix, B::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}) = _A_mul_B(Size(A), Size(B), A, B)
-@inline Ac_mul_B(A::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}, B::StaticVecOrMat) = _Ac_mul_B(Size(A), Size(B), A, B)
-@inline A_mul_Bc(A::StaticMatrix, B::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}) = _A_mul_Bc(Size(A), Size(B), A, B)
-@inline At_mul_B(A::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}, B::StaticVecOrMat) = _At_mul_B(Size(A), Size(B), A, B)
-@inline A_mul_Bt(A::StaticMatrix, B::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}) = _A_mul_Bt(Size(A), Size(B), A, B)
+@static if VERSION < v"0.7-"
+    import Base: Ac_mul_B, At_mul_B, A_mul_Bc, A_mul_Bt, At_mul_Bt, Ac_mul_Bc
+    import Base: Ac_ldiv_B, At_ldiv_B
 
-# Specializations for Adjoint
-@inline *(rowvec::Adjoint{<:Any,<:StaticVector}, A::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}) = transpose(A * transpose(rowvec))
-@inline A_mul_Bt(rowvec::Adjoint{<:Any,<:StaticVector}, A::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}) = transpose(A * transpose(rowvec))
-@inline A_mul_Bt(A::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}, rowvec::Adjoint{<:Any,<:StaticVector}) = A * transpose(rowvec)
-@inline At_mul_Bt(A::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}, rowvec::Adjoint{<:Any,<:StaticVector}) = transpose(A) * transpose(rowvec)
-@inline A_mul_Bc(rowvec::Adjoint{<:Any,<:StaticVector}, A::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}) = adjoint(A * adjoint(rowvec))
-@inline A_mul_Bc(A::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}, rowvec::Adjoint{<:Any,<:StaticVector}) = A * adjoint(rowvec)
-@inline Ac_mul_Bc(A::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}, rowvec::Adjoint{<:Any,<:StaticVector}) = A' * adjoint(rowvec)
 
-Ac_mul_B(A::StaticMatrix, B::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}) = (*)(adjoint(A), B)
-At_mul_B(A::StaticMatrix, B::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}) = (*)(transpose(A), B)
-A_mul_Bc(A::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}, B::StaticMatrix) = (*)(A, adjoint(B))
-A_mul_Bt(A::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}, B::StaticMatrix) = (*)(A, transpose(B))
-Ac_mul_Bc(A::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}, B::StaticMatrix) = Ac_mul_B(A, B')
-Ac_mul_Bc(A::StaticMatrix, B::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}) = A_mul_Bc(A', B)
-At_mul_Bt(A::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}, B::StaticMatrix) = At_mul_B(A, transpose(B))
-At_mul_Bt(A::StaticMatrix, B::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}) = A_mul_Bt(transpose(A), B)
+    # TODO add specialized op(AbstractTriangular, AbstractTriangular) methods
+    # TODO add A*_rdiv_B* methods
+    @inline Ac_mul_B(A::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}, B::StaticVecOrMat) = _Ac_mul_B(Size(A), Size(B), A, B)
+    @inline A_mul_Bc(A::StaticVecOrMat, B::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}) = _A_mul_Bc(Size(A), Size(B), A, B)
+    @inline At_mul_B(A::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}, B::StaticVecOrMat) = _At_mul_B(Size(A), Size(B), A, B)
+    @inline A_mul_Bt(A::StaticMatrix, B::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}) = _A_mul_Bt(Size(A), Size(B), A, B)
 
-@inline \(A::Union{UpperTriangular{<:Any,<:StaticMatrix},LowerTriangular{<:Any,<:StaticMatrix}}, B::StaticVecOrMat) = _A_ldiv_B(Size(A), Size(B), A, B)
-@inline Ac_ldiv_B(A::Union{UpperTriangular{<:Any,<:StaticMatrix},LowerTriangular{<:Any,<:StaticMatrix}}, B::StaticVecOrMat) = _Ac_ldiv_B(Size(A), Size(B), A, B)
-@inline At_ldiv_B(A::Union{UpperTriangular{<:Any,<:StaticMatrix},LowerTriangular{<:Any,<:StaticMatrix}}, B::StaticVecOrMat) = _At_ldiv_B(Size(A), Size(B), A, B)
+    # Specializations for Adjoint
+    @inline Base.:*(rowvec::Adjoint{<:Any,<:StaticVector}, A::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}) = transpose(A * transpose(rowvec))
+    @inline Base.:*(A::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}, rowvec::RowVector{<:Any,<:StaticVector}) = transpose(rowvec.vec * A)
+    @inline A_mul_Bt(rowvec::Adjoint{<:Any,<:StaticVector}, A::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}) = transpose(A * transpose(rowvec))
+    @inline A_mul_Bt(A::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}, rowvec::Adjoint{<:Any,<:StaticVector}) = A * transpose(rowvec)
+    @inline At_mul_B(A::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}, rowvec::RowVector{<:Any,<:StaticVector}) = transpose(rowvec.vec * A)
+    @inline At_mul_Bt(A::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}, rowvec::Adjoint{<:Any,<:StaticVector}) = transpose(A) * transpose(rowvec)
+    @inline At_mul_Bt(rowvec::RowVector{<:Any,<:StaticVector}, A::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}) = rowvec.vec * transpose(A)
+    @inline A_mul_Bc(rowvec::RowVector{<:Any,<:StaticVector}, A::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}) = transpose(conj(A * adjoint(rowvec)))
+    @inline A_mul_Bc(A::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}, rowvec::Adjoint{<:Any,<:StaticVector}) = A * adjoint(rowvec)
+    @inline Ac_mul_B(A::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}, rowvec::RowVector{<:Any,<:StaticVector}) = adjoint(conj(rowvec.vec) * A)
+    @inline Ac_mul_Bc(A::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}, rowvec::Adjoint{<:Any,<:StaticVector}) = A' * adjoint(rowvec)
+    @inline Ac_mul_Bc(rowvec::RowVector{<:Any,<:StaticVector}, A::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}) = conj(rowvec.vec) * A'
+
+    Ac_mul_B(A::StaticMatrix, B::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}) = (*)(adjoint(A), B)
+    At_mul_B(A::StaticMatrix, B::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}) = (*)(transpose(A), B)
+    A_mul_Bc(A::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}, B::StaticMatrix) = (*)(A, adjoint(B))
+    A_mul_Bt(A::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}, B::StaticMatrix) = (*)(A, transpose(B))
+    Ac_mul_Bc(A::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}, B::StaticMatrix) = Ac_mul_B(A, B')
+    Ac_mul_Bc(A::StaticMatrix, B::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}) = A_mul_Bc(A', B)
+    At_mul_Bt(A::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}, B::StaticMatrix) = At_mul_B(A, transpose(B))
+    At_mul_Bt(A::StaticMatrix, B::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}) = A_mul_Bt(transpose(A), B)
+
+    @inline Ac_ldiv_B(A::Union{UpperTriangular{<:Any,<:StaticMatrix},LowerTriangular{<:Any,<:StaticMatrix}}, B::StaticVecOrMat) = _Ac_ldiv_B(Size(A), Size(B), A, B)
+    @inline At_ldiv_B(A::Union{UpperTriangular{<:Any,<:StaticMatrix},LowerTriangular{<:Any,<:StaticMatrix}}, B::StaticVecOrMat) = _At_ldiv_B(Size(A), Size(B), A, B)
+else
+    @inline transpose(A::LinearAlgebra.LowerTriangular{<:Any,<:StaticMatrix}) =
+        LinearAlgebra.UpperTriangular(transpose(A.data))
+    @inline adjoint(A::LinearAlgebra.LowerTriangular{<:Any,<:StaticMatrix}) =
+        LinearAlgebra.UpperTriangular(adjoint(A.data))
+    @inline transpose(A::LinearAlgebra.UpperTriangular{<:Any,<:StaticMatrix}) =
+        LinearAlgebra.LowerTriangular(transpose(A.data))
+    @inline adjoint(A::LinearAlgebra.UpperTriangular{<:Any,<:StaticMatrix}) =
+        LinearAlgebra.LowerTriangular(adjoint(A.data))
+
+    @inline Base.:*(A::Adjoint{<:Any,<:StaticVecOrMat}, B::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}) =
+        adjoint(adjoint(B) * adjoint(A))
+    @inline Base.:*(A::Transpose{<:Any,<:StaticVecOrMat}, B::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}) =
+        transpose(transpose(B) * transpose(A))
+    @inline Base.:*(A::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}, B::Adjoint{<:Any,<:StaticVecOrMat}) =
+        adjoint(adjoint(B) * adjoint(A))
+    @inline Base.:*(A::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}, B::Transpose{<:Any,<:StaticVecOrMat}) =
+        transpose(transpose(B) * transpose(A))
+end
+
+@inline Base.:*(A::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}, B::StaticVecOrMat) = _A_mul_B(Size(A), Size(B), A, B)
+@inline Base.:*(A::StaticVecOrMat, B::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}) = _A_mul_B(Size(A), Size(B), A, B)
+@inline Base.:\(A::Union{UpperTriangular{<:Any,<:StaticMatrix},LowerTriangular{<:Any,<:StaticMatrix}}, B::StaticVecOrMat) = _A_ldiv_B(Size(A), Size(B), A, B)
+
 
 @generated function _A_mul_B(::Size{sa}, ::Size{sb}, A::UpperTriangular{TA,<:StaticMatrix}, B::StaticVecOrMat{TB}) where {sa,sb,TA,TB}
     m = sb[1]
@@ -202,8 +230,13 @@ end
     end
 end
 
-@generated function _A_mul_B(::Size{sa}, ::Size{sb}, A::StaticMatrix{<:Any,<:Any,TA}, B::UpperTriangular{TB,<:StaticMatrix}) where {sa,sb,TA,TB}
-    m, n = sa[1], sa[2]
+@generated function _A_mul_B(::Size{sa}, ::Size{sb}, A::StaticArray{<:Any,TA}, B::UpperTriangular{TB,<:StaticMatrix}) where {sa,sb,TA,TB}
+    m = sa[1]
+    if length(sa) == 1
+        n = 1
+    else
+        n = sa[2]
+    end
     if sb[1] != n
         throw(DimensionMismatch("right hand side B needs first dimension of size $n, has size $(sb[1])"))
     end
@@ -225,12 +258,17 @@ end
         @_inline_meta
         @inbounds $code
         TAB = promote_op(matprod, TA, TB)
-        return similar_type(A, TAB)(tuple($(X...)))
+        return similar_type(A, TAB, Size($m,$n))(tuple($(X...)))
     end
 end
 
-@generated function _A_mul_Bc(::Size{sa}, ::Size{sb}, A::StaticMatrix{<:Any,<:Any,TA}, B::UpperTriangular{TB,<:StaticMatrix}) where {sa,sb,TA,TB}
-    m, n = sa[1], sa[2]
+@generated function _A_mul_Bc(::Size{sa}, ::Size{sb}, A::StaticArray{<:Any,TA}, B::UpperTriangular{TB,<:StaticMatrix}) where {sa,sb,TA,TB}
+    m = sa[1]
+    if length(sa) == 1
+        n = 1
+    else
+        n = sa[2]
+    end
     if sb[1] != n
         throw(DimensionMismatch("right hand side B needs first dimension of size $n, has size $(sb[1])"))
     end
@@ -252,7 +290,7 @@ end
         @_inline_meta
         @inbounds $code
         TAB = promote_op(matprod, TA, TB)
-        return similar_type(A, TAB)(tuple($(X...)))
+        return similar_type(A, TAB, Size($m, $n))(tuple($(X...)))
     end
 end
 
@@ -283,8 +321,13 @@ end
     end
 end
 
-@generated function _A_mul_B(::Size{sa}, ::Size{sb}, A::StaticMatrix{<:Any,<:Any,TA}, B::LowerTriangular{TB,<:StaticMatrix}) where {sa,sb,TA,TB}
-    m, n = sa[1], sa[2]
+@generated function _A_mul_B(::Size{sa}, ::Size{sb}, A::StaticArray{<:Any,TA}, B::LowerTriangular{TB,<:StaticMatrix}) where {sa,sb,TA,TB}
+    m = sa[1]
+    if length(sa) == 1
+        n = 1
+    else
+        n = sa[2]
+    end
     if sb[1] != n
         throw(DimensionMismatch("right hand side B needs first dimension of size $n, has size $(sb[1])"))
     end
@@ -306,12 +349,17 @@ end
         @_inline_meta
         @inbounds $code
         TAB = promote_op(matprod, TA, TB)
-        return similar_type(A, TAB)(tuple($(X...)))
+        return similar_type(A, TAB, Size($m,$n))(tuple($(X...)))
     end
 end
 
-@generated function _A_mul_Bc(::Size{sa}, ::Size{sb}, A::StaticMatrix{<:Any,<:Any,TA}, B::LowerTriangular{TB,<:StaticMatrix}) where {sa,sb,TA,TB}
-    m, n = sa[1], sa[2]
+@generated function _A_mul_Bc(::Size{sa}, ::Size{sb}, A::StaticArray{<:Any,TA}, B::LowerTriangular{TB,<:StaticMatrix}) where {sa,sb,TA,TB}
+    m = sa[1]
+    if length(sa) == 1
+        n = 1
+    else
+        n = sa[2]
+    end
     if sb[1] != n
         throw(DimensionMismatch("right hand side B needs first dimension of size $n, has size $(sb[1])"))
     end
@@ -333,7 +381,7 @@ end
         @_inline_meta
         @inbounds $code
         TAB = promote_op(matprod, TA, TB)
-        return similar_type(A, TAB)(tuple($(X...)))
+        return similar_type(A, TAB, Size($m,$n))(tuple($(X...)))
     end
 end
 

--- a/test/triangular.jl
+++ b/test/triangular.jl
@@ -4,8 +4,8 @@
             (t, uplo) in ((UpperTriangular, :U), (LowerTriangular, :L)),
                 eltyB in (Float64, Complex128)
 
-        A = t(eltyA == Int ? rand(1:7, n, n) : convert(Matrix{eltyA}, (eltyA <: Complex ? complex.(randn(n, n), randn(n, n)) : randn(n, n)) |> t -> chol(t't) |> t -> uplo == :U ? t : adjoint(t)))
-        B = convert(Matrix{eltyB}, eltyA <: Complex ? real(A)*ones(n, n) : A*ones(n, n))
+        A = t(eltyA == Int ? rand(1:7, n, n) : rand(eltyA, n, n))
+        B = rand(eltyB, n, n)
         SA = t(SMatrix{n,n}(A.data))
         SB = SMatrix{n,n}(B)
 
@@ -20,13 +20,23 @@
         @test (SA.'*SB)::SMatrix{n,n} ≈ A.'*B
         @test (SA.'*SB.')::SMatrix{n,n} ≈ A.'*B.'
         @test (SB*SA)::SMatrix{n,n} ≈ B*A
-        @test (SB[:,1].'*SA)::Adjoint{<:Any,<:SVector{n}} ≈ B[:,1].'*A
+        if VERSION < v"0.7-"
+            @test (SB[:,1].'*SA)::RowVector{<:Any,<:SVector{n}} ≈ B[:,1].'*A
+        else
+            @test (SB[:,1]'*SA)::Adjoint{<:Any,<:SVector{n}} ≈ B[:,1]'*A
+            @test (SB[:,1].'*SA)::Transpose{<:Any,<:SVector{n}} ≈ B[:,1].'*A
+        end
         @test (SB.'*SA)::SMatrix{n,n} ≈ B.'*A
         @test SB[:,1]'*SA ≈ B[:,1]'*A
         @test (SB'*SA)::SMatrix{n,n} ≈ B'*A
         @test (SB*SA')::SMatrix{n,n} ≈ B*A'
         @test (SB*SA.')::SMatrix{n,n} ≈ B*A.'
-        @test (SB[:,1].'*SA.')::Adjoint{<:Any,<:SVector{n}} ≈ B[:,1].'*A.'
+        if VERSION < v"0.7-"
+            @test (SB[:,1].'*SA.')::RowVector{<:Any,<:SVector{n}} ≈ B[:,1].'*A.'
+        else
+            @test (SB[:,1]'*SA.')::Adjoint{<:Any,<:SVector{n}} ≈ B[:,1]'*A.'
+            @test (SB[:,1].'*SA.')::Transpose{<:Any,<:SVector{n}} ≈ B[:,1].'*A.'
+        end
         @test (SB.'*SA.')::SMatrix{n,n} ≈ B.'*A.'
         @test (SB[:,1]'*SA') ≈ SB[:,1]'*SA'
         @test (SB'*SA')::SMatrix{n,n} ≈ B'*A'
@@ -46,30 +56,35 @@ end
             (t, uplo) in ((UpperTriangular, :U), (LowerTriangular, :L)),
                 eltyB in (Float64, Complex128)
 
-        A = t(eltyA == Int ? rand(1:7, n, n) : convert(Matrix{eltyA}, (eltyA <: Complex ? complex.(randn(n, n), randn(n, n)) : randn(n, n)) |> t -> chol(t't) |> t -> uplo == :U ? t : adjoint(t)))
-        B = convert(Vector{eltyB}, eltyA <: Complex ? real(A)*ones(n) : A*ones(n))
+        A = t(eltyA == Int ? rand(1:7, n, n) : rand(eltyA, n, n))
+        B = rand(eltyB, n)
         SA = t(SMatrix{n,n}(A.data))
         SB = SVector{n}(B).'
 
-        @test (SA*SB)::Matrix ≈ A*B.'
+        @test (SA*SB)::SMatrix{n,n} ≈ A*B.'
         @test (SA*SB.')::SVector{n} ≈ A*B
-        # Some weird type stuff going on here
-        @test (SA*SB') ≈ A*conj(B)
-        @test (SA'*SB)::Matrix ≈ A'*B.'
+        @test (SA*SB')::SVector{n} ≈ A*conj(B)
+        @test (SA'*SB)::SMatrix{n,n} ≈ A'*B.'
         @test (SA'*SB.')::SVector{n} ≈ A'*B
-        @test (SA'*SB') ≈ A'*conj(B)
-        @test (SA.'*SB)::Matrix ≈ A.'*B.'
+        @test (SA'*SB')::SVector{n} ≈ A'*conj(B)
+        @test (SA.'*SB)::SMatrix{n,n} ≈ A.'*B.'
         @test (SA.'*SB.')::SVector{n} ≈ A.'*B
-        @test (SA.'*SB') ≈ A.'*conj(B)
-        @test (SB*SA)::Adjoint{<:Any,<:SVector{n}} ≈ B.'*A
-        @test (SB*SA') ≈ B.'*A'
-        @test (SB*SA.')::Adjoint{<:Any,<:SVector{n}} ≈ B.'*A.'
-        @test (SB.'*SA)::Matrix ≈ B*A
-        @test (SB'*SA)::Matrix ≈ conj(B)*A
-        @test (SB.'*SA.')::Matrix ≈ B*A.'
-        @test (SB.'*SA')::Matrix ≈ B*A'
-        @test (SB'*SA.')::Matrix ≈ conj(B)*A.'
-        @test (SB'*SA')::Matrix ≈ conj(B)*A'
+        @test (SA.'*SB')::SVector{n} ≈ A.'*conj(B)
+        if VERSION < v"0.7-"
+            @test (SB*SA)::RowVector{<:Any,<:SVector{n}} ≈ B.'*A
+            @test (SB*SA')::RowVector{<:Any,<:SVector{n}} ≈ B.'*A'
+            @test (SB*SA.')::RowVector{<:Any,<:SVector{n}} ≈ B.'*A.'
+        else
+            @test (SB*SA)::Transpose{<:Any,<:SVector{n}} ≈ B.'*A
+            @test (SB*SA')::Transpose{<:Any,<:SVector{n}} ≈ B.'*A'
+            @test (SB*SA.')::Transpose{<:Any,<:SVector{n}} ≈ B.'*A.'
+        end
+        @test (SB.'*SA)::SMatrix{n,n} ≈ B*A
+        @test (SB'*SA)::SMatrix{n,n} ≈ conj(B)*A
+        @test (SB.'*SA.')::SMatrix{n,n} ≈ B*A.'
+        @test (SB.'*SA')::SMatrix{n,n} ≈ B*A'
+        @test (SB'*SA.')::SMatrix{n,n} ≈ conj(B)*A.'
+        @test (SB'*SA')::SMatrix{n,n} ≈ conj(B)*A'
     end
 end
 


### PR DESCRIPTION
Ensure that all tested multiplications involving one `AbstractTriangular{<:Any,<:StaticMatrix}` return an `SArray` (wrapped as necessary for row vectors) and allow non-zero imaginary part in tests, both on Julia 0.6 and 0.7.

For the test to pass on 0.7, https://github.com/JuliaLang/julia/pull/26349 is needed (otherwise computation of the `Array`-based reference results fails). Further, for `Pkg.test` to even reach the relevant testsets, #377 is required. But with those, things are looking good locally.