### PR TITLE
diagm 0.7-style

### DIFF
--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -200,8 +200,11 @@ end
     end
 end
 
-# old interface, to be deprecated/deleted eventually
-@inline diagm(v::StaticVector, k::Type{Val{D}}=Val{0}) where {D} = diagm(k() => v)
+if VERSION < v"v0.7.0-DEV.2161"
+    @inline diagm(v::StaticVector, k::Type{Val{D}}=Val{0}) where {D} = diagm(k() => v)
+else
+    @deprecate(diagm(v::StaticVector, k::Type{Val{D}}=Val{0}) where {D}, diagm(k() => v))
+end
 
 @inline diag(m::StaticMatrix, k::Type{Val{D}}=Val{0}) where {D} = _diag(Size(m), m, k)
 @generated function _diag(::Size{S}, m::StaticMatrix, ::Type{Val{D}}) where {S,D}

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -182,23 +182,26 @@ end
     end
 #end
 
-@inline diagm(v::StaticVector, k::Type{Val{D}}=Val{0}) where {D} = _diagm(Size(v), v, k)
-@generated function _diagm(::Size{S}, v::StaticVector, ::Type{Val{D}}) where {S,D}
-    S1 = S[1]
-    Snew1 = S1+abs(D)
-    Snew = (Snew1, Snew1)
-    Lnew = Snew1 * Snew1
-    T = eltype(v)
-    ind = diagind(Snew1, Snew1, D)
-    exprs = fill(:(zero($T)), Lnew)
-    for n = 1:S[1]
-        exprs[ind[n]] = :(v[$n])
+@generated function diagm(kvs::Pair{<:Val,<:StaticVector}...)
+    N = maximum(abs(kv.parameters[1].parameters[1]) + length(kv.parameters[2]) for kv in kvs)
+    X = [Symbol("x_$(i)_$(j)") for i in 1:N, j in 1:N]
+    T = promote_type((eltype(kv.parameters[2]) for kv in kvs)...)
+    exprs = fill(:(zero($T)), N*N)
+    for m in eachindex(kvs)
+        kv = kvs[m]
+        ind = diagind(N, N, kv.parameters[1].parameters[1])
+        for n = 1:length(kv.parameters[2])
+            exprs[ind[n]] = :(kvs[$m].second[$n])
+        end
     end
     return quote
         $(Expr(:meta, :inline))
-        @inbounds return similar_type($v, Size($Snew))(tuple($(exprs...)))
+        @inbounds return SMatrix{$N,$N,$T}(tuple($(exprs...)))
     end
 end
+
+# old interface, to be deprecated/deleted eventually
+@inline diagm(v::StaticVector, k::Type{Val{D}}=Val{0}) where {D} = diagm(k() => v)
 
 @inline diag(m::StaticMatrix, k::Type{Val{D}}=Val{0}) where {D} = _diag(Size(m), m, k)
 @generated function _diag(::Size{S}, m::StaticMatrix, ::Type{Val{D}}) where {S,D}

--- a/test/SDiagonal.jl
+++ b/test/SDiagonal.jl
@@ -22,13 +22,13 @@
     
         @test StaticArrays.scalem(@SMatrix([1 1 1;1 1 1; 1 1 1]), @SVector [1,2,3]) === @SArray [1 2 3; 1 2 3; 1 2 3]
         @test StaticArrays.scalem(@SVector([1,2,3]),@SMatrix [1 1 1;1 1 1; 1 1 1])' === @SArray [1 2 3; 1 2 3; 1 2 3]
-    
-        m = SDiagonal(@SVector [11, 12, 13, 14])  
-        
-        @test diag(m) === m.diag 
-     
-        m2 = diagm([11, 12, 13, 14])
-     
+
+        m = SDiagonal(@SVector [11, 12, 13, 14])
+
+        @test diag(m) === m.diag
+
+        m2 = diagm(0 => [11, 12, 13, 14])
+
         @test logdet(m) == logdet(m2)
         @test logdet(im*m) ≈ logdet(im*m2)
         @test det(m) == det(m2)
@@ -113,7 +113,7 @@
         @test m\[1; 1; 1; 1] == [11; 12; 13; 14].\[1; 1; 1; 1]
         @test SMatrix{4,4}(Matrix{Float64}(I, 4, 4))*m == m
         @test m*SMatrix{4,4}(Matrix{Float64}(I, 4, 4)) == m
-        @test SMatrix{4,4}(Matrix{Float64}(I, 4, 4))/m == diagm([11; 12; 13; 14].\[1; 1; 1; 1])
-        @test m\SMatrix{4,4}(Matrix{Float64}(I, 4, 4)) == diagm([11; 12; 13; 14].\[1; 1; 1; 1])
+        @test SMatrix{4,4}(Matrix{Float64}(I, 4, 4))/m == diagm(0 => [11; 12; 13; 14].\[1; 1; 1; 1])
+        @test m\SMatrix{4,4}(Matrix{Float64}(I, 4, 4)) == diagm(0 => [11; 12; 13; 14].\[1; 1; 1; 1])
     end
 end

--- a/test/eigen.jl
+++ b/test/eigen.jl
@@ -30,35 +30,35 @@
         (vals, vecs) = eig(m)
         @test vals::SVector ≈ vals_a
         @test eigvals(m) ≈ vals
-        @test (vecs*diagm(vals)*vecs')::SMatrix ≈ m
+        @test (vecs*diagm(Val(0) => vals)*vecs')::SMatrix ≈ m
         ef = eigfact(m)
         @test ef[:values]::SVector ≈ vals_a
-        @test (ef[:vectors]*diagm(vals)*ef[:vectors]')::SMatrix ≈ m
+        @test (ef[:vectors]*diagm(Val(0) => vals)*ef[:vectors]')::SMatrix ≈ m
 
         (vals, vecs) = eig(Symmetric(m))
         @test vals::SVector ≈ vals_a
         @test eigvals(m) ≈ vals
-        @test (vecs*diagm(vals)*vecs')::SMatrix ≈ m
+        @test (vecs*diagm(Val(0) => vals)*vecs')::SMatrix ≈ m
         ef = eigfact(Symmetric(m))
         @test ef[:values]::SVector ≈ vals_a
-        @test (ef[:vectors]*diagm(vals)*ef[:vectors]')::SMatrix ≈ m
+        @test (ef[:vectors]*diagm(Val(0) => vals)*ef[:vectors]')::SMatrix ≈ m
         ef = eigfact(Symmetric(m, :L))
         @test ef[:values]::SVector ≈ vals_a
-        @test (ef[:vectors]*diagm(vals)*ef[:vectors]')::SMatrix ≈ m
+        @test (ef[:vectors]*diagm(Val(0) => vals)*ef[:vectors]')::SMatrix ≈ m
 
         (vals, vecs) = eig(Hermitian(m))
         @test vals::SVector ≈ vals_a
         @test eigvals(Hermitian(m)) ≈ vals
         @test eigvals(Hermitian(m, :L)) ≈ vals
-        @test (vecs*diagm(vals)*vecs')::SMatrix ≈ m
+        @test (vecs*diagm(Val(0) => vals)*vecs')::SMatrix ≈ m
         ef = eigfact(Hermitian(m))
         @test ef[:values]::SVector ≈ vals_a
-        @test (ef[:vectors]*diagm(vals)*ef[:vectors]')::SMatrix ≈ m
+        @test (ef[:vectors]*diagm(Val(0) => vals)*ef[:vectors]')::SMatrix ≈ m
         ef = eigfact(Hermitian(m, :L))
         @test ef[:values]::SVector ≈ vals_a
-        @test (ef[:vectors]*diagm(vals)*ef[:vectors]')::SMatrix ≈ m
+        @test (ef[:vectors]*diagm(Val(0) => vals)*ef[:vectors]')::SMatrix ≈ m
 
-        m_d = randn(SVector{2}); m = diagm(m_d)
+        m_d = randn(SVector{2}); m = diagm(Val(0) => m_d)
         (vals, vecs) = eig(Hermitian(m))
         @test vals::SVector ≈ sort(m_d)
         (vals, vecs) = eig(Hermitian(m, :L))
@@ -76,19 +76,19 @@
         (vals, vecs) = eig(m)
         @test vals::SVector ≈ vals_a
         @test eigvals(m) ≈ vals
-        @test (vecs*diagm(vals)*vecs')::SMatrix ≈ m
+        @test (vecs*diagm(Val(0) => vals)*vecs')::SMatrix ≈ m
 
         (vals, vecs) = eig(Symmetric(m))
         @test vals::SVector ≈ vals_a
         @test eigvals(m) ≈ vals
         @test eigvals(Hermitian(m)) ≈ vals
         @test eigvals(Hermitian(m, :L)) ≈ vals
-        @test (vecs*diagm(vals)*vecs')::SMatrix ≈ m
+        @test (vecs*diagm(Val(0) => vals)*vecs')::SMatrix ≈ m
 
         (vals, vecs) = eig(Symmetric(m, :L))
         @test vals::SVector ≈ vals_a
 
-        m_d = randn(SVector{3}); m = diagm(m_d)
+        m_d = randn(SVector{3}); m = diagm(Val(0) => m_d)
         (vals, vecs) = eig(Hermitian(m))
         @test vals::SVector ≈ sort(m_d)
         (vals, vecs) = eig(Hermitian(m, :L))
@@ -146,7 +146,7 @@
         vals, vecs = eig(m)::Tuple{SVector,SMatrix}
 
         @test vals ≈ [0.0, 1.0, 2.0]
-        @test vecs*diagm(vals)*vecs' ≈ m
+        @test vecs*diagm(Val(0) => vals)*vecs' ≈ m
         @test eigvals(m) ≈ vals
 
         m = @SMatrix [1.0 0.0 1.0;
@@ -155,7 +155,7 @@
         vals, vecs = eig(m)::Tuple{SVector,SMatrix}
 
         @test vals ≈ [0.0, 1.0, 2.0]
-        @test vecs*diagm(vals)*vecs' ≈ m
+        @test vecs*diagm(Val(0) => vals)*vecs' ≈ m
         @test eigvals(m) ≈ vals
 
         m = @SMatrix [1.0 1.0 0.0;
@@ -164,7 +164,7 @@
         vals, vecs = eig(m)::Tuple{SVector,SMatrix}
 
         @test vals ≈ [0.0, 1.0, 2.0]
-        @test vecs*diagm(vals)*vecs' ≈ m
+        @test vecs*diagm(Val(0) => vals)*vecs' ≈ m
         @test eigvals(m) ≈ vals
     end
 
@@ -177,18 +177,18 @@
         (vals, vecs) = eig(m)
         @test vals::SVector ≈ vals_a
         @test eigvals(m) ≈ vals
-        @test (vecs*diagm(vals)*vecs')::SMatrix ≈ m
+        @test (vecs*diagm(Val(0) => vals)*vecs')::SMatrix ≈ m
 
         (vals, vecs) = eig(Symmetric(m))
         @test vals::SVector ≈ vals_a
         @test eigvals(m) ≈ vals
         @test eigvals(Hermitian(m)) ≈ vals
         @test eigvals(Hermitian(m, :L)) ≈ vals
-        @test (vecs*diagm(vals)*vecs')::SMatrix ≈ m
+        @test (vecs*diagm(Val(0) => vals)*vecs')::SMatrix ≈ m
 
         (vals, vecs) = eig(Symmetric(m, :L))
         @test vals::SVector ≈ vals_a
-        m_d = randn(SVector{4}); m = diagm(m_d)
+        m_d = randn(SVector{4}); m = diagm(Val(0) => m_d)
         (vals, vecs) = eig(Hermitian(m))
         @test vals::SVector ≈ sort(m_d)
         (vals, vecs) = eig(Hermitian(m, :L))
@@ -207,8 +207,8 @@
             A = Hermitian(SMatrix{n,n}(a))
             D,V = eig(A)
             @test V'V ≈ eye(n)
-            @test V*diagm(D)*V' ≈ A
-            @test V'*A*V ≈ diagm(D)
+            @test V*diagm(Val(0) => D)*V' ≈ A
+            @test V'*A*V ≈ diagm(Val(0) => D)
         end
     end
 end

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -40,9 +40,14 @@ using StaticArrays, Base.Test
     end
 
     @testset "diagm()" begin
+        @test @inferred(diagm(Val(0) => SVector(1,2))) === @SMatrix [1 0; 0 2]
+        @test @inferred(diagm(Val(2) => SVector(1,2,3)))::SMatrix == diagm(2 => [1,2,3])
+        @test @inferred(diagm(Val(-2) => SVector(1,2,3)))::SMatrix == diagm(-2 => [1,2,3])
+        @test @inferred(diagm(Val(-2) => SVector(1,2,3), Val(1) => SVector(4,5)))::SMatrix == diagm(-2 => [1,2,3], 1 => [4,5])
+        # old interface, to be deprecated/deleted eventually
         @test @inferred(diagm(SVector(1,2))) === @SMatrix [1 0; 0 2]
-        @test @inferred(diagm(SVector(1,2,3), Val{2}))::SMatrix == diagm([1,2,3], 2)
-        @test @inferred(diagm(SVector(1,2,3), Val{-2}))::SMatrix == diagm([1,2,3], -2)
+        @test @inferred(diagm(SVector(1,2,3), Val{2}))::SMatrix == diagm(2 => [1,2,3])
+        @test @inferred(diagm(SVector(1,2,3), Val{-2}))::SMatrix == diagm(-2 => [1,2,3])
     end
 
     @testset "diag()" begin

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -44,10 +44,12 @@ using StaticArrays, Base.Test
         @test @inferred(diagm(Val(2) => SVector(1,2,3)))::SMatrix == diagm(2 => [1,2,3])
         @test @inferred(diagm(Val(-2) => SVector(1,2,3)))::SMatrix == diagm(-2 => [1,2,3])
         @test @inferred(diagm(Val(-2) => SVector(1,2,3), Val(1) => SVector(4,5)))::SMatrix == diagm(-2 => [1,2,3], 1 => [4,5])
-        # old interface, to be deprecated/deleted eventually
-        @test @inferred(diagm(SVector(1,2))) === @SMatrix [1 0; 0 2]
-        @test @inferred(diagm(SVector(1,2,3), Val{2}))::SMatrix == diagm(2 => [1,2,3])
-        @test @inferred(diagm(SVector(1,2,3), Val{-2}))::SMatrix == diagm(-2 => [1,2,3])
+	if VERSION < v"0.7.0-DEV.2161"
+            # old interface, deprecated in Julia 0.7
+            @test @inferred(diagm(SVector(1,2))) === @SMatrix [1 0; 0 2]
+            @test @inferred(diagm(SVector(1,2,3), Val{2}))::SMatrix == diagm(2 => [1,2,3])
+            @test @inferred(diagm(SVector(1,2,3), Val{-2}))::SMatrix == diagm(-2 => [1,2,3])
+	end
     end
 
     @testset "diag()" begin


### PR DESCRIPTION
Add `diagm(k1 => v1, k2 => v2, ...)` style interface, where the diagonals `k` are given as `Val` instances (not types!). Also use this syntax in the tests when calling `Base.diagm` to avoid deprecation warnings on Julia 0.7.

The old interface is left in place, but should be deprecated/deleted eventually.