### PR TITLE
Specialize arithmetic_closure on type to eliminate allocation

### DIFF
--- a/src/arraymath.jl
+++ b/src/arraymath.jl
@@ -165,4 +165,4 @@ julia> arithmetic_closure(BigInt)
 BigFloat
 ```
 """
-arithmetic_closure(T) = typeof((one(T)*zero(T) + zero(T))/one(T))
+arithmetic_closure(::Type{T}) where T = typeof((one(T)*zero(T) + zero(T))/one(T))

--- a/test/arraymath.jl
+++ b/test/arraymath.jl
@@ -75,5 +75,9 @@ import StaticArrays.arithmetic_closure
         @test (t-t) isa T
         @test (t*t) isa T
         @test (t/t) isa T
+
+        if isbits(T0)
+            @test @allocated(arithmetic_closure(T0)) == 0
+        end
     end
 end


### PR DESCRIPTION
On master + Julia 0.6.2, 
```julia
using StaticArrays
const TT = Complex{Float64} 
@allocated StaticArrays.arithmetic_closure(TT)
```
returns 224. This is a significant tax when working with `ForwardDiff.Dual`. It is fixed by this PR.