### PR TITLE
Resolve Scalar convert method ambiguity.

### DIFF
--- a/src/Scalar.jl
+++ b/src/Scalar.jl
@@ -12,6 +12,7 @@ const Scalar{T} = SArray{Tuple{},T,0,1}
 @inline function convert(::Type{SA}, a::AbstractArray) where {SA <: Scalar}
     return SA((a[],))
 end
+@inline convert(::Type{SA}, sa::SA) where {SA <: Scalar} = sa
 
 getindex(v::Scalar) = v.data[1]
 @inline function getindex(v::Scalar, i::Int)

--- a/test/Scalar.jl
+++ b/test/Scalar.jl
@@ -9,4 +9,6 @@
     a = Array{Float64, 0}(undef)
     a[] = 2
     @test Scalar(a)[] == 2
+    s = Scalar(a)
+    @test convert(typeof(s), s) === s
 end


### PR DESCRIPTION
Fixes #414 (but see discussion point in that issue). This was also broken on 0.6, but this method just wasn't being called.