### PR TITLE
Use `LinearIndices` instead of `sub2ind`

### DIFF
--- a/src/abstractarray.jl
+++ b/src/abstractarray.jl
@@ -134,8 +134,8 @@ reshape(a::Array, s::Size{S}) where {S} = s(a)
 @inline Base.full(sym::Symmetric{T,SM}) where {T,SM <: StaticMatrix} = _full(Size(SM), sym)
 
 @generated function _full(::Size{S}, sym::Symmetric{T,SM}) where {S, T, SM <: StaticMatrix}
-    exprs_up = [i <= j ? :(m[$(sub2ind(S, i, j))]) : :(m[$(sub2ind(S, j, i))]) for i = 1:S[1], j=1:S[2]]
-    exprs_lo = [i >= j ? :(m[$(sub2ind(S, i, j))]) : :(m[$(sub2ind(S, j, i))]) for i = 1:S[1], j=1:S[2]]
+    exprs_up = [i <= j ? :(m[$(LinearIndices(S)[i, j])]) : :(m[$(LinearIndices(S)[j, i])]) for i = 1:S[1], j=1:S[2]]
+    exprs_lo = [i >= j ? :(m[$(LinearIndices(S)[i, j])]) : :(m[$(LinearIndices(S)[j, i])]) for i = 1:S[1], j=1:S[2]]
 
     return quote
         @_inline_meta
@@ -151,8 +151,8 @@ end
 @inline Base.full(herm::Hermitian{T,SM}) where {T,SM <: StaticMatrix} = _full(Size(SM), herm)
 
 @generated function _full(::Size{S}, herm::Hermitian{T,SM}) where {S, T, SM <: StaticMatrix}
-    exprs_up = [i <= j ? :(m[$(sub2ind(S, i, j))]) : :(conj(m[$(sub2ind(S, j, i))])) for i = 1:S[1], j=1:S[2]]
-    exprs_lo = [i >= j ? :(m[$(sub2ind(S, i, j))]) : :(conj(m[$(sub2ind(S, j, i))])) for i = 1:S[1], j=1:S[2]]
+    exprs_up = [i <= j ? :(m[$(LinearIndices(S)[i, j])]) : :(conj(m[$(LinearIndices(S)[j, i])])) for i = 1:S[1], j=1:S[2]]
+    exprs_lo = [i >= j ? :(m[$(LinearIndices(S)[i, j])]) : :(conj(m[$(LinearIndices(S)[j, i])])) for i = 1:S[1], j=1:S[2]]
 
     return quote
         @_inline_meta

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -89,7 +89,7 @@ function broadcasted_index(oldsize, newindex)
             index[i] = newindex[i]
         end
     end
-    return sub2ind(oldsize, index...)
+    return LinearIndices(oldsize)[index...]
 end
 
 @generated function _broadcast(f, s::Tuple{Vararg{Size}}, a...)

--- a/src/deque.jl
+++ b/src/deque.jl
@@ -86,4 +86,8 @@ import Base: setindex
 end
 
 # TODO proper multidimension boundscheck
-@propagate_inbounds setindex(a::StaticArray, x, inds::Int...) = setindex(a, x, sub2ind(size(typeof(a)), inds...))
+if VERSION < v"0.7-"
+    @propagate_inbounds setindex(a::StaticArray, x, inds::Int...) = setindex(a, x, sub2ind(size(typeof(a)), inds...))
+else
+    @propagate_inbounds setindex(a::StaticArray, x, inds::Int...) = setindex(a, x, LinearIndices(a)[inds...])
+end

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -40,7 +40,7 @@ import Base: +, -, *, /, \
         throw(DimensionMismatch("matrix is not square: dimensions are $S"))
     end
     n = S[1]
-    exprs = [i == j ? :(a[$(sub2ind(size(a), i, j))] + λ) : :(a[$(sub2ind(size(a), i, j))]) for i = 1:n, j = 1:n]
+    exprs = [i == j ? :(a[$(LinearIndices(S)[i, j])] + λ) : :(a[$(LinearIndices(S)[i, j])]) for i = 1:n, j = 1:n]
     return quote
         $(Expr(:meta, :inline))
         @inbounds return similar_type(a, promote_type(eltype(a), typeof(λ)))(tuple($(exprs...)))
@@ -61,7 +61,7 @@ end
 @generated function _transpose(::Size{S}, m::StaticMatrix) where {S}
     Snew = (S[2], S[1])
 
-    exprs = [:(m[$(sub2ind(S, j1, j2))]) for j2 = 1:S[2], j1 = 1:S[1]]
+    exprs = [:(m[$(LinearIndices(S)[j1, j2])]) for j2 = 1:S[2], j1 = 1:S[1]]
 
     return quote
         $(Expr(:meta, :inline))
@@ -74,7 +74,7 @@ end
 @generated function _adjoint(::Size{S}, m::StaticMatrix) where {S}
     Snew = (S[2], S[1])
 
-    exprs = [:(conj(m[$(sub2ind(S, j1, j2))])) for j2 = 1:S[2], j1 = 1:S[1]]
+    exprs = [:(conj(m[$(LinearIndices(S)[j1, j2])])) for j2 = 1:S[2], j1 = 1:S[1]]
 
     return quote
         $(Expr(:meta, :inline))
@@ -327,7 +327,7 @@ end
         return zero(eltype(a))
     end
 
-    exprs = [:(a[$(sub2ind(S, i, i))]) for i = 1:S[1]]
+    exprs = [:(a[$(LinearIndices(S)[i, i])]) for i = 1:S[1]]
     total = reduce((ex1, ex2) -> :($ex1 + $ex2), exprs)
 
     return quote
@@ -344,7 +344,7 @@ const _length_limit = Length(200)
     if prod(outsize) > length_limit
         return :( SizedMatrix{$(outsize[1]),$(outsize[2])}( kron(drop_sdims(a), drop_sdims(b)) ) )
     end
-    rows = [:(hcat($([:(a[$(sub2ind(SA,i,j))]*b) for j=1:SA[2]]...))) for i=1:SA[1]]
+    rows = [:(hcat($([:(a[$(LinearIndices(SA)[i, j])]*b) for j=1:SA[2]]...))) for i=1:SA[1]]
     return quote
         @_inline_meta
         @inbounds return vcat($(rows...))

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -84,7 +84,13 @@ Length(::Type{SA}) where {SA <: StaticArray} = Length(Size(SA))
 
 @pure Base.prod(::Size{S}) where {S} = prod(S)
 
-@pure @inline Base.sub2ind(::Size{S}, x::Int...) where {S} = sub2ind(S, x...)
+if !isdefined(Base, :LinearIndices) # VERSION < v"0.7-"
+    @pure @inline Base.sub2ind(::Size{S}, x::Int...) where {S} = sub2ind(S, x...)
+elseif isdefined(Base, :sub2ind)
+    import Base: sub2ind
+    @deprecate sub2ind(s::Size, x::Int...) LinearIndices(s)[x...]
+end
+Compat.LinearIndices(::Size{S}) where {S} = LinearIndices(S)
 
 @pure size_tuple(::Size{S}) where {S} = Tuple{S...}
 

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -46,9 +46,9 @@ At_mul_Bt(A::StaticMatrix, B::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMat
     code = quote end
     for j = 1:n
         for i = 1:m
-            ex = :(A.data[$(sub2ind(sa,i,i))]*B[$(sub2ind(sb,i,j))])
+            ex = :(A.data[$(LinearIndices(sa)[i, i])]*B[$(LinearIndices(sb)[i, j])])
             for k = i+1:m
-                ex = :($ex + A.data[$(sub2ind(sa,i,k))]*B[$(sub2ind(sb,k,j))])
+                ex = :($ex + A.data[$(LinearIndices(sa)[i, k])]*B[$(LinearIndices(sb)[k, j])])
             end
             push!(code.args, :($(X[i,j]) = $ex))
         end
@@ -74,9 +74,9 @@ end
     code = quote end
     for j = 1:n
         for i = m:-1:1
-            ex = :(A.data[$(sub2ind(sa,i,i))]'*B[$(sub2ind(sb,i,j))])
+            ex = :(A.data[$(LinearIndices(sa)[i, i])]'*B[$(LinearIndices(sb)[i, j])])
             for k = 1:i-1
-                ex = :($ex + A.data[$(sub2ind(sa,k,i))]'*B[$(sub2ind(sb,k,j))])
+                ex = :($ex + A.data[$(LinearIndices(sa)[k, i])]'*B[$(LinearIndices(sb)[k, j])])
             end
             push!(code.args, :($(X[i,j]) = $ex))
         end
@@ -102,9 +102,9 @@ end
     code = quote end
     for j = 1:n
         for i = m:-1:1
-            ex = :(transpose(A.data[$(sub2ind(sa,i,i))])*B[$(sub2ind(sb,i,j))])
+            ex = :(transpose(A.data[$(LinearIndices(sa)[i, i])])*B[$(LinearIndices(sb)[i, j])])
             for k = 1:i-1
-                ex = :($ex + transpose(A.data[$(sub2ind(sa,k,i))])*B[$(sub2ind(sb,k,j))])
+                ex = :($ex + transpose(A.data[$(LinearIndices(sa)[k, i])])*B[$(LinearIndices(sb)[k, j])])
             end
             push!(code.args, :($(X[i,j]) = $ex))
         end
@@ -130,9 +130,9 @@ end
     code = quote end
     for j = 1:n
         for i = m:-1:1
-            ex = :(A.data[$(sub2ind(sa,i,i))]*B[$(sub2ind(sb,i,j))])
+            ex = :(A.data[$(LinearIndices(sa)[i, i])]*B[$(LinearIndices(sb)[i, j])])
             for k = 1:i-1
-                ex = :($ex + A.data[$(sub2ind(sa,i,k))]*B[$(sub2ind(sb,k,j))])
+                ex = :($ex + A.data[$(LinearIndices(sa)[i, k])]*B[$(LinearIndices(sb)[k, j])])
             end
             push!(code.args, :($(X[i,j]) = $ex))
         end
@@ -158,9 +158,9 @@ end
     code = quote end
     for j = 1:n
         for i = 1:m
-            ex = :(A.data[$(sub2ind(sa,i,i))]'*B[$(sub2ind(sb,i,j))])
+            ex = :(A.data[$(LinearIndices(sa)[i, i])]'*B[$(LinearIndices(sb)[i, j])])
             for k = i+1:m
-                ex = :($ex + A.data[$(sub2ind(sa,k,i))]'*B[$(sub2ind(sb,k,j))])
+                ex = :($ex + A.data[$(LinearIndices(sa)[k, i])]'*B[$(LinearIndices(sb)[k, j])])
             end
             push!(code.args, :($(X[i,j]) = $ex))
         end
@@ -186,9 +186,9 @@ end
     code = quote end
     for j = 1:n
         for i = 1:m
-            ex = :(transpose(A.data[$(sub2ind(sa,i,i))])*B[$(sub2ind(sb,i,j))])
+            ex = :(transpose(A.data[$(LinearIndices(sa)[i, i])])*B[$(LinearIndices(sb)[i, j])])
             for k = i+1:m
-                ex = :($ex + transpose(A.data[$(sub2ind(sa,k,i))])*B[$(sub2ind(sb,k,j))])
+                ex = :($ex + transpose(A.data[$(LinearIndices(sa)[k, i])])*B[$(LinearIndices(sb)[k, j])])
             end
             push!(code.args, :($(X[i,j]) = $ex))
         end
@@ -213,9 +213,9 @@ end
     code = quote end
     for i = 1:m
         for j = n:-1:1
-            ex = :(A[$(sub2ind(sa,i,j))]*B[$(sub2ind(sb,j,j))])
+            ex = :(A[$(LinearIndices(sa)[i, j])]*B[$(LinearIndices(sb)[j, j])])
             for k = 1:j-1
-                ex = :($ex + A[$(sub2ind(sa,i,k))]*B.data[$(sub2ind(sb,k,j))])
+                ex = :($ex + A[$(LinearIndices(sa)[i, k])]*B.data[$(LinearIndices(sb)[k, j])])
             end
             push!(code.args, :($(X[i,j]) = $ex))
         end
@@ -240,9 +240,9 @@ end
     code = quote end
     for i = 1:m
         for j = 1:n
-            ex = :(A[$(sub2ind(sa,i,j))]*B[$(sub2ind(sb,j,j))]')
+            ex = :(A[$(LinearIndices(sa)[i, j])]*B[$(LinearIndices(sb)[j, j])]')
             for k = j+1:n
-                ex = :($ex + A[$(sub2ind(sa,i,k))]*B.data[$(sub2ind(sb,j,k))]')
+                ex = :($ex + A[$(LinearIndices(sa)[i, k])]*B.data[$(LinearIndices(sb)[j, k])]')
             end
             push!(code.args, :($(X[i,j]) = $ex))
         end
@@ -267,9 +267,9 @@ end
     code = quote end
     for i = 1:m
         for j = 1:n
-            ex = :(A[$(sub2ind(sa,i,j))]*transpose(B[$(sub2ind(sb,j,j))]))
+            ex = :(A[$(LinearIndices(sa)[i, j])]*transpose(B[$(LinearIndices(sb)[j, j])]))
             for k = j+1:n
-                ex = :($ex + A[$(sub2ind(sa,i,k))]*transpose(B.data[$(sub2ind(sb,j,k))]))
+                ex = :($ex + A[$(LinearIndices(sa)[i, k])]*transpose(B.data[$(LinearIndices(sb)[j, k])]))
             end
             push!(code.args, :($(X[i,j]) = $ex))
         end
@@ -294,9 +294,9 @@ end
     code = quote end
     for i = 1:m
         for j = 1:n
-            ex = :(A[$(sub2ind(sa,i,j))]*B[$(sub2ind(sb,j,j))])
+            ex = :(A[$(LinearIndices(sa)[i, j])]*B[$(LinearIndices(sb)[j, j])])
             for k = j+1:n
-                ex = :($ex + A[$(sub2ind(sa,i,k))]*B.data[$(sub2ind(sb,k,j))])
+                ex = :($ex + A[$(LinearIndices(sa)[i, k])]*B.data[$(LinearIndices(sb)[k, j])])
             end
             push!(code.args, :($(X[i,j]) = $ex))
         end
@@ -321,9 +321,9 @@ end
     code = quote end
     for i = 1:m
         for j = n:-1:1
-            ex = :(A[$(sub2ind(sa,i,j))]*B[$(sub2ind(sb,j,j))]')
+            ex = :(A[$(LinearIndices(sa)[i, j])]*B[$(LinearIndices(sb)[j, j])]')
             for k = 1:j-1
-                ex = :($ex + A[$(sub2ind(sa,i,k))]*B.data[$(sub2ind(sb,j,k))]')
+                ex = :($ex + A[$(LinearIndices(sa)[i, k])]*B.data[$(LinearIndices(sb)[j, k])]')
             end
             push!(code.args, :($(X[i,j]) = $ex))
         end
@@ -348,9 +348,9 @@ end
     code = quote end
     for i = 1:m
         for j = n:-1:1
-            ex = :(A[$(sub2ind(sa,i,j))]*transpose(B[$(sub2ind(sb,j,j))]))
+            ex = :(A[$(LinearIndices(sa)[i, j])]*transpose(B[$(LinearIndices(sb)[j, j])]))
             for k = 1:j-1
-                ex = :($ex + A[$(sub2ind(sa,i,k))]*transpose(B.data[$(sub2ind(sb,j,k))]))
+                ex = :($ex + A[$(LinearIndices(sa)[i, k])]*transpose(B.data[$(LinearIndices(sb)[j, k])]))
             end
             push!(code.args, :($(X[i,j]) = $ex))
         end
@@ -372,17 +372,17 @@ end
     end
 
     X = [Symbol("X_$(i)_$(j)") for i = 1:m, j = 1:n]
-    init = [:($(X[i,j]) = B[$(sub2ind(sb,i,j))]) for i = 1:m, j = 1:n]
+    init = [:($(X[i,j]) = B[$(LinearIndices(sb)[i, j])]) for i = 1:m, j = 1:n]
 
     code = quote end
     for k = 1:n
         for j = m:-1:1
             if k == 1
-                push!(code.args, :(A.data[$(sub2ind(sa,j,j))] == zero(A.data[$(sub2ind(sa,j,j))]) && throw(LinearAlgebra.SingularException($j))))
+                push!(code.args, :(A.data[$(LinearIndices(sa)[j, j])] == zero(A.data[$(LinearIndices(sa)[j, j])]) && throw(LinearAlgebra.SingularException($j))))
             end
-            push!(code.args, :($(X[j,k]) = A.data[$(sub2ind(sa,j,j))] \ $(X[j,k])))
+            push!(code.args, :($(X[j,k]) = A.data[$(LinearIndices(sa)[j, j])] \ $(X[j,k])))
             for i = j-1:-1:1
-                push!(code.args, :($(X[i,k]) -= A.data[$(sub2ind(sa,i,j))]*$(X[j,k])))
+                push!(code.args, :($(X[i,k]) -= A.data[$(LinearIndices(sa)[i, j])]*$(X[j,k])))
             end
         end
     end
@@ -404,17 +404,17 @@ end
     end
 
     X = [Symbol("X_$(i)_$(j)") for i = 1:m, j = 1:n]
-    init = [:($(X[i,j]) = B[$(sub2ind(sb,i,j))]) for i = 1:m, j = 1:n]
+    init = [:($(X[i,j]) = B[$(LinearIndices(sb)[i, j])]) for i = 1:m, j = 1:n]
 
     code = quote end
     for k = 1:n
         for j = 1:m
             if k == 1
-                push!(code.args, :(A.data[$(sub2ind(sa,j,j))] == zero(A.data[$(sub2ind(sa,j,j))]) && throw(LinearAlgebra.SingularException($j))))
+                push!(code.args, :(A.data[$(LinearIndices(sa)[j, j])] == zero(A.data[$(LinearIndices(sa)[j, j])]) && throw(LinearAlgebra.SingularException($j))))
             end
-            push!(code.args, :($(X[j,k]) = A.data[$(sub2ind(sa,j,j))] \ $(X[j,k])))
+            push!(code.args, :($(X[j,k]) = A.data[$(LinearIndices(sa)[j, j])] \ $(X[j,k])))
             for i = j+1:m
-                push!(code.args, :($(X[i,k]) -= A.data[$(sub2ind(sa,i,j))]*$(X[j,k])))
+                push!(code.args, :($(X[i,k]) -= A.data[$(LinearIndices(sa)[i, j])]*$(X[j,k])))
             end
         end
     end
@@ -440,14 +440,14 @@ end
     code = quote end
     for k = 1:n
         for j = 1:m
-            ex = :(B[$(sub2ind(sb,j,k))])
+            ex = :(B[$(LinearIndices(sb)[j, k])])
             for i = 1:j-1
-                ex = :($ex - A.data[$(sub2ind(sa,i,j))]'*$(X[i,k]))
+                ex = :($ex - A.data[$(LinearIndices(sa)[i, j])]'*$(X[i,k]))
             end
             if k == 1
-                push!(code.args, :(A.data[$(sub2ind(sa,j,j))] == zero(A.data[$(sub2ind(sa,j,j))]) && throw(LinearAlgebra.SingularException($j))))
+                push!(code.args, :(A.data[$(LinearIndices(sa)[j, j])] == zero(A.data[$(LinearIndices(sa)[j, j])]) && throw(LinearAlgebra.SingularException($j))))
             end
-            push!(code.args, :($(X[j,k]) = A.data[$(sub2ind(sa,j,j))]' \ $ex))
+            push!(code.args, :($(X[j,k]) = A.data[$(LinearIndices(sa)[j, j])]' \ $ex))
         end
     end
 
@@ -471,14 +471,14 @@ end
     code = quote end
     for k = 1:n
         for j = 1:m
-            ex = :(B[$(sub2ind(sb,j,k))])
+            ex = :(B[$(LinearIndices(sb)[j, k])])
             for i = 1:j-1
-                ex = :($ex - A.data[$(sub2ind(sa,i,j))]*$(X[i,k]))
+                ex = :($ex - A.data[$(LinearIndices(sa)[i, j])]*$(X[i,k]))
             end
             if k == 1
-                push!(code.args, :(A.data[$(sub2ind(sa,j,j))] == zero(A.data[$(sub2ind(sa,j,j))]) && throw(LinearAlgebra.SingularException($j))))
+                push!(code.args, :(A.data[$(LinearIndices(sa)[j, j])] == zero(A.data[$(LinearIndices(sa)[j, j])]) && throw(LinearAlgebra.SingularException($j))))
             end
-            push!(code.args, :($(X[j,k]) = A.data[$(sub2ind(sa,j,j))] \ $ex))
+            push!(code.args, :($(X[j,k]) = A.data[$(LinearIndices(sa)[j, j])] \ $ex))
         end
     end
 
@@ -502,14 +502,14 @@ end
     code = quote end
     for k = 1:n
         for j = m:-1:1
-            ex = :(B[$(sub2ind(sb,j,k))])
+            ex = :(B[$(LinearIndices(sb)[j, k])])
             for i = m:-1:j+1
-                ex = :($ex - A.data[$(sub2ind(sa,i,j))]'*$(X[i,k]))
+                ex = :($ex - A.data[$(LinearIndices(sa)[i, j])]'*$(X[i,k]))
             end
             if k == 1
-                push!(code.args, :(A.data[$(sub2ind(sa,j,j))] == zero(A.data[$(sub2ind(sa,j,j))]) && throw(LinearAlgebra.SingularException($j))))
+                push!(code.args, :(A.data[$(LinearIndices(sa)[j, j])] == zero(A.data[$(LinearIndices(sa)[j, j])]) && throw(LinearAlgebra.SingularException($j))))
             end
-            push!(code.args, :($(X[j,k]) = A.data[$(sub2ind(sa,j,j))]' \ $ex))
+            push!(code.args, :($(X[j,k]) = A.data[$(LinearIndices(sa)[j, j])]' \ $ex))
         end
     end
 
@@ -533,14 +533,14 @@ end
     code = quote end
     for k = 1:n
         for j = m:-1:1
-            ex = :(B[$(sub2ind(sb,j,k))])
+            ex = :(B[$(LinearIndices(sb)[j, k])])
             for i = m:-1:j+1
-                ex = :($ex - A.data[$(sub2ind(sa,i,j))]*$(X[i,k]))
+                ex = :($ex - A.data[$(LinearIndices(sa)[i, j])]*$(X[i,k]))
             end
             if k == 1
-                push!(code.args, :(A.data[$(sub2ind(sa,j,j))] == zero(A.data[$(sub2ind(sa,j,j))]) && throw(LinearAlgebra.SingularException($j))))
+                push!(code.args, :(A.data[$(LinearIndices(sa)[j, j])] == zero(A.data[$(LinearIndices(sa)[j, j])]) && throw(LinearAlgebra.SingularException($j))))
             end
-            push!(code.args, :($(X[j,k]) = A.data[$(sub2ind(sa,j,j))] \ $ex))
+            push!(code.args, :($(X[j,k]) = A.data[$(LinearIndices(sa)[j, j])] \ $ex))
         end
     end
 


### PR DESCRIPTION
Mostly mechanical changes.

I did some very basic benchmarking of `sub2ind(s, i, j)` vs. `LinearIndices(s)[i,j]` and it looks like the latter on 0.7 is indeed equal to the former on 0.6 performance-wise, but `Compat.LinearIndices` (on 0.6) seems to be a tiny bit slower. Fortunately, these are almost only used in `@generated` function generators where performance is less of a concern. The only exception is `setindex` where I have introduced a `VERSION` dependency to be on the safe (performance) side.