### PR TITLE
Activate helpful error message for undefined-Size conversions

### DIFF
--- a/src/FixedSizeArrays.jl
+++ b/src/FixedSizeArrays.jl
@@ -109,29 +109,29 @@ macro fixed_vector(name, parent)
         size_or(::Type{$(name){S, T} where T}, or) where {S} = Size{(S,)}()
         size_or(::Type{$(name){S, T}}, or) where {S, T} = (S,)
         # Array constructor
-        @inline function (::Type{$(name){S}})(x::AbstractVector{T}) where {S, T}
+        @inline function $(name){S}(x::AbstractVector{T}) where {S, T}
             @assert S <= length(x)
             $(name){S, T}(ntuple(i-> x[i], Val(S)))
         end
-        @inline function (::Type{$(name){S, T1}})(x::AbstractVector{T2}) where {S, T1, T2}
+        @inline function $(name){S, T1}(x::AbstractVector{T2}) where {S, T1, T2}
             @assert S <= length(x)
             $(name){S, T1}(ntuple(i-> T1(x[i]), Val(S)))
         end
 
-        @inline function (::Type{$(name){S, T}})(x) where {S, T}
+        @inline function $(name){S, T}(x) where {S, T}
             $(name){S, T}(ntuple(i-> T(x), Val(S)))
         end
 
 
-        @inline function (::Type{$(name){S}})(x::T) where {S, T}
+        @inline function $(name){S}(x::T) where {S, T}
             $(name){S, T}(ntuple(i-> x, Val(S)))
         end
-        @inline function (::Type{$(name){1, T}})(x::T) where T
+        @inline function $(name){1, T}(x::T) where T
             $(name){1, T}((x,))
         end
-        @inline (::Type{$(name)})(x::NTuple{S}) where {S} = $(name){S}(x)
-        @inline (::Type{$(name)})(x::T) where {S, T <: Tuple{Vararg{Any, S}}} = $(name){S, StaticArrays.promote_tuple_eltype(T)}(x)
-        @inline function (::Type{$(name){S}})(x::T) where {S, T <: Tuple}
+        @inline $(name)(x::NTuple{S}) where {S} = $(name){S}(x)
+        @inline $(name)(x::T) where {S, T <: Tuple{Vararg{Any, S}}} = $(name){S, StaticArrays.promote_tuple_eltype(T)}(x)
+        @inline function $(name){S}(x::T) where {S, T <: Tuple}
             $(name){S, StaticArrays.promote_tuple_eltype(T)}(x)
         end
         $(name){S, T}(x::StaticVector) where {S, T} = $(name){S, T}(Tuple(x))

--- a/src/SDiagonal.jl
+++ b/src/SDiagonal.jl
@@ -23,7 +23,7 @@ diagtype(::Type{SDiagonal}) = SVector
 # this is to deal with convert.jl
 @inline (::Type{SD})(a::AbstractVector) where {SD <: SDiagonal} = SDiagonal(convert(diagtype(SD), a))
 @inline (::Type{SD})(a::Tuple) where {SD <: SDiagonal} = SDiagonal(convert(diagtype(SD), a))
-@inline (::Type{SDiagonal})(a::SVector{N,T}) where {N,T} = SDiagonal{N,T}(a)
+@inline SDiagonal(a::SVector{N,T}) where {N,T} = SDiagonal{N,T}(a)
 
 @generated function SDiagonal(a::StaticMatrix{N,N,T}) where {N,T}
     expr = [:(a[$i,$i]) for i=1:N]

--- a/src/SVector.jl
+++ b/src/SVector.jl
@@ -15,9 +15,9 @@ compiler (the element type may optionally also be specified).
 """
 const SVector{S, T} = SArray{Tuple{S}, T, 1, S}
 
-@inline (::Type{SVector})(x::NTuple{S,Any}) where {S} = SVector{S}(x)
-@inline (::Type{SVector{S}})(x::NTuple{S,T}) where {S, T} = SVector{S,T}(x)
-@inline (::Type{SVector{S}})(x::T) where {S, T <: Tuple} = SVector{S,promote_tuple_eltype(T)}(x)
+@inline SVector(x::NTuple{S,Any}) where {S} = SVector{S}(x)
+@inline SVector{S}(x::NTuple{S,T}) where {S, T} = SVector{S,T}(x)
+@inline SVector{S}(x::T) where {S, T <: Tuple} = SVector{S,promote_tuple_eltype(T)}(x)
 
 # conversion from AbstractVector / AbstractArray (better inference than default)
 #@inline convert{S,T}(::Type{SVector{S}}, a::AbstractArray{T}) = SVector{S,T}((a...))

--- a/src/SizedArray.jl
+++ b/src/SizedArray.jl
@@ -24,12 +24,12 @@ struct SizedArray{S <: Tuple, T, N, M} <: StaticArray{S, T, N}
     end
 end
 
-@inline (::Type{SizedArray{S,T,N}})(a::Array{T,M}) where {S,T,N,M} = SizedArray{S,T,N,M}(a)
-@inline (::Type{SizedArray{S,T}})(a::Array{T,M}) where {S,T,M} = SizedArray{S,T,tuple_length(S),M}(a)
-@inline (::Type{SizedArray{S}})(a::Array{T,M}) where {S,T,M} = SizedArray{S,T,tuple_length(S),M}(a)
+@inline SizedArray{S,T,N}(a::Array{T,M}) where {S,T,N,M} = SizedArray{S,T,N,M}(a)
+@inline SizedArray{S,T}(a::Array{T,M}) where {S,T,M} = SizedArray{S,T,tuple_length(S),M}(a)
+@inline SizedArray{S}(a::Array{T,M}) where {S,T,M} = SizedArray{S,T,tuple_length(S),M}(a)
 
-@inline (::Type{SizedArray{S,T,N}})() where {S,T,N} = SizedArray{S,T,N,N}()
-@inline (::Type{SizedArray{S,T}})() where {S,T} = SizedArray{S,T,tuple_length(S),tuple_length(S)}()
+@inline SizedArray{S,T,N}() where {S,T,N} = SizedArray{S,T,N,N}()
+@inline SizedArray{S,T}() where {S,T} = SizedArray{S,T,tuple_length(S),tuple_length(S)}()
 
 @generated function (::Type{SizedArray{S,T,N,M}})(x::NTuple{L,Any}) where {S,T,N,M,L}
     if L != tuple_prod(S)
@@ -44,18 +44,18 @@ end
     end
 end
 
-@inline (::Type{SizedArray{S,T,N}})(x::Tuple) where {S,T,N} = SizedArray{S,T,N,N}(x)
-@inline (::Type{SizedArray{S,T}})(x::Tuple) where {S,T} = SizedArray{S,T,tuple_length(S),tuple_length(S)}(x)
-@inline (::Type{SizedArray{S}})(x::NTuple{L,T}) where {S,T,L} = SizedArray{S,T,tuple_length(S),tuple_length(S)}(x)
+@inline SizedArray{S,T,N}(x::Tuple) where {S,T,N} = SizedArray{S,T,N,N}(x)
+@inline SizedArray{S,T}(x::Tuple) where {S,T} = SizedArray{S,T,tuple_length(S),tuple_length(S)}(x)
+@inline SizedArray{S}(x::NTuple{L,T}) where {S,T,L} = SizedArray{S,T,tuple_length(S),tuple_length(S)}(x)
 
 # Overide some problematic default behaviour
 @inline convert(::Type{SA}, sa::SizedArray) where {SA<:SizedArray} = SA(sa.data)
 @inline convert(::Type{SA}, sa::SA) where {SA<:SizedArray} = sa
 
 # Back to Array (unfortunately need both convert and construct to overide other methods)
-@inline (::Type{Array})(sa::SizedArray) = sa.data
-@inline (::Type{Array{T}})(sa::SizedArray{S,T}) where {T,S} = sa.data
-@inline (::Type{Array{T,N}})(sa::SizedArray{S,T,N}) where {T,S,N} = sa.data
+@inline Array(sa::SizedArray) = sa.data
+@inline Array{T}(sa::SizedArray{S,T}) where {T,S} = sa.data
+@inline Array{T,N}(sa::SizedArray{S,T,N}) where {T,S,N} = sa.data
 
 @inline convert(::Type{Array}, sa::SizedArray) = sa.data
 @inline convert(::Type{Array{T}}, sa::SizedArray{S,T}) where {T,S} = sa.data
@@ -65,12 +65,12 @@ end
 @propagate_inbounds setindex!(a::SizedArray, v, i::Int) = setindex!(a.data, v, i)
 
 SizedVector{S,T,M} = SizedArray{Tuple{S},T,1,M}
-@inline (::Type{SizedVector{S}})(a::Array{T,M}) where {S,T,M} = SizedArray{Tuple{S},T,1,M}(a)
-@inline (::Type{SizedVector{S}})(x::NTuple{L,T}) where {S,T,L} = SizedArray{Tuple{S},T,1,1}(x)
+@inline SizedVector{S}(a::Array{T,M}) where {S,T,M} = SizedArray{Tuple{S},T,1,M}(a)
+@inline SizedVector{S}(x::NTuple{L,T}) where {S,T,L} = SizedArray{Tuple{S},T,1,1}(x)
 
 SizedMatrix{S1,S2,T,M} = SizedArray{Tuple{S1,S2},T,2,M}
-@inline (::Type{SizedMatrix{S1,S2}})(a::Array{T,M}) where {S1,S2,T,M} = SizedArray{Tuple{S1,S2},T,2,M}(a)
-@inline (::Type{SizedMatrix{S1,S2}})(x::NTuple{L,T}) where {S1,S2,T,L} = SizedArray{Tuple{S1,S2},T,2,2}(x)
+@inline SizedMatrix{S1,S2}(a::Array{T,M}) where {S1,S2,T,M} = SizedArray{Tuple{S1,S2},T,2,M}(a)
+@inline SizedMatrix{S1,S2}(x::NTuple{L,T}) where {S1,S2,T,L} = SizedArray{Tuple{S1,S2},T,2,2}(x)
 
 if isdefined(Base, :dataids) # v0.7-
     Base.dataids(sa::SizedArray) = Base.dataids(sa.data)

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -68,7 +68,7 @@ end
 
 Base.show(io::IO, ::Size{S}) where {S} = print(io, "Size", S)
 
-#= There seems to be a subtyping/specialization bug...
+Size(a::T) where {T<:AbstractArray} = Size(T)
 function Size(::Type{SA}) where {SA <: StaticArray} # A nice, default error message for when S not defined
     error("""
         The size of type `$SA` is not known.
@@ -82,9 +82,8 @@ function Size(::Type{SA}) where {SA <: StaticArray} # A nice, default error mess
             SMatrix(m)      # this error
             SMatrix{3,3}(m) # correct - size is inferrable
         """)
-end =#
-Size(a::T) where {T<:AbstractArray} = Size(T)
-Size(::Type{<:StaticArray{S}}) where {S} = Size(S)
+end
+Size(::Type{SA}) where {SA <: StaticArray{S}} where {S<:Tuple} = Size(S)  # S defined as a Tuple
 @pure Size(::Type{<:AbstractArray{<:Any, N}}) where {N} = Size(ntuple(_ -> Dynamic(), N))
 
 struct Length{L}

--- a/test/core.jl
+++ b/test/core.jl
@@ -133,6 +133,13 @@
         @test @inferred(convert(Array, ma)) == a
         @test @inferred(convert(Array{Int}, ma)) == a
         @test @inferred(convert(Array{Int,2}, ma)) == a
+
+        try
+            convert(SVector, [1,2,3])
+        catch err
+            @test isa(err, ErrorException)
+            @test startswith(err.msg, "The size of type `StaticArrays.SArray{Tuple{S},T,1,S} where T where S` is not known.")
+        end
     end
     @test_throws Exception Length{2.5}()
     @test Length(2) == Length{2}()

--- a/test/fixed_size_arrays.jl
+++ b/test/fixed_size_arrays.jl
@@ -419,6 +419,7 @@ const binaryOps = (
                                 @test r[j] == op(v1[j], v2[j])
                             end
                         end
+                    catch
                     end
                 end
             end
@@ -436,6 +437,7 @@ const binaryOps = (
                                 @test v[i] == op(t[i])
                             end
                         end
+                    catch
                     end
                 end
             end


### PR DESCRIPTION
Adding `S<:Tuple` ensured a method would be higher in the methodtable.