### PR TITLE
Add general Tuple(::StaticArray) constructor and remove related convert method

### DIFF
--- a/src/convert.jl
+++ b/src/convert.jl
@@ -9,10 +9,8 @@
 @inline convert(::Type{SA}, sa::SA) where {SA<:StaticArray} = sa
 @inline convert(::Type{SA}, x::Tuple) where {SA<:StaticArray} = SA(x) # convert -> constructor. Hopefully no loops...
 
-# A general way of going back to a tuple
-@inline function convert(::Type{Tuple}, a::StaticArray)
-    unroll_tuple(a, Length(a))
-end
+# Constructing a Tuple from a StaticArray
+@inline Tuple(a::StaticArray) = unroll_tuple(a, Length(a))
 
 @noinline function dimension_mismatch_fail(SA::Type, a::AbstractArray)
     error("Dimension mismatch. Expected input array of length $(length(SA)), got length $(length(a))")

--- a/test/FieldVector.jl
+++ b/test/FieldVector.jl
@@ -18,6 +18,8 @@
         @test length(p) === 3
         @test eltype(p) === Float64
 
+        @testinf Tuple(p) === (1.0, 2.0, 3.0)
+
         @test (p + p) === Point3D(2.0, 4.0, 6.0)
 
         @test (p[1], p[2], p[3]) === (p.x, p.y, p.z)
@@ -58,6 +60,8 @@
         @test size(p) === (2,)
         @test length(p) === 2
         @test eltype(p) === Float64
+
+        @testinf Tuple(p) === (1.0, 2.0)
 
         @test (p[1], p[2]) === (p.x, p.y)
         @test (p[1], p[2]) === (1.0, 2.0)

--- a/test/MArray.jl
+++ b/test/MArray.jl
@@ -101,7 +101,7 @@
         @test m[3] === 13
         @test m[4] === 14
 
-        @test Tuple(m) === (11, 12, 13, 14)
+        @testinf Tuple(m) === (11, 12, 13, 14)
 
         @test size(m) === (2, 2)
         @test size(typeof(m)) === (2, 2)

--- a/test/MMatrix.jl
+++ b/test/MMatrix.jl
@@ -76,7 +76,7 @@
         @test m[3] === 13
         @test m[4] === 14
 
-        @test Tuple(m) === (11, 12, 13, 14)
+        @testinf Tuple(m) === (11, 12, 13, 14)
 
         @test size(m) === (2, 2)
         @test size(typeof(m)) === (2, 2)

--- a/test/MVector.jl
+++ b/test/MVector.jl
@@ -56,7 +56,7 @@
         @test v[2] === 12
         @test v[3] === 13
 
-        @test Tuple(v) === (11, 12, 13)
+        @testinf Tuple(v) === (11, 12, 13)
 
         @test size(v) === (3,)
         @test size(typeof(v)) === (3,)

--- a/test/SArray.jl
+++ b/test/SArray.jl
@@ -96,7 +96,7 @@
         @test m[3] === 13
         @test m[4] === 14
 
-        @test Tuple(m) === (11, 12, 13, 14)
+        @testinf Tuple(m) === (11, 12, 13, 14)
 
         @test size(m) === (2, 2)
         @test size(typeof(m)) === (2, 2)

--- a/test/SMatrix.jl
+++ b/test/SMatrix.jl
@@ -74,7 +74,7 @@
         @test m[3] === 13
         @test m[4] === 14
 
-        @test Tuple(m) === (11, 12, 13, 14)
+        @testinf Tuple(m) === (11, 12, 13, 14)
 
         @test size(m) === (2, 2)
         @test size(typeof(m)) === (2, 2)

--- a/test/SVector.jl
+++ b/test/SVector.jl
@@ -55,7 +55,7 @@
         @test v[2] === 12
         @test v[3] === 13
 
-        @test Tuple(v) === (11, 12, 13)
+        @testinf Tuple(v) === (11, 12, 13)
 
         @test size(v) === (3,)
         @test size(typeof(v)) === (3,)

--- a/test/Scalar.jl
+++ b/test/Scalar.jl
@@ -4,8 +4,8 @@
     @test (Scalar(1) + Scalar(1.0))::Scalar{Float64} ≈ Scalar(2.0)
     @test_throws ErrorException Scalar(2)[2]
     @test Scalar(2)[] == 2
-    @test Tuple(Scalar(2)) == (2,)
-    @test Tuple(convert(Scalar{Float64}, [2.0])) == (2.0,)
+    @testinf Tuple(Scalar(2)) === (2,)
+    @testinf Tuple(convert(Scalar{Float64}, [2.0])) === (2.0,)
     a = Array{Float64, 0}(undef)
     a[] = 2
     @test Scalar(a)[] == 2

--- a/test/core.jl
+++ b/test/core.jl
@@ -149,8 +149,6 @@
     @test StaticArrays.check_length(2) == nothing
     @test StaticArrays.check_length(StaticArrays.Dynamic()) == nothing
 
-    @test convert(Tuple, @SVector [2]) == (2,)
-
     @testset "dimmatch" begin
         @test StaticArrays.dimmatch(3, 3)
         @test StaticArrays.dimmatch(3, StaticArrays.Dynamic())


### PR DESCRIPTION
Fixes #446. The issue seems to be that `Tuple(::StaticArray)` does not fall back to `convert` as defined in the lines above this proposed change (see below) so one fix is to make that fallback explicit.
```julia
  | | |_| | | | (_| |  |  Version 0.7.0-beta.125 (2018-07-02 20:55 UTC)
 _/ |\__'_|_|_|\__'_|  |  Commit c5bf467361 (1 day old master)
|__/                   |  x86_64-linux-gnu

julia> using BenchmarkTools, StaticArrays

julia> struct Point3D <: FieldVector{3, Float64}
           x::Float64
           y::Float64
           z::Float64
       end

julia> p = rand(Point3D)
3-element Point3D:
 0.6628326877139248
 0.14765795872117993
 0.48470441802594144

julia> @benchmark Point3D($p)
BenchmarkTools.Trial:
  memory estimate:  224 bytes
  allocs estimate:  6
  --------------
  minimum time:     342.486 ns (0.00% GC)
  median time:      355.670 ns (0.00% GC)
  mean time:        387.416 ns (7.73% GC)
  maximum time:     144.887 μs (99.70% GC)
  --------------
  samples:          10000
  evals/sample:     212

julia> @which Tuple(p)
(::Type{T})(itr) where T<:Tuple in Base at tuple.jl:242

julia> @inline Tuple(a::StaticArray) = convert(Tuple, a)
Tuple

julia> @benchmark Point3D($p)
BenchmarkTools.Trial:
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     1.302 ns (0.00% GC)
  median time:      1.312 ns (0.00% GC)
  mean time:        1.312 ns (0.00% GC)
  maximum time:     17.192 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     1000

```