### PR TITLE
Make Cholesky factorization compatible with 0.7

### DIFF
--- a/src/SDiagonal.jl
+++ b/src/SDiagonal.jl
@@ -94,7 +94,7 @@ else
     log(D::SDiagonal) = SDiagonal(log.(D.diag))
     sqrt(D::SDiagonal) = SDiagonal(sqrt.(D.diag))
 end
-LinearAlgebra.chol(D::SDiagonal) = SDiagonal(Base.chol.(D.diag))
+LinearAlgebra.chol(D::SDiagonal) = SDiagonal(chol.(D.diag))
 LinearAlgebra._chol!(D::SDiagonal, ::Type{UpperTriangular}) = chol(D)
 
 \(D::SDiagonal, B::StaticMatrix) = scalem(1 ./ D.diag, B)
@@ -112,4 +112,3 @@ function inv(D::SDiagonal)
     check_singular(D)
     SDiagonal(inv.(D.diag))
 end
-

--- a/test/SDiagonal.jl
+++ b/test/SDiagonal.jl
@@ -1,8 +1,10 @@
+using Compat.LinearAlgebra: chol
+
 @testset "SDiagonal" begin
     @testset "Constructors" begin
         @test SDiagonal{1,Int64}((1,)).diag === SVector{1,Int64}((1,))
         @test SDiagonal{1,Float64}((1,)).diag === SVector{1,Float64}((1,))
-     
+
         @test SDiagonal{4,Float64}((1, 1.0, 1, 1)).diag.data === (1.0, 1.0, 1.0, 1.0)
         @test SDiagonal{4}((1, 1.0, 1, 1)).diag.data === (1.0, 1.0, 1.0, 1.0)
         @test SDiagonal((1, 1.0, 1, 1)).diag.data === (1.0, 1.0, 1.0, 1.0)

--- a/test/chol.jl
+++ b/test/chol.jl
@@ -1,4 +1,11 @@
+using StaticArrays, Compat, Compat.Test, Compat.LinearAlgebra
+
 @testset "Cholesky decomposition" begin
+    if !isdefined(Compat.LinearAlgebra, :non_hermitian_error)
+        PosDefException = Compat.LinearAlgebra.PosDefException
+    else
+        PosDefException = ArgumentError
+    end
     @testset "1×1" begin
         m = @SMatrix [4.0]
         (c,) = chol(m)
@@ -8,7 +15,7 @@
     @testset "2×2" for i = 1:100
         m_a = randn(2,2)
         #non hermitian
-        @test_throws ArgumentError chol(SMatrix{2,2}(m_a))
+        @test_throws PosDefException chol(SMatrix{2,2}(m_a))
         m_a = m_a*m_a'
         m = SMatrix{2,2}(m_a)
         @test chol(Hermitian(m)) ≈ chol(m_a)
@@ -17,7 +24,7 @@
     @testset "3×3" for i = 1:100
         m_a = randn(3,3)
         #non hermitian
-        @test_throws ArgumentError chol(SMatrix{3,3}(m_a))
+        @test_throws PosDefException chol(SMatrix{3,3}(m_a))
         m_a = m_a*m_a'
         m = SMatrix{3,3}(m_a)
         @test chol(m) ≈ chol(m_a)
@@ -26,7 +33,7 @@
     @testset "4×4" for i = 1:100
         m_a = randn(4,4)
         #non hermitian
-        @test_throws ArgumentError chol(SMatrix{4,4}(m_a))
+        @test_throws PosDefException chol(SMatrix{4,4}(m_a))
         m_a = m_a*m_a'
         m = SMatrix{4,4}(m_a)
         @test chol(m) ≈ chol(m_a)
@@ -36,7 +43,7 @@
         m_a = randn(3,3)
         m_a = m_a*m_a'
         m = SMatrix{3,3}(m_a)
-        @test chol(reshape([m, 0m, 0m, m], 2, 2)) == 
+        @test chol(reshape([m, 0m, 0m, m], 2, 2)) ==
             reshape([chol(m), 0m, 0m, chol(m)], 2, 2)
     end
 end


### PR DESCRIPTION
Note that the error handling is still a bit different as `_chol!` still throws an error instead of returning a non-zero `info`.