### PR TITLE
Remove "inferabilty of index_sizes helper" testset

### DIFF
--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -165,10 +165,4 @@
         @test (zeros(0,2)[SVector{0,Int}(),SVector(1)] = 0) == 0
         @test (zeros(2,0)[SVector(1),SVector{0,Int}()] = 0) == 0
     end
-
-    @testset "inferabilty of index_sizes helper" begin
-        # see JuliaLang/julia#21244
-        # it's not about inferring the correct type, but about inference throwing an error
-        @test code_warntype(devnull, StaticArrays.index_sizes, Tuple{Vararg{Any}}) == nothing
-    end
 end


### PR DESCRIPTION
This set was introduced to test an inference issue (https://github.com/JuliaLang/julia/issues/21244) in an old version of Julia.

It currently fails on Julia master because of https://github.com/JuliaLang/julia/issues/27276.

In my opinion, it's currently not really testing anything valuable, and the Julia PR that fixed the issue has associated test cases that should cover this.