### PR TITLE
import mean from Statistics

### DIFF
--- a/src/StaticArrays.jl
+++ b/src/StaticArrays.jl
@@ -7,8 +7,14 @@ import Base: @_inline_meta, @_propagate_inbounds_meta, @_pure_meta, @propagate_i
 import Base: getindex, setindex!, size, similar, vec, show, length, convert, promote_op,
              promote_rule, map, map!, reduce, reducedim, mapreducedim, mapreduce, broadcast,
              broadcast!, conj, hcat, vcat, ones, zeros, one, reshape, fill, fill!, inv,
-             iszero, sum, prod, count, any, all, minimum, maximum, extrema, mean,
+             iszero, sum, prod, count, any, all, minimum, maximum, extrema,
              copy, read, read!, write
+
+if VERSION >= v"0.7.0-beta.85"
+    import Statistics: mean
+else
+    import Base: mean
+end
 
 using Random
 import Random: rand, randn, randexp, rand!, randn!, randexp!

--- a/test/mapreduce.jl
+++ b/test/mapreduce.jl
@@ -1,4 +1,7 @@
 using StaticArrays, Test
+if VERSION >= v"0.7.0-beta.85"
+    import Statistics: mean
+end
 
 @testset "Map, reduce, mapreduce, broadcast" begin
     @testset "map and map!" begin


### PR DESCRIPTION
I wonder if we still need this specialized mean now that it requires an extra dependency. This dependency does not cost anything while Statistics comes with Julia, but might be something to consider removing in the future.