### PR TITLE
Fix `setindex` for multidimensional arrays

### DIFF
--- a/src/deque.jl
+++ b/src/deque.jl
@@ -73,12 +73,12 @@ end
 # Immutable version of setindex!(). Seems similar in nature to the above, but
 # could also be justified to live in src/indexing.jl
 import Base.setindex
-@propagate_inbounds setindex(a::StaticArray, x, index::Int) = _setindex(Size(a), a, convert(eltype(typeof(a)), x), index)
-@generated function _setindex(::Size{s}, a::StaticArray{<:Any,T}, x::T, index::Int) where {s, T}
-    exprs = [:(ifelse($i == index, x, a[$i])) for i = 1:s[1]]
+@propagate_inbounds setindex(a::StaticArray, x, index::Int) = _setindex(Length(a), a, convert(eltype(typeof(a)), x), index)
+@generated function _setindex(::Length{L}, a::StaticArray{<:Any,T}, x::T, index::Int) where {L, T}
+    exprs = [:(ifelse($i == index, x, a[$i])) for i = 1:L]
     return quote
         @_propagate_inbounds_meta
-        @boundscheck if (index < 1 || index > $(s[1]))
+        @boundscheck if (index < 1 || index > $(L))
             throw(BoundsError(a, index))
         end
         @inbounds return typeof(a)(tuple($(exprs...)))

--- a/test/deque.jl
+++ b/test/deque.jl
@@ -17,8 +17,43 @@
     @test_throws BoundsError setindex(v, 2, -2)
 end
 
-@testset "setindex" begin
+@testset "setindex!" begin
     a = @MArray ones(3, 3, 3)
     a[2, 1, 3] = 2.
     @test a[2, 1, 3] == 2.
 end
+
+@testset "setindex" begin
+    v1 = @SVector [1., 2., 3.]
+    @test @inferred(setindex(v1, 5, 2)) == @SVector [1., 5., 3.]
+    @test @inferred(setindex(v1, 5.0, 2)) == @SVector [1., 5., 3.]
+    @test_throws BoundsError setindex(v1, 5.0, 0)
+    @test_throws BoundsError setindex(v1, 5.0, 4)
+
+    v2 = @SMatrix [1 2; 3 4]
+    @test @inferred(setindex(v2, 7, 1)) == @SMatrix [7 2; 3 4]
+    @test @inferred(setindex(v2, 7, 1, 1)) == @SMatrix [7 2; 3 4]
+    @test @inferred(setindex(v2, 7, 2)) == @SMatrix [1 2; 7 4]
+    @test @inferred(setindex(v2, 7, 2, 1)) == @SMatrix [1 2; 7 4]
+    @test @inferred(setindex(v2, 7, 3)) == @SMatrix [1 7; 3 4]
+    @test @inferred(setindex(v2, 7, 1, 2)) == @SMatrix [1 7; 3 4]
+    @test @inferred(setindex(v2, 7, 4)) == @SMatrix [1 2; 3 7]
+    @test @inferred(setindex(v2, 7, 2, 2)) == @SMatrix [1 2; 3 7]
+    @test_throws BoundsError setindex(v2, 7, 0)
+    @test_throws BoundsError setindex(v2, 7, 5)
+
+    v3 = @SArray ones(2, 2, 2)
+    @test @inferred(setindex(v3, 7, 2, 1, 2)) == reshape([1, 1, 1, 1, 1, 7, 1, 1], (2, 2, 2))
+    @test_throws BoundsError setindex(v3, 7, 0)
+    @test_throws BoundsError setindex(v3, 7, 9)
+
+    # TODO: still missing proper multidimensional bounds checking
+    # These should throw BoundsError, but don't
+    @test_broken setindex(v3, 7, 3, 1, 2)
+    @test_broken setindex(v3, 7, 2, 1, 0)
+end
+
+
+
+
+


### PR DESCRIPTION
This PR fixes setindex for multidimensional StaticArrays by using the `Length` trait instead of just pulling the first index from the `Size`. 

Fixes #401 

This doesn't resolve the still-existing issue that there's still no multi-dimensional bounds checking currently (I added two `@test_broken` tests to show the problem), so it's possible to call `setindex` using indices which are out of bounds for their individual axes, as long as the computed linear index is in range. AFAIK that doesn't create opportunity for segfaults or other bad behavior, but it's still something we should fix. 

