### PR TITLE
fix FixedSizeArrays tests on v0.7

### DIFF
--- a/src/FixedSizeArrays.jl
+++ b/src/FixedSizeArrays.jl
@@ -111,20 +111,20 @@ macro fixed_vector(name, parent)
         # Array constructor
         @inline function (::Type{$(name){S}})(x::AbstractVector{T}) where {S, T}
             @assert S <= length(x)
-            $(name){S, T}(ntuple(i-> x[i], Val{S}))
+            $(name){S, T}(ntuple(i-> x[i], Val{S}()))
         end
         @inline function (::Type{$(name){S, T1}})(x::AbstractVector{T2}) where {S, T1, T2}
             @assert S <= length(x)
-            $(name){S, T1}(ntuple(i-> T1(x[i]), Val{S}))
+            $(name){S, T1}(ntuple(i-> T1(x[i]), Val{S}()))
         end
 
         @inline function (::Type{$(name){S, T}})(x) where {S, T}
-            $(name){S, T}(ntuple(i-> T(x), Val{S}))
+            $(name){S, T}(ntuple(i-> T(x), Val{S}()))
         end
 
 
         @inline function (::Type{$(name){S}})(x::T) where {S, T}
-            $(name){S, T}(ntuple(i-> x, Val{S}))
+            $(name){S, T}(ntuple(i-> x, Val{S}()))
         end
         @inline function (::Type{$(name){1, T}})(x::T) where T
             $(name){1, T}((x,))

--- a/src/FixedSizeArrays.jl
+++ b/src/FixedSizeArrays.jl
@@ -66,7 +66,7 @@ end
 
 
 function unit(::Type{T}, i::Integer) where T <: StaticVector
-    T(ntuple(Val{length(T)}) do j
+    T(ntuple(Val(length(T))) do j
         ifelse(i == j, 1, 0)
     end)
 end
@@ -111,20 +111,20 @@ macro fixed_vector(name, parent)
         # Array constructor
         @inline function (::Type{$(name){S}})(x::AbstractVector{T}) where {S, T}
             @assert S <= length(x)
-            $(name){S, T}(ntuple(i-> x[i], Val{S}()))
+            $(name){S, T}(ntuple(i-> x[i], Val(S)))
         end
         @inline function (::Type{$(name){S, T1}})(x::AbstractVector{T2}) where {S, T1, T2}
             @assert S <= length(x)
-            $(name){S, T1}(ntuple(i-> T1(x[i]), Val{S}()))
+            $(name){S, T1}(ntuple(i-> T1(x[i]), Val(S)))
         end
 
         @inline function (::Type{$(name){S, T}})(x) where {S, T}
-            $(name){S, T}(ntuple(i-> T(x), Val{S}()))
+            $(name){S, T}(ntuple(i-> T(x), Val(S)))
         end
 
 
         @inline function (::Type{$(name){S}})(x::T) where {S, T}
-            $(name){S, T}(ntuple(i-> x, Val{S}()))
+            $(name){S, T}(ntuple(i-> x, Val(S)))
         end
         @inline function (::Type{$(name){1, T}})(x::T) where T
             $(name){1, T}((x,))

--- a/src/arraymath.jl
+++ b/src/arraymath.jl
@@ -38,7 +38,14 @@ end
 
 # Also consider randcycle, randperm? Also faster rand!(staticarray, collection)
 
-@inline rand(rng::AbstractRNG, ::Type{SA}) where {SA <: StaticArray} = _rand(rng, Size(SA), SA)
+@static if VERSION >= v"0.7.0-DEV.3406"
+    using Random: SamplerType
+    @inline rand(rng::AbstractRNG, ::Type{SA}, dims::Dims) where {SA <: StaticArray} = rand!(rng, Array{SA}(undef, dims), SA)
+    @inline rand(rng::AbstractRNG, ::SamplerType{SA}) where {SA <: StaticArray} = _rand(rng, Size(SA), SA)
+else
+    @inline rand(rng::AbstractRNG, ::Type{SA}) where {SA <: StaticArray} = _rand(rng, Size(SA), SA)
+end
+
 @generated function _rand(rng::AbstractRNG, ::Size{s}, ::Type{SA}) where {s, SA <: StaticArray}
     T = eltype(SA)
     if T == Any

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,0 +1,1 @@
+SpecialFunctions

--- a/test/fixed_size_arrays.jl
+++ b/test/fixed_size_arrays.jl
@@ -385,8 +385,8 @@ const unaryOps = (
 
     trunc, round, ceil, floor,
     significand, lgamma,
-    gamma, lfact, frexp, modf, airy, airyai,
-    airyprime, airyaiprime, airybi, airybiprime,
+    gamma, lfact, frexp, modf, airyai,
+    airyaiprime, airybi, airybiprime,
     besselj0, besselj1, bessely0, bessely1,
     eta, zeta, digamma, real, imag
 )

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using StaticArrays, Compat, Compat.Test, Compat.Random, Compat.LinearAlgebra
+using StaticArrays, Compat, Compat.Test, Compat.Random, Compat.LinearAlgebra, SpecialFunctions
 if VERSION > v"0.7-"
     using InteractiveUtils
 else


### PR DESCRIPTION
A couple things here: 

* A lot of the unary op tests in `test/fixed_size_arrays.jl` were silently failing because those functions have been moved to SpecialFunctions.jl, and the test itself is wrapped in a `try`
* I *maybe* fixed the random SArray generation? This is my first attempt at understanding the new way Random works. I didn't touch the `@inline rand(rng::AbstractRNG, range::AbstractArray, ::Type{SA}) where {SA <: StaticArray} = _rand(rng, range, Size(SA), SA)` method, which probably needs to be updated too. 