### PR TITLE
Fix #382: stack overflow from `SVector(1,1)' .+ [1, 1]`

### DIFF
--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -14,6 +14,9 @@
     _containertype(::Type{<:StaticArray}) = StaticArray
     _containertype(::Type{<:Adjoint{<:Any,<:StaticVector}}) = StaticArray
 
+    # issue #382; prevent infinite recursion in generic broadcast code:
+    Base.Broadcast.broadcast_indices(::Type{StaticArray}, A) = indices(A)
+
     # With the above, the default promote_containertype gives reasonable defaults:
     #   StaticArray, StaticArray -> StaticArray
     #   Array, StaticArray       -> Array

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -90,6 +90,8 @@ end
         @test @inferred(SVector{0,Int}() .+ SVector(1)) === SVector{0,Int}()
         # Issue #200: broadcast with Adjoint
         @test @inferred(v1 .+ v2') === @SMatrix [2 5; 3 6]
+        # Issue 382: infinite recursion in Base.Broadcast.broadcast_indices with Adjoint
+        @test @inferred(SVector(1,1)' .+ [1, 1]) == [2 2; 2 2]
     end
 
     @testset "StaticVector with Scalar" begin


### PR DESCRIPTION
Fixes infinite recursion with generic broadcast code.