### PR TITLE
Adds more Kronecker product specialisations

### DIFF
--- a/src/util.jl
+++ b/src/util.jl
@@ -91,4 +91,5 @@ TrivialView(a::AbstractArray{T,N}) where {T,N} = TrivialView{typeof(a),T,N}(a)
 # than the input.
 # """
 @inline drop_sdims(a::StaticArray) = TrivialView(a)
+@inline drop_sdims(a::RowVector{<:Number, <:StaticArray}) = TrivialView(a)
 @inline drop_sdims(a) = a


### PR DESCRIPTION
Defines `kron` between two `StaticVector` types as well as between a `StaticVector` and a `StaticMatrix` type.  The definitions also include cases for transposed `StaticVector` types (i.e. a `StaticVector` wrapped by a `RowVector`type).

There are three broken tests which are due to the fact that taking the transpose of a `SizedArray` returns a `SMatrix`. I've made a comment in the relevant part of the test. Not sure of this behaviour of transpose is intentional or not? 
   