### PR TITLE
Fix #428, zeros and ones shouldn't use _fill

### DIFF
--- a/src/arraymath.jl
+++ b/src/arraymath.jl
@@ -1,32 +1,28 @@
 @inline zeros(::SA) where {SA <: StaticArray} = zeros(SA)
-@generated function zeros(::Type{SA}) where {SA <: StaticArray}
+@inline zeros(::Type{SA}) where {SA <: StaticArray} = _zeros(Size(SA), SA)
+@generated function _zeros(::Size{s}, ::Type{SA}) where {s, SA <: StaticArray}
     T = eltype(SA)
-    if T === Any
-        return quote
-            @_inline_meta
-            _fill(zero(Float64), Size(SA), SA)
-        end
-    else
-        return quote
-            @_inline_meta
-            _fill(zero($T), Size(SA), SA)
-        end
+    if T == Any
+        T = Float64
+    end
+    v = [:(zero($T)) for i = 1:prod(s)]
+    return quote
+        @_inline_meta
+        $SA(tuple($(v...)))
     end
 end
 
 @inline ones(::SA) where {SA <: StaticArray} = ones(SA)
-@generated function ones(::Type{SA}) where {SA <: StaticArray}
+@inline ones(::Type{SA}) where {SA <: StaticArray} = _ones(Size(SA), SA)
+@generated function _ones(::Size{s}, ::Type{SA}) where {s, SA <: StaticArray}
     T = eltype(SA)
-    if T === Any
-        return quote
-            @_inline_meta
-            _fill(one(Float64), Size(SA), SA)
-        end
-    else
-        return quote
-            @_inline_meta
-            _fill(one($T), Size(SA), SA)
-        end
+    if T == Any
+        T = Float64
+    end
+    v = [:(one($T)) for i = 1:prod(s)]
+    return quote
+        @_inline_meta
+        $SA(tuple($(v...)))
     end
 end
 

--- a/test/arraymath.jl
+++ b/test/arraymath.jl
@@ -19,6 +19,15 @@ import StaticArrays.arithmetic_closure
         @test @inferred(ones(MVector{3}))::MVector == @MVector [1.0, 1.0, 1.0]
         @test @inferred(ones(MMatrix{2,2}))::MMatrix == @MMatrix [1.0 1.0; 1.0 1.0]
         @test @inferred(ones(MArray{Tuple{1,1,1}}))::MArray == MArray{Tuple{1,1,1}}((1.0,))
+
+        # https://github.com/JuliaArrays/StaticArrays.jl/issues/428
+        bigzeros = zeros(SVector{2, BigInt})
+        @test bigzeros == @SVector [big(0), big(0)]
+        @test bigzeros[1] !== bigzeros[2]
+
+        bigones = ones(SVector{2, BigInt})
+        @test bigones == @SVector [big(1), big(1)]
+        @test bigones[1] !== bigones[2]
     end
 
     @testset "zero()" begin


### PR DESCRIPTION
Fixes #428. Pattern match `_fill` and `_rand` below.