### PR TITLE
make transpose and ctranspose recursive like Base

### DIFF
--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -65,7 +65,7 @@ end
 @generated function _transpose(::Size{S}, m::StaticMatrix) where {S}
     Snew = (S[2], S[1])
 
-    exprs = [:(m[$(LinearIndices(S)[j1, j2])]) for j2 = 1:S[2], j1 = 1:S[1]]
+    exprs = [:(transpose(m[$(LinearIndices(S)[j1, j2])])) for j2 = 1:S[2], j1 = 1:S[1]]
 
     return quote
         $(Expr(:meta, :inline))
@@ -82,7 +82,7 @@ end
 @generated function _adjoint(::Size{S}, m::StaticMatrix) where {S}
     Snew = (S[2], S[1])
 
-    exprs = [:(conj(m[$(LinearIndices(S)[j1, j2])])) for j2 = 1:S[2], j1 = 1:S[1]]
+    exprs = [:(ctranspose(m[$(LinearIndices(S)[j1, j2])])) for j2 = 1:S[2], j1 = 1:S[1]]
 
     return quote
         $(Expr(:meta, :inline))

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -82,7 +82,7 @@ end
 @generated function _adjoint(::Size{S}, m::StaticMatrix) where {S}
     Snew = (S[2], S[1])
 
-    exprs = [:(ctranspose(m[$(LinearIndices(S)[j1, j2])])) for j2 = 1:S[2], j1 = 1:S[1]]
+    exprs = [:(adjoint(m[$(LinearIndices(S)[j1, j2])])) for j2 = 1:S[2], j1 = 1:S[1]]
 
     return quote
         $(Expr(:meta, :inline))

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -124,7 +124,9 @@ using StaticArrays, Compat.Test
         
         m = [1 2; 3 4] + im*[5 6; 7 8]
         @test @inferred(ctranspose(@SVector [m,m])) == ctranspose([m,m])
+        @test @inferred(transpose(@SVector [m,m])) == transpose([m,m])
         @test @inferred(ctranspose(@SMatrix [m m; m m])) == ctranspose([[m] [m]; [m] [m]])
+        @test @inferred(transpose(@SMatrix [m m; m m])) == transpose([[m] [m]; [m] [m]])
 
     end
 

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -123,9 +123,9 @@ using StaticArrays, Compat.Test
         @test @inferred(adjoint(@SMatrix([1 2*im 3; 4 5 6]))) === @SMatrix([1 4; -2*im 5; 3 6])
         
         m = [1 2; 3 4] + im*[5 6; 7 8]
-        @test @inferred(ctranspose(@SVector [m,m])) == ctranspose([m,m])
+        @test @inferred(adjoint(@SVector [m,m])) == ctranspose([m,m])
         @test @inferred(transpose(@SVector [m,m])) == transpose([m,m])
-        @test @inferred(ctranspose(@SMatrix [m m; m m])) == ctranspose([[m] [m]; [m] [m]])
+        @test @inferred(adjoint(@SMatrix [m m; m m])) == ctranspose([[m] [m]; [m] [m]])
         @test @inferred(transpose(@SMatrix [m m; m m])) == transpose([[m] [m]; [m] [m]])
 
     end

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -121,6 +121,11 @@ using StaticArrays, Compat.Test
         @test @inferred(adjoint(@SMatrix([1 2; 0 3]))) === @SMatrix([1 0; 2 3])
         @test @inferred(adjoint(@SMatrix([1 2 3; 4 5 6]))) === @SMatrix([1 4; 2 5; 3 6])
         @test @inferred(adjoint(@SMatrix([1 2*im 3; 4 5 6]))) === @SMatrix([1 4; -2*im 5; 3 6])
+        
+        m = [1 2; 3 4] + im*[5 6; 7 8]
+        @test @inferred(ctranspose(@SVector [m,m])) == ctranspose([m,m])
+        @test @inferred(ctranspose(@SMatrix [m m; m m])) == ctranspose([[m] [m]; [m] [m]])
+
     end
 
     @testset "vcat() and hcat()" begin


### PR DESCRIPTION
Asking this question in the form a PR which can maybe be merged if the answer is yes, but shouldn't `transpose` and `ctranspose` be recursive like Base? 

For reference with Base (everything here is 0.6.2):

```julia
julia> [[[1 2; 3 4]] [[1 2; 3 4]]; [[1 2; 3 4]] [[1 2; 3 4]]]'
2×2 Array{Array{Int64,2},2}:
 [1 3; 2 4]  [1 3; 2 4]
 [1 3; 2 4]  [1 3; 2 4]
```
StaticArrays without this PR:
```julia
julia> (@SMatrix [[1 2; 3 4] [1 2; 3 4]; [1 2; 3 4] [1 2; 3 4]])'
2×2 StaticArrays.SArray{Tuple{2,2},Array{Int64,2},2,4}:
 [1 2; 3 4]  [1 2; 3 4]
 [1 2; 3 4]  [1 2; 3 4]                                                                                                        
```
and with it:
```julia
julia> (@SMatrix [[1 2; 3 4] [1 2; 3 4]; [1 2; 3 4] [1 2; 3 4]])'
2×2 StaticArrays.SArray{Tuple{2,2},Array{Int64,2},2,4}:
 [1 3; 2 4]  [1 3; 2 4]
 [1 3; 2 4]  [1 3; 2 4]
```
