### PR TITLE
Adds a missing explicit `promote_type` to the set of `kron` definitions

### DIFF
--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -423,7 +423,7 @@ end
 
     return quote
         @_inline_meta
-        @inbounds return similar_type($a, Size($(outsize)))(tuple($(M...)))
+        @inbounds return similar_type($a, promote_type(eltype(a),eltype(b)), Size($(outsize)))(tuple($(M...)))
     end
 end
 


### PR DESCRIPTION
The definition of  `kron(a::StaticVector, b::RowVector{<:Number,<:StaticArray})` is missing an explicit `promote_type` rule in its return statement. The code works fine without the explicit statement but I'm adding it for `symmetry` because all of the other `kron` definitions include the explicit `promote_type` rule.