### PR TITLE
Fix #385, broadcast! with non-static LHS broken on Julia master 

### DIFF
--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -226,7 +226,7 @@ end
 
     return quote
         @_inline_meta
-        sizematch($(Size{newsize}()), dest) || throw(DimensionMismatch("array could not be broadcast to match destination"))
+        @boundscheck sizematch($(Size{newsize}()), dest) || throw(DimensionMismatch("array could not be broadcast to match destination"))
         @inbounds $(Expr(:block, exprs...))
         return dest
     end

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -190,7 +190,8 @@ end
     sizes = tuple(sizes...)
 
     # TODO: this could also be done outside the generated function:
-    sizematch(Size{newsize}(), Size(dest)) || throw(DimensionMismatch("Tried to broadcast to destination sized $newsize from inputs sized $sizes"))
+    sizematch(Size{newsize}(), Size(dest)) ||
+        throw(DimensionMismatch("Tried to broadcast to destination sized $newsize from inputs sized $sizes"))
 
     ndims = 0
     for i = 1:length(sizes)
@@ -225,6 +226,7 @@ end
 
     return quote
         @_inline_meta
+        sizematch($(Size{newsize}()), dest) || throw(DimensionMismatch("array could not be broadcast to match destination"))
         @inbounds $(Expr(:block, exprs...))
         return dest
     end

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -36,9 +36,7 @@
         _broadcast(f, combine_sizes(argsizes), argsizes, as...)
     end
 
-    # TODO: This signature could be relaxed to (::Any, ::Type{StaticArray}, ::Type, ...), though
-    # we'd need to rework how _broadcast!() and broadcast_sizes() interact with normal AbstractArray.
-    @inline function broadcast_c!(f, ::Type{StaticArray}, ::Type{StaticArray}, dest, as...)
+    @inline function broadcast_c!(f, ::Type, ::Type{StaticArray}, dest, as...)
         argsizes = broadcast_sizes(as...)
         _broadcast!(f, broadcast_dest_size(broadcast_size(dest), combine_sizes(argsizes)), dest, argsizes, as...)
     end

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -22,24 +22,41 @@ dimmatch(x::StaticDimension, y::StaticDimension) = true
 """
     Size(dims::Int...)
 
-`Size` is used extensively in throughout the `StaticArrays` API to describe the size of a
-static array desired by the user. The dimensions are stored as a type parameter and are
-statically propagated by the compiler, resulting in efficient, type inferrable code. For
+`Size` is used extensively throughout the `StaticArrays` API to describe _compile-time_
+knowledge of the size of an array. The dimensions are stored as a type parameter and are
+statically propagated by the compiler, resulting in efficient, type-inferrable code. For
 example, to create a static matrix of zeros, use `zeros(Size(3,3))` (rather than
 `zeros(3,3)`, which constructs a `Base.Array`).
 
-    Size(a::StaticArray)
-    Size(::Type{T<:StaticArray})
-
-Extract the `Size` corresponding to the given static array. This has multiple uses,
-including using for "trait"-based dispatch on the size of a statically sized array. For
-example:
+```julia
+Size(a::StaticArray)
+Size(::Type{T<:StaticArray})
 ```
+
+Note that if dimensions are not known statically (e.g., for standard `Array`s),
+[`Dynamic()`](@ref) should be used instead of an `Int`.
+
+The `Size` constructor can be used to extract static dimension information from a given
+array. For example:
+
+```julia-repl
+julia> Size(zeros(SMatrix{3, 4}))
+Size(3, 4)
+
+julia> Size(zeros(3, 4))
+Size(StaticArrays.Dynamic(), StaticArrays.Dynamic())
+```
+
+This has multiple uses, including "trait"-based dispatch on the size of a statically-sized
+array. For example:
+
+```julia
 det(x::StaticMatrix) = _det(Size(x), x)
 _det(::Size{(1,1)}, x::StaticMatrix) = x[1,1]
 _det(::Size{(2,2)}, x::StaticMatrix) = x[1,1]*x[2,2] - x[1,2]*x[2,1]
 # and other definitions as necessary
 ```
+
 """
 struct Size{S}
     function Size{S}() where {S}

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -177,5 +177,8 @@ end
         c = SVector(1, 2, 3)
         a .= c
         @test a == [1 1 1; 2 2 2; 3 3 3]
+
+        d = SVector(1, 2, 3, 4)
+        @test_throws DimensionMismatch a .= d
     end
 end

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -166,4 +166,12 @@ end
         @testinf broadcast!(identity, mv, Ref(aX)) == MVector(aX,aX,aX)
         @test mv == SVector(aX,aX,aX)
     end
+
+    @testset "broadcast! with Array destination" begin
+        # Issue #385
+        a = zeros(3, 3)
+        b = ones(SMatrix{3, 3})
+        a .= b
+        @test a == b
+    end
 end

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -170,8 +170,12 @@ end
     @testset "broadcast! with Array destination" begin
         # Issue #385
         a = zeros(3, 3)
-        b = ones(SMatrix{3, 3})
+        b = @SMatrix [1 2 3; 4 5 6; 7 8 9]
         a .= b
         @test a == b
+
+        c = SVector(1, 2, 3)
+        a .= c
+        @test a == [1 1 1; 2 2 2; 3 3 3]
     end
 end

--- a/test/core.jl
+++ b/test/core.jl
@@ -142,4 +142,39 @@
     @test StaticArrays.check_length(StaticArrays.Dynamic()) == nothing
 
     @test convert(Tuple, @SVector [2]) == (2,)
+
+    @testset "dimmatch" begin
+        @test StaticArrays.dimmatch(3, 3)
+        @test StaticArrays.dimmatch(3, StaticArrays.Dynamic())
+        @test StaticArrays.dimmatch(StaticArrays.Dynamic(), 3)
+        @test StaticArrays.dimmatch(StaticArrays.Dynamic(), StaticArrays.Dynamic())
+
+        @test !StaticArrays.dimmatch(3, 2)
+    end
+
+    @testset "sizematch" begin
+        @test StaticArrays.sizematch(Size(1, 2, 3), Size(1, 2, 3))
+        @test StaticArrays.sizematch(Size(1, StaticArrays.Dynamic(), 3), Size(1, 2, 3))
+        @test StaticArrays.sizematch(Size(1, 2, 3), Size(1, StaticArrays.Dynamic(), 3))
+        @test StaticArrays.sizematch(Size(StaticArrays.Dynamic()), Size(StaticArrays.Dynamic()))
+
+        @test !StaticArrays.sizematch(Size(1, 2, 3), Size(1, 2, 4))
+        @test !StaticArrays.sizematch(Size(2, 2, 3), Size(1, 2, 3))
+        @test !StaticArrays.sizematch(Size(2, 2, StaticArrays.Dynamic()), Size(1, 2, 3))
+        @test !StaticArrays.sizematch(Size(1, 2), Size(1, 2, 3))
+        @test !StaticArrays.sizematch(Size(1, 2, 3), Size(1, 2))
+
+        sa = SArray{Tuple{2,3}, Int}((3, 4, 5, 6, 7, 8))
+        a = [3 5 7; 4 6 8]
+
+        @test StaticArrays.sizematch(Size(2, 3), sa)
+        @test StaticArrays.sizematch(Size(2, StaticArrays.Dynamic()), sa)
+        @test StaticArrays.sizematch(Size(2, 3), a)
+        @test StaticArrays.sizematch(Size(2, StaticArrays.Dynamic()), a)
+
+        @test !StaticArrays.sizematch(Size(2, 2), sa)
+        @test !StaticArrays.sizematch(Size(3, StaticArrays.Dynamic()), sa)
+        @test !StaticArrays.sizematch(Size(2, 2), a)
+        @test !StaticArrays.sizematch(Size(3, StaticArrays.Dynamic()), a)
+    end
 end

--- a/test/core.jl
+++ b/test/core.jl
@@ -139,6 +139,7 @@
     @test Tuple{2, 3, 5} != StaticArrays.Size{(2, 3, 4)}
     @test StaticArrays.Size{(2, 3, 4)} != Tuple{2, 3, 5}
     @test StaticArrays.check_length(2) == nothing
+    @test StaticArrays.check_length(StaticArrays.Dynamic()) == nothing
 
     @test convert(Tuple, @SVector [2]) == (2,)
 end


### PR DESCRIPTION
Fix #385.

* extract `broadcast_size` function out of `broadcast_sizes`, which returns a single `Size` for a single ~~`AbstractArray`~~ argument
* extract `combine_sizes` function (similar to `Base.Broadcast.combine_indices`) out of `_broadcast`, to determine the appropriate destination `Size` from the right hand side arguments (`as...`)
~~* add `broadcast_dest_size` function, used by `broadcast!`, which selects the correct `Size` and checks that sizes match, given `broadcast_size(dest)` and `combine_sizes(broadcast_sizes(as...))`~~

~~On 0.6, `broadcast!` with a non-static LHS dispatches to generic `broadcast!` code in Base, both before this PR and after, meaning that some of this code won't get coverage on 0.6. I can change that if desired; it would probably result in a speedup as well.~~

Edit: I went ahead and pulled the trigger on this since it resolves a TODO.