### PR TITLE
 Rework use of RowVector/ConjVector/Transpose/Adjoint.

### DIFF
--- a/src/StaticArrays.jl
+++ b/src/StaticArrays.jl
@@ -23,8 +23,10 @@ if VERSION < v"0.7-"
                         isposdef, normalize, normalize!, Eigen, det, logdet, cross, diff, qr
     const LinearAlgebra = Base.LinAlg
 
+    const TransposeVector{T, V<:AbstractVector{T}} = RowVector{T, V}
+    const AdjointVector{T, V<:AbstractVector{T}} = RowVector{T, ConjVector{T, V}}
+
     const adjoint = ctranspose
-    const Adjoint = RowVector
     const tr = trace
 else
     using Compat
@@ -40,6 +42,9 @@ else
                           kron, diag, vecnorm, norm, dot, diagm, lu, svd, svdvals, svdfact,
                           factorize, ishermitian, issymmetric, isposdef, normalize,
                           normalize!, Eigen, det, logdet, cross, diff, qr
+
+    const TransposeVector{T, V<:AbstractVector{T}} = Transpose{T, V}
+    const AdjointVector{T, V<:AbstractVector{T}} = Adjoint{T, V}
 end
 
 export StaticScalar, StaticArray, StaticVector, StaticMatrix
@@ -92,6 +97,7 @@ abstract type StaticArray{S <: Tuple, T, N} <: AbstractArray{T, N} end
 const StaticScalar{T} = StaticArray{Tuple{}, T, 0}
 const StaticVector{N, T} = StaticArray{Tuple{N}, T, 1}
 const StaticMatrix{N, M, T} = StaticArray{Tuple{N, M}, T, 2}
+const StaticVecOrMat{T} = Union{StaticVector{<:Any, T}, StaticMatrix{<:Any, <:Any, T}}
 
 const AbstractScalar{T} = AbstractArray{T, 0} # not exported, but useful none-the-less
 const StaticArrayNoEltype{S, N, T} = StaticArray{S, T, N}

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -12,7 +12,7 @@
     # This isn't the precise output type, just a placeholder to return from
     # promote_containertype, which will control dispatch to our broadcast_c.
     _containertype(::Type{<:StaticArray}) = StaticArray
-    _containertype(::Type{<:Adjoint{<:Any,<:StaticVector}}) = StaticArray
+    _containertype(::Type{<:RowVector{<:Any,<:StaticVector}}) = StaticArray
 
     # issue #382; prevent infinite recursion in generic broadcast code:
     Base.Broadcast.broadcast_indices(::Type{StaticArray}, A) = indices(A)
@@ -54,8 +54,8 @@ else
     StaticArrayStyle{M}(::Val{N}) where {M,N} = StaticArrayStyle{N}()
 
     BroadcastStyle(::Type{<:StaticArray{<:Any, <:Any, N}}) where {N} = StaticArrayStyle{N}()
-    BroadcastStyle(::Type{<:Adjoint{<:Any, <:StaticVector}}) = StaticArrayStyle{2}()
-    BroadcastStyle(::Type{<:Adjoint{<:Any, <:StaticMatrix}}) = StaticArrayStyle{2}()
+    BroadcastStyle(::Type{<:Transpose{<:Any, <:StaticArray{<:Any, <:Any, N}}}) where {N} = StaticArrayStyle{N}()
+    BroadcastStyle(::Type{<:Adjoint{<:Any, <:StaticArray{<:Any, <:Any, N}}}) where {N} = StaticArrayStyle{N}()
 
     # Precedence rules
     BroadcastStyle(::StaticArrayStyle{M}, ::DefaultArrayStyle{N}) where {M,N} =

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -12,18 +12,18 @@
     @inline At_mul_B(A::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}, B::StaticVecOrMat) = _At_mul_B(Size(A), Size(B), A, B)
     @inline A_mul_Bt(A::StaticMatrix, B::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}) = _A_mul_Bt(Size(A), Size(B), A, B)
 
-    # Specializations for Adjoint
-    @inline Base.:*(rowvec::Adjoint{<:Any,<:StaticVector}, A::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}) = transpose(A * transpose(rowvec))
+    # Specializations for RowVector
+    @inline Base.:*(rowvec::RowVector{<:Any,<:StaticVector}, A::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}) = transpose(A * transpose(rowvec))
     @inline Base.:*(A::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}, rowvec::RowVector{<:Any,<:StaticVector}) = transpose(rowvec.vec * A)
-    @inline A_mul_Bt(rowvec::Adjoint{<:Any,<:StaticVector}, A::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}) = transpose(A * transpose(rowvec))
-    @inline A_mul_Bt(A::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}, rowvec::Adjoint{<:Any,<:StaticVector}) = A * transpose(rowvec)
+    @inline A_mul_Bt(rowvec::RowVector{<:Any,<:StaticVector}, A::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}) = transpose(A * transpose(rowvec))
+    @inline A_mul_Bt(A::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}, rowvec::RowVector{<:Any,<:StaticVector}) = A * transpose(rowvec)
     @inline At_mul_B(A::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}, rowvec::RowVector{<:Any,<:StaticVector}) = transpose(rowvec.vec * A)
-    @inline At_mul_Bt(A::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}, rowvec::Adjoint{<:Any,<:StaticVector}) = transpose(A) * transpose(rowvec)
+    @inline At_mul_Bt(A::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}, rowvec::RowVector{<:Any,<:StaticVector}) = transpose(A) * transpose(rowvec)
     @inline At_mul_Bt(rowvec::RowVector{<:Any,<:StaticVector}, A::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}) = rowvec.vec * transpose(A)
     @inline A_mul_Bc(rowvec::RowVector{<:Any,<:StaticVector}, A::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}) = transpose(conj(A * adjoint(rowvec)))
-    @inline A_mul_Bc(A::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}, rowvec::Adjoint{<:Any,<:StaticVector}) = A * adjoint(rowvec)
+    @inline A_mul_Bc(A::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}, rowvec::RowVector{<:Any,<:StaticVector}) = A * adjoint(rowvec)
     @inline Ac_mul_B(A::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}, rowvec::RowVector{<:Any,<:StaticVector}) = adjoint(conj(rowvec.vec) * A)
-    @inline Ac_mul_Bc(A::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}, rowvec::Adjoint{<:Any,<:StaticVector}) = A' * adjoint(rowvec)
+    @inline Ac_mul_Bc(A::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}, rowvec::RowVector{<:Any,<:StaticVector}) = A' * adjoint(rowvec)
     @inline Ac_mul_Bc(rowvec::RowVector{<:Any,<:StaticVector}, A::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}) = conj(rowvec.vec) * A'
 
     Ac_mul_B(A::StaticMatrix, B::LinearAlgebra.AbstractTriangular{<:Any,<:StaticMatrix}) = (*)(adjoint(A), B)

--- a/src/util.jl
+++ b/src/util.jl
@@ -91,5 +91,11 @@ TrivialView(a::AbstractArray{T,N}) where {T,N} = TrivialView{typeof(a),T,N}(a)
 # than the input.
 # """
 @inline drop_sdims(a::StaticArray) = TrivialView(a)
-@inline drop_sdims(a::RowVector{<:Number, <:StaticArray}) = TrivialView(a)
+@static if VERSION < v"0.7-"
+    @inline drop_sdims(a::RowVector{<:Number, <:StaticVector}) = TrivialView(a)
+    @inline drop_sdims(a::RowVector{T, ConjVector{T, <:StaticVector}}) where {T<:Number} = TrivialView(a)
+else
+    @inline drop_sdims(a::Transpose{<:Number, <:StaticArray}) = TrivialView(a)
+    @inline drop_sdims(a::Adjoint{<:Number, <:StaticArray}) = TrivialView(a)
+end
 @inline drop_sdims(a) = a

--- a/test/SDiagonal.jl
+++ b/test/SDiagonal.jl
@@ -15,13 +15,13 @@ using Compat.LinearAlgebra: chol
 
         # From SMatrix
         @test SDiagonal(SMatrix{2,2,Int}((1,2,3,4))).diag.data === (1,4)
-        
+
         @test SDiagonal{1,Int}(SDiagonal{1,Float64}((1,))).diag[1] === 1
 
     end
 
     @testset "Methods" begin
-    
+
         @test StaticArrays.scalem(@SMatrix([1 1 1;1 1 1; 1 1 1]), @SVector [1,2,3]) === @SArray [1 2 3; 1 2 3; 1 2 3]
         @test StaticArrays.scalem(@SVector([1,2,3]),@SMatrix [1 1 1;1 1 1; 1 1 1])' === @SArray [1 2 3; 1 2 3; 1 2 3]
 
@@ -45,9 +45,9 @@ using Compat.LinearAlgebra: chol
             @test sqrt(m) == sqrt(m2)
         end
         @test chol(m) == chol(m2)
-        
+
         # Aparently recursive chol never really worked
-        #@test_broken chol(reshape([1.0*m, 0.0*m, 0.0*m, 1.0*m], 2, 2)) == 
+        #@test_broken chol(reshape([1.0*m, 0.0*m, 0.0*m, 1.0*m], 2, 2)) ==
         #    reshape([chol(1.0*m), 0.0*m, 0.0*m, chol(1.0*m)], 2, 2)
 
         @test isimmutable(m) == true
@@ -56,18 +56,18 @@ using Compat.LinearAlgebra: chol
         @test m[2,2] === 12
         @test m[3,3] === 13
         @test m[4,4] === 14
-        
+
         for i in 1:4
             for j in 1:4
                 i == j || @test m[i,j] === 0
             end
         end
-        
+
         @test_throws Exception m[5,5]
-        
+
         @test_throws Exception m[1,5]
-        
-    
+
+
         @test size(m) === (4, 4)
         @test size(typeof(m)) === (4, 4)
         @test size(SDiagonal{4}) === (4, 4)
@@ -80,17 +80,19 @@ using Compat.LinearAlgebra: chol
         @test length(m) === 4*4
 
         @test_throws Exception m[1] = 1
-        
+
         b = @SVector [2,-1,2,1]
         b2 = Vector(b)
-  
-        
+
+
         @test m*b ==  @SVector [22,-12,26,14]
         @test (b'*m)' ==  @SVector [22,-12,26,14]
-        
+        @test transpose(transpose(b)*m) ==  @SVector [22,-12,26,14]
+
         @test m\b == m2\b
 
         @test b'/m == b'/m2
+        @test transpose(b)/m == transpose(b)/m2
         # @test_throws Exception b/m # Apparently this is now some kind of minimization problem
         @test m*m == m2*m
 
@@ -103,6 +105,7 @@ using Compat.LinearAlgebra: chol
         @test issymmetric(m) == issymmetric(m2)
 
         @test (2*m/2)' == m
+        @test transpose(2*m/2) == m
         @test 2m == m + m
         @test -(-m) == m
         @test m - SMatrix{4,4}(zeros(4,4)) == m

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -90,8 +90,10 @@ end
         @test @inferred(SVector{0,Int}() .+ SVector(1)) === SVector{0,Int}()
         # Issue #200: broadcast with Adjoint
         @test @inferred(v1 .+ v2') === @SMatrix [2 5; 3 6]
+        @test @inferred(v1 .+ transpose(v2)) === @SMatrix [2 5; 3 6]
         # Issue 382: infinite recursion in Base.Broadcast.broadcast_indices with Adjoint
         @test @inferred(SVector(1,1)' .+ [1, 1]) == [2 2; 2 2]
+        @test @inferred(transpose(SVector(1,1)) .+ [1, 1]) == [2 2; 2 2]
     end
 
     @testset "StaticVector with Scalar" begin

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -194,6 +194,26 @@ using StaticArrays, Compat.Test
         M2 = collect(20:-1:1)'
         @test @inferred(kron(SMatrix{20,1}(M1),SMatrix{1,20}(M2)))::SizedMatrix{20,20} == kron(M1,M2)
 
+        test_kron = function (a, b, A, p, q, P)
+            @test @inferred(kron(a,b)) ===  SVector{9}(kron(p,q))
+            @test @inferred(kron(b,a)) ===  SVector{9}(kron(q,p))
+            @test @inferred(kron(a',b')) ===  SMatrix{1,9}(kron(p',q'))
+            @test @inferred(kron(b',a')) ===  SMatrix{9,1}(kron(q',p'))'
+            @test @inferred(kron(b',a)) ===  SMatrix{3,3}(kron(q',p))
+            @test @inferred(kron(b,a')) ===  SMatrix{3,3}(kron(q,p'))
+            @test @inferred(kron(b,A)) ===  SMatrix{6,2}(kron(q,P))
+            @test @inferred(kron(b',A)) ===  SMatrix{2,6}(kron(q',P))
+            @test @inferred(kron(A,b)) ===  SMatrix{6,2}(kron(P,q))
+            @test @inferred(kron(A,b')) ===  SMatrix{2,6}(kron(P,q'))
+
+            @test @inferred(kron(transpose(a),transpose(b))) ===  SMatrix{1,9}(kron(transpose(p),transpose(q)))
+            @test @inferred(kron(transpose(b),transpose(a))) ===  SMatrix{9,1}(kron(transpose(q),transpose(p)))'
+            @test @inferred(kron(transpose(b),a)) ===  SMatrix{3,3}(kron(transpose(q),p))
+            @test @inferred(kron(b,transpose(a))) ===  SMatrix{3,3}(kron(q,transpose(p)))
+            @test @inferred(kron(transpose(b),A)) ===  SMatrix{2,6}(kron(transpose(q),P))
+            @test @inferred(kron(A,transpose(b))) ===  SMatrix{2,6}(kron(P,transpose(q)))
+        end
+
         # Tests for kron of two SVectors as well as between SVectors and SMatrices.
         a = @SVector [1, 2, 3]
         b = @SVector [4, 5, 6]
@@ -203,16 +223,8 @@ using StaticArrays, Compat.Test
         q = [4,5,6]
         P = [1 2; 3 4]
 
-        @test @inferred(kron(a,b)) ===  SVector{9}(kron(p,q))
-        @test @inferred(kron(b,a)) ===  SVector{9}(kron(q,p))
-        @test @inferred(kron(a',b')) ===  SMatrix{1,9}(kron(p',q'))
-        @test @inferred(kron(b',a')) ===  SMatrix{9,1}(kron(q',p'))'
-        @test @inferred(kron(b',a)) ===  SMatrix{3,3}(kron(q',p))
-        @test @inferred(kron(b,a')) ===  SMatrix{3,3}(kron(q,p'))
-        @test @inferred(kron(b,A)) ===  SMatrix{6,2}(kron(q,P))
-        @test @inferred(kron(b',A)) ===  SMatrix{2,6}(kron(q',P))
-        @test @inferred(kron(A,b)) ===  SMatrix{6,2}(kron(P,q))
-        @test @inferred(kron(A,b')) ===  SMatrix{2,6}(kron(P,q'))
+        test_kron(a, b, A, p, q, P)
+
 
         # Tests for kron of two SVectors as well as between SVectors and
         # SMatrices and verifies type promotion (e.g. Int to Float).
@@ -224,16 +236,7 @@ using StaticArrays, Compat.Test
         q = [4.5, 5.5, 6.5]
         P = [1 2; 3 4]
 
-        @test @inferred(kron(a,b)) ===  SVector{9}(kron(p,q))
-        @test @inferred(kron(b,a)) ===  SVector{9}(kron(q,p))
-        @test @inferred(kron(a',b')) ===  SMatrix{1,9}(kron(p',q'))
-        @test @inferred(kron(b',a')) ===  SMatrix{9,1}(kron(q',p'))'
-        @test @inferred(kron(b',a)) ===  SMatrix{3,3}(kron(q',p))
-        @test @inferred(kron(b,a')) ===  SMatrix{3,3}(kron(q,p'))
-        @test @inferred(kron(b,A)) ===  SMatrix{6,2}(kron(q,P))
-        @test @inferred(kron(b',A)) ===  SMatrix{2,6}(kron(q',P))
-        @test @inferred(kron(A,b)) ===  SMatrix{6,2}(kron(P,q))
-        @test @inferred(kron(A,b')) ===  SMatrix{2,6}(kron(P,q'))
+        test_kron(a, b, A, p, q, P)
 
         # Output should be heap allocated into a SizedArray when it gets large
         # enough.
@@ -254,6 +257,13 @@ using StaticArrays, Compat.Test
         @test @inferred(kron(A,b'))::SizedMatrix{10,210} == kron(P,q')
         @test @inferred(kron(b,A))::SizedMatrix{210,10} == kron(q,P)
         @test @inferred(kron(A,b))::SizedMatrix{210,10} == kron(P,q)
+
+        @test @inferred(kron(b,transpose(a)))::SizedMatrix{21,10} == kron(q,transpose(p))
+        @test @inferred(kron(transpose(b),a))::SizedMatrix{10,21} == kron(transpose(q),p)
+        @test @inferred(kron(transpose(a),transpose(b)))::SizedMatrix{1,210} == kron(transpose(p),transpose(q))
+        @test @inferred(kron(transpose(b),transpose(a)))::SizedMatrix{1,210} == kron(transpose(q),transpose(p))
+        @test @inferred(kron(transpose(b),A))::SizedMatrix{10,210} == kron(transpose(q),P)
+        @test @inferred(kron(A,transpose(b)))::SizedMatrix{10,210} == kron(P,transpose(q))
 
     end
 end

--- a/test/matrix_multiply.jl
+++ b/test/matrix_multiply.jl
@@ -18,9 +18,11 @@
 
         # inner product
         @test @inferred(v'*v) === 5
+        @test @inferred(transpose(v)*v) === 5
 
         # outer product
         @test @inferred(v*v') === @SMatrix [1 2; 2 4]
+        @test @inferred(v*transpose(v)) === @SMatrix [1 2; 2 4]
 
         v3 = [1, 2]
         @test m*v3 === @SVector [5, 11]
@@ -65,10 +67,12 @@
         v2 = SVector(1, 2)
         v3 = SVector(3, 4)
         @test v2 * v3' === @SMatrix [3 4; 6 8]
+        @test v2 * transpose(v3) === @SMatrix [3 4; 6 8]
 
         v4 = SVector(1+0im, 2+0im)
         v5 = SVector(3+0im, 4+0im)
         @test v4 * v5' === @SMatrix [3+0im 4+0im; 6+0im 8+0im]
+        @test v4 * transpose(v5) === @SMatrix [3+0im 4+0im; 6+0im 8+0im]
     end
 
     @testset "Matrix-matrix" begin
@@ -83,9 +87,9 @@
         @test m'*n === @SMatrix [14 18; 20 26]
         @test m*n' === @SMatrix [8 14; 18 32]
         @test m'*n' === @SMatrix [11 19; 16 28]
-        @test m.'*n === @SMatrix [14 18; 20 26]
-        @test m*n.' === @SMatrix [8 14; 18 32]
-        @test m.'*n.' === @SMatrix [11 19; 16 28]
+        @test transpose(m)*n === @SMatrix [14 18; 20 26]
+        @test m*transpose(n) === @SMatrix [8 14; 18 32]
+        @test transpose(m)*transpose(n) === @SMatrix [11 19; 16 28]
 
         m = @MMatrix [1 2; 3 4]
         n = @MMatrix [2 3; 4 5]

--- a/test/svd.jl
+++ b/test/svd.jl
@@ -36,6 +36,10 @@ using StaticArrays, Compat.Test
         @testinf svdfact(m23').S  ≊ svdfact(Matrix(m23'))[:S]
         @testinf svdfact(m23').Vt ≊ svdfact(Matrix(m23'))[:Vt]
 
+        @testinf svdfact(transpose(m23)).U  ≊ svdfact(Matrix(transpose(m23)))[:U]
+        @testinf svdfact(transpose(m23)).S  ≊ svdfact(Matrix(transpose(m23)))[:S]
+        @testinf svdfact(transpose(m23)).Vt ≊ svdfact(Matrix(transpose(m23)))[:Vt]
+
         @testinf svdfact(m3c).U  ≊ svdfact(Matrix(m3c))[:U]
         @testinf svdfact(m3c).S  ≊ svdfact(Matrix(m3c))[:S]
         @testinf svdfact(m3c).Vt ≊ svdfact(Matrix(m3c))[:Vt]

--- a/test/triangular.jl
+++ b/test/triangular.jl
@@ -11,41 +11,41 @@
 
         @test (SA*SB[:,1])::SVector{n} ≈ A*B[:,1]
         @test (SA*SB)::SMatrix{n,n} ≈ A*B
-        @test (SA*SB.')::SMatrix{n,n} ≈ A*B.'
+        @test (SA*transpose(SB))::SMatrix{n,n} ≈ A*transpose(B)
         @test (SA*SB')::SMatrix{n,n} ≈ A*B'
         @test (SA'*SB[:,1])::SVector{n} ≈ A'*B[:,1]
         @test (SA'*SB)::SMatrix{n,n} ≈ A'*B
         @test (SA'*SB')::SMatrix{n,n} ≈ A'*B'
-        @test (SA.'*SB[:,1])::SVector{n} ≈ A.'*B[:,1]
-        @test (SA.'*SB)::SMatrix{n,n} ≈ A.'*B
-        @test (SA.'*SB.')::SMatrix{n,n} ≈ A.'*B.'
+        @test (transpose(SA)*SB[:,1])::SVector{n} ≈ transpose(A)*B[:,1]
+        @test (transpose(SA)*SB)::SMatrix{n,n} ≈ transpose(A)*B
+        @test (transpose(SA)*transpose(SB))::SMatrix{n,n} ≈ transpose(A)*transpose(B)
         @test (SB*SA)::SMatrix{n,n} ≈ B*A
         if VERSION < v"0.7-"
-            @test (SB[:,1].'*SA)::RowVector{<:Any,<:SVector{n}} ≈ B[:,1].'*A
+            @test (transpose(SB[:,1])*SA)::RowVector{<:Any,<:SVector{n}} ≈ transpose(B[:,1])*A
         else
             @test (SB[:,1]'*SA)::Adjoint{<:Any,<:SVector{n}} ≈ B[:,1]'*A
-            @test (SB[:,1].'*SA)::Transpose{<:Any,<:SVector{n}} ≈ B[:,1].'*A
+            @test (transpose(SB[:,1])*SA)::Transpose{<:Any,<:SVector{n}} ≈ transpose(B[:,1])*A
         end
-        @test (SB.'*SA)::SMatrix{n,n} ≈ B.'*A
+        @test (transpose(SB)*SA)::SMatrix{n,n} ≈ transpose(B)*A
         @test SB[:,1]'*SA ≈ B[:,1]'*A
         @test (SB'*SA)::SMatrix{n,n} ≈ B'*A
         @test (SB*SA')::SMatrix{n,n} ≈ B*A'
-        @test (SB*SA.')::SMatrix{n,n} ≈ B*A.'
+        @test (SB*transpose(SA))::SMatrix{n,n} ≈ B*transpose(A)
         if VERSION < v"0.7-"
-            @test (SB[:,1].'*SA.')::RowVector{<:Any,<:SVector{n}} ≈ B[:,1].'*A.'
+            @test (transpose(SB[:,1])*transpose(SA))::RowVector{<:Any,<:SVector{n}} ≈ transpose(B[:,1])*transpose(A)
         else
-            @test (SB[:,1]'*SA.')::Adjoint{<:Any,<:SVector{n}} ≈ B[:,1]'*A.'
-            @test (SB[:,1].'*SA.')::Transpose{<:Any,<:SVector{n}} ≈ B[:,1].'*A.'
+            @test (SB[:,1]'*transpose(SA))::Adjoint{<:Any,<:SVector{n}} ≈ B[:,1]'*transpose(A)
+            @test (transpose(SB[:,1])*transpose(SA))::Transpose{<:Any,<:SVector{n}} ≈ transpose(B[:,1])*transpose(A)
         end
-        @test (SB.'*SA.')::SMatrix{n,n} ≈ B.'*A.'
+        @test (transpose(SB)*transpose(SA))::SMatrix{n,n} ≈ transpose(B)*transpose(A)
         @test (SB[:,1]'*SA') ≈ SB[:,1]'*SA'
         @test (SB'*SA')::SMatrix{n,n} ≈ B'*A'
 
         @test_throws DimensionMismatch SA*ones(SVector{n+1,eltyB})
         @test_throws DimensionMismatch ones(SMatrix{n+1,n+1,eltyB})*SA
-        @test_throws DimensionMismatch SA.'*ones(SVector{n+1,eltyB})
+        @test_throws DimensionMismatch transpose(SA)*ones(SVector{n+1,eltyB})
         @test_throws DimensionMismatch SA'*ones(SVector{n+1,eltyB})
-        @test_throws DimensionMismatch ones(SMatrix{n+1,n+1,eltyB})*SA.'
+        @test_throws DimensionMismatch ones(SMatrix{n+1,n+1,eltyB})*transpose(SA)
         @test_throws DimensionMismatch ones(SMatrix{n+1,n+1,eltyB})*SA'
     end
 end
@@ -59,31 +59,31 @@ end
         A = t(eltyA == Int ? rand(1:7, n, n) : rand(eltyA, n, n))
         B = rand(eltyB, n)
         SA = t(SMatrix{n,n}(A.data))
-        SB = SVector{n}(B).'
+        SB = transpose(SVector{n}(B))
 
-        @test (SA*SB)::SMatrix{n,n} ≈ A*B.'
-        @test (SA*SB.')::SVector{n} ≈ A*B
+        @test (SA*SB)::SMatrix{n,n} ≈ A*transpose(B)
+        @test (SA*transpose(SB))::SVector{n} ≈ A*B
         @test (SA*SB')::SVector{n} ≈ A*conj(B)
-        @test (SA'*SB)::SMatrix{n,n} ≈ A'*B.'
-        @test (SA'*SB.')::SVector{n} ≈ A'*B
+        @test (SA'*SB)::SMatrix{n,n} ≈ A'*transpose(B)
+        @test (SA'*transpose(SB))::SVector{n} ≈ A'*B
         @test (SA'*SB')::SVector{n} ≈ A'*conj(B)
-        @test (SA.'*SB)::SMatrix{n,n} ≈ A.'*B.'
-        @test (SA.'*SB.')::SVector{n} ≈ A.'*B
-        @test (SA.'*SB')::SVector{n} ≈ A.'*conj(B)
+        @test (transpose(SA)*SB)::SMatrix{n,n} ≈ transpose(A)*transpose(B)
+        @test (transpose(SA)*transpose(SB))::SVector{n} ≈ transpose(A)*B
+        @test (transpose(SA)*SB')::SVector{n} ≈ transpose(A)*conj(B)
         if VERSION < v"0.7-"
-            @test (SB*SA)::RowVector{<:Any,<:SVector{n}} ≈ B.'*A
-            @test (SB*SA')::RowVector{<:Any,<:SVector{n}} ≈ B.'*A'
-            @test (SB*SA.')::RowVector{<:Any,<:SVector{n}} ≈ B.'*A.'
+            @test (SB*SA)::RowVector{<:Any,<:SVector{n}} ≈ transpose(B)*A
+            @test (SB*SA')::RowVector{<:Any,<:SVector{n}} ≈ transpose(B)*A'
+            @test (SB*transpose(SA))::RowVector{<:Any,<:SVector{n}} ≈ transpose(B)*transpose(A)
         else
-            @test (SB*SA)::Transpose{<:Any,<:SVector{n}} ≈ B.'*A
-            @test (SB*SA')::Transpose{<:Any,<:SVector{n}} ≈ B.'*A'
-            @test (SB*SA.')::Transpose{<:Any,<:SVector{n}} ≈ B.'*A.'
+            @test (SB*SA)::Transpose{<:Any,<:SVector{n}} ≈ transpose(B)*A
+            @test (SB*SA')::Transpose{<:Any,<:SVector{n}} ≈ transpose(B)*A'
+            @test (SB*transpose(SA))::Transpose{<:Any,<:SVector{n}} ≈ transpose(B)*transpose(A)
         end
-        @test (SB.'*SA)::SMatrix{n,n} ≈ B*A
+        @test (transpose(SB)*SA)::SMatrix{n,n} ≈ B*A
         @test (SB'*SA)::SMatrix{n,n} ≈ conj(B)*A
-        @test (SB.'*SA.')::SMatrix{n,n} ≈ B*A.'
-        @test (SB.'*SA')::SMatrix{n,n} ≈ B*A'
-        @test (SB'*SA.')::SMatrix{n,n} ≈ conj(B)*A.'
+        @test (transpose(SB)*transpose(SA))::SMatrix{n,n} ≈ B*transpose(A)
+        @test (transpose(SB)*SA')::SMatrix{n,n} ≈ B*A'
+        @test (SB'*transpose(SA))::SMatrix{n,n} ≈ conj(B)*transpose(A)
         @test (SB'*SA')::SMatrix{n,n} ≈ conj(B)*A'
     end
 end
@@ -101,17 +101,17 @@ end
 
         @test (SA\SB[:,1])::SVector{n} ≈ A\B[:,1]
         @test (SA\SB)::SMatrix{n,n} ≈ A\B
-        @test (SA.'\SB[:,1])::SVector{n} ≈ A.'\B[:,1]
-        @test (SA.'\SB)::SMatrix{n,n} ≈ A.'\B
+        @test (transpose(SA)\SB[:,1])::SVector{n} ≈ transpose(A)\B[:,1]
+        @test (transpose(SA)\SB)::SMatrix{n,n} ≈ transpose(A)\B
         @test (SA'\SB[:,1])::SVector{n} ≈ A'\B[:,1]
         @test (SA'\SB)::SMatrix{n,n} ≈ A'\B
 
         @test_throws DimensionMismatch SA\ones(SVector{n+2,eltyB})
-        @test_throws DimensionMismatch SA.'\ones(SVector{n+2,eltyB})
+        @test_throws DimensionMismatch transpose(SA)\ones(SVector{n+2,eltyB})
         @test_throws DimensionMismatch SA'\ones(SVector{n+2,eltyB})
 
         @test_throws LinearAlgebra.SingularException t(zeros(SMatrix{n,n,eltyA}))\ones(SVector{n,eltyB})
-        @test_throws LinearAlgebra.SingularException t(zeros(SMatrix{n,n,eltyA})).'\ones(SVector{n,eltyB})
+        @test_throws LinearAlgebra.SingularException t(transpose(zeros(SMatrix{n,n,eltyA})))\ones(SVector{n,eltyB})
         @test_throws LinearAlgebra.SingularException t(zeros(SMatrix{n,n,eltyA}))'\ones(SVector{n,eltyB})
     end
 end


### PR DESCRIPTION
Fixes #416.

* get rid of iffy Adjoint definition for 0.6.
* define TransposeVector and AdjointVector.
* just use RowVector instead of Adjoint in 0.6-only code.
* simplify Size code a bit.
* use both adjoint and transpose in tests.
* convert tests to use transpose instead of `.'`.

Passes almost all tests on master now.