### PR TITLE
Reduce test time

### DIFF
--- a/test/det.jl
+++ b/test/det.jl
@@ -4,7 +4,7 @@
     @test det(@SMatrix [0 1; 1 0]) == -1
     @test logdet(@SMatrix Complex{Float64}[0 1; 1 0]) == log(det(@SMatrix Complex{Float64}[0 1; 1 0]))
     @test det(one(SMatrix{3,3})*im) == det([1.0*im 0.0 0.0; 0.0 1.0*im 0.0; 0.0 0.0 1.0*im])
-    
+
     @test det(@SMatrix [0 1 0; 1 0 0; 0 0 1]) == -1
     m = [0.570085  0.667147  0.264427  0.561446
          0.115197  0.141744  0.83314   0.0457302
@@ -25,7 +25,7 @@
     end
 
     # lu-based (sz in 5:14) and fallback (sz > 15)
-    for sz in (5, 14, 15, 50), typ in (Float64, Complex{Float64})
+    for sz in (5, 14, 15), typ in (Float64, Complex{Float64})
         A = rand(typ, sz, sz)
         SA = SMatrix{sz,sz,typ}(A)
         @test det(A) ≈ det(SA)

--- a/test/det.jl
+++ b/test/det.jl
@@ -24,8 +24,8 @@
         @test det(Mtag) == det(Array(Mtag))
     end
 
-    # lu-based (sz in 5:14) and fallback (sz > 15)
-    for sz in (5, 14, 15), typ in (Float64, Complex{Float64})
+    # lu-based (sz up to 14) and fallback (sz >= 15)
+    for sz in (5, 8, 15), typ in (Float64, Complex{Float64})
         A = rand(typ, sz, sz)
         SA = SMatrix{sz,sz,typ}(A)
         @test det(A) ≈ det(SA)

--- a/test/inv.jl
+++ b/test/inv.jl
@@ -90,12 +90,10 @@ end
     @test inv(SMatrix{5,5}(m))::StaticMatrix ≈ inv(m)
 end
 
-@testset "Matrix inverse NxN, N > 5" begin
-    for sz in (5, 14, 15), typ in (Float64, Complex{Float64})
-        A = rand(typ, sz, sz)
-        SA = SMatrix{sz,sz,typ}(A)
-        @test inv(A) ≈ inv(SA)
-    end
+@testset "Matrix inverse ($typ, $sz×$sz)" for sz in (5, 14, 15), typ in (Float64, Complex{Float64})
+    A = rand(typ, sz, sz)
+    SA = SMatrix{sz,sz,typ}(A)
+    @test inv(A) ≈ inv(SA)
 end
 
 #-------------------------------------------------------------------------------

--- a/test/inv.jl
+++ b/test/inv.jl
@@ -25,7 +25,7 @@ end
     @test inv(@SMatrix [1+im 2 0; 1 2-im 1; 1 1 2+im])::SMatrix ≈ [2-2im  -3+1im   1-1im
                                                          -1+0im   2+1im  -1+0im
                                                           0+1im   0-1im   1-0.0im]/2
-   
+
     m = randn(Float64, 10,10) + 10*I # well conditioned
     @test inv(SMatrix{10,10}(m))::StaticMatrix ≈ inv(m)
 
@@ -91,7 +91,7 @@ end
 end
 
 @testset "Matrix inverse NxN, N > 5" begin
-    for sz in (5, 14, 15, 50), typ in (Float64, Complex{Float64})
+    for sz in (5, 14, 15), typ in (Float64, Complex{Float64})
         A = rand(typ, sz, sz)
         SA = SMatrix{sz,sz,typ}(A)
         @test inv(A) ≈ inv(SA)

--- a/test/inv.jl
+++ b/test/inv.jl
@@ -90,7 +90,7 @@ end
     @test inv(SMatrix{5,5}(m))::StaticMatrix ≈ inv(m)
 end
 
-@testset "Matrix inverse ($typ, $sz×$sz)" for sz in (5, 14, 15), typ in (Float64, Complex{Float64})
+@testset "Matrix inverse ($typ, $sz×$sz)" for sz in (5, 8, 15), typ in (Float64, Complex{Float64})
     A = rand(typ, sz, sz)
     SA = SMatrix{sz,sz,typ}(A)
     @test inv(A) ≈ inv(SA)

--- a/test/lu.jl
+++ b/test/lu.jl
@@ -1,41 +1,39 @@
 using StaticArrays, Compat.Test
 
-@testset "LU decomposition (pivot=$pivot)" for pivot in (true, false)
-    @testset "$m×$n" for m in [0:4..., 15], n in [0:4..., 15]
-        a = SMatrix{m,n,Int}(1:(m*n))
-        l, u, p = @inferred(lu(a, Val{pivot}))
+@testset "LU decomposition ($m×$n, pivot=$pivot)" for pivot in (true, false), m in [0:4..., 15], n in [0:4..., 15]
+    a = SMatrix{m,n,Int}(1:(m*n))
+    l, u, p = @inferred(lu(a, Val{pivot}))
 
-        # expected types
-        @test p isa SVector{m,Int}
-        if m==n
-            @test l isa LowerTriangular{<:Any,<:SMatrix{m,n}}
-            @test u isa UpperTriangular{<:Any,<:SMatrix{m,n}}
-        else
-            @test l isa SMatrix{m,min(m,n)}
-            @test u isa SMatrix{min(m,n),n}
-        end
-
-        if pivot
-            # p is a permutation
-            @test sort(p) == collect(1:m)
-        else
-            @test p == collect(1:m)
-        end
-
-        # l is unit lower triangular
-        for i=1:m, j=(i+1):size(l,2)
-            @test iszero(l[i,j])
-        end
-        for i=1:size(l,2)
-            @test l[i,i] == 1
-        end
-
-        # u is upper triangular
-        for i=1:size(u,1), j=1:i-1
-            @test iszero(u[i,j])
-        end
-
-        # decomposition is correct
-        @test l*u ≈ a[p,:]
+    # expected types
+    @test p isa SVector{m,Int}
+    if m==n
+        @test l isa LowerTriangular{<:Any,<:SMatrix{m,n}}
+        @test u isa UpperTriangular{<:Any,<:SMatrix{m,n}}
+    else
+        @test l isa SMatrix{m,min(m,n)}
+        @test u isa SMatrix{min(m,n),n}
     end
+
+    if pivot
+        # p is a permutation
+        @test sort(p) == collect(1:m)
+    else
+        @test p == collect(1:m)
+    end
+
+    # l is unit lower triangular
+    for i=1:m, j=(i+1):size(l,2)
+        @test iszero(l[i,j])
+    end
+    for i=1:size(l,2)
+        @test l[i,i] == 1
+    end
+
+    # u is upper triangular
+    for i=1:size(u,1), j=1:i-1
+        @test iszero(u[i,j])
+    end
+
+    # decomposition is correct
+    @test l*u ≈ a[p,:]
 end

--- a/test/lu.jl
+++ b/test/lu.jl
@@ -1,7 +1,7 @@
 using StaticArrays, Compat.Test
 
 @testset "LU decomposition (pivot=$pivot)" for pivot in (true, false)
-    @testset "$m×$n" for m in [0:4..., 15, 50], n in [0:4..., 15, 50]
+    @testset "$m×$n" for m in [0:4..., 15], n in [0:4..., 15]
         a = SMatrix{m,n,Int}(1:(m*n))
         l, u, p = @inferred(lu(a, Val{pivot}))
 

--- a/test/solve.jl
+++ b/test/solve.jl
@@ -1,7 +1,7 @@
 using StaticArrays, Compat.Test
 
 @testset "Solving linear system" begin
-    @testset "Problem size: $n x $n. Matrix type: $m. Element type: $elty" for n in (1,2,3,4,5,14,15),
+    @testset "Problem size: $n x $n. Matrix type: $m. Element type: $elty" for n in (1,2,3,4,5,8,15),
             (m, v) in ((SMatrix{n,n}, SVector{n}), (MMatrix{n,n}, MVector{n})),
                 elty in (Float64, Int)
 
@@ -18,7 +18,7 @@ using StaticArrays, Compat.Test
 end
 
 @testset "Solving linear system (multiple RHS)" begin
-    @testset "Problem size: $n x $n. Matrix type: $m1. Element type: $elty" for n in (1,2,3,4,5,14,15),
+    @testset "Problem size: $n x $n. Matrix type: $m1. Element type: $elty" for n in (1,2,3,4,5,8,15),
             (m1, m2) in ((SMatrix{n,n}, SMatrix{n,2}), (MMatrix{n,n}, MMatrix{n,2})),
                 elty in (Float64, Int)
 

--- a/test/solve.jl
+++ b/test/solve.jl
@@ -1,7 +1,7 @@
 using StaticArrays, Compat.Test
 
 @testset "Solving linear system" begin
-    @testset "Problem size: $n x $n. Matrix type: $m. Element type: $elty" for n in (1,2,3,4,5,14,15,50),
+    @testset "Problem size: $n x $n. Matrix type: $m. Element type: $elty" for n in (1,2,3,4,5,14,15),
             (m, v) in ((SMatrix{n,n}, SVector{n}), (MMatrix{n,n}, MVector{n})),
                 elty in (Float64, Int)
 
@@ -18,7 +18,7 @@ using StaticArrays, Compat.Test
 end
 
 @testset "Solving linear system (multiple RHS)" begin
-    @testset "Problem size: $n x $n. Matrix type: $m1. Element type: $elty" for n in (1,2,3,4,5,14,15,50),
+    @testset "Problem size: $n x $n. Matrix type: $m1. Element type: $elty" for n in (1,2,3,4,5,14,15),
             (m1, m2) in ((SMatrix{n,n}, SMatrix{n,2}), (MMatrix{n,n}, MMatrix{n,2})),
                 elty in (Float64, Int)
 


### PR DESCRIPTION
This reduces total test time from about 16:30 to 6:20 on my machine. It also prints stuff more frequently for tests with a heavy compilation load, so that there's a smaller chance of having test timeouts.

The main win was not testing N = 50 for various tests due to https://github.com/JuliaArrays/StaticArrays.jl/issues/430#issuecomment-395977617. This approximately halved test time.

Fixes #430.