### PR TITLE
PromoteType for MArray

### DIFF
--- a/test/MArray.jl
+++ b/test/MArray.jl
@@ -161,5 +161,6 @@
         @test @inferred(promote_type(MVector{1,Float64}, MVector{1,BigFloat})) == MVector{1,BigFloat}
         @test @inferred(promote_type(MVector{2,Int}, MVector{2,Float64})) === MVector{2,Float64}
         @test @inferred(promote_type(MMatrix{2,3,Float32,6}, MMatrix{2,3,Complex{Float64},6})) === MMatrix{2,3,Complex{Float64},6}
+        @test @inferred(promote_type(MArray{Tuple{2, 2, 2, 2},Float32, 4, 16}, MArray{Tuple{2, 2, 2, 2}, Complex{Float64}, 4, 16})) === MArray{Tuple{2, 2, 2, 2}, Complex{Float64}, 4, 16}
     end
 end


### PR DESCRIPTION
I think again we are going through methods for `MVector` and `MMatrix` so I wrote a test which requires `MArray`.