### PR TITLE
Fix #388, hcat allocations with Julia master

### DIFF
--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -89,9 +89,9 @@ end
 end
 
 @inline vcat(a::StaticVecOrMat) = a
-@inline vcat(a::Union{StaticVector, StaticMatrix}, b::StaticVecOrMat) = _vcat(Size(a), Size(b), a, b)
-@inline vcat(a::StaticVecOrMat, b::StaticVecOrMat, c::StaticVecOrMat...) =
-    vcat(vcat(a,b), vcat(c...))
+@inline vcat(a::StaticVecOrMat, b::StaticVecOrMat) = _vcat(Size(a), Size(b), a, b)
+@inline vcat(a::StaticVecOrMat, b::StaticVecOrMat, c::StaticVecOrMat...) = vcat(vcat(a,b), vcat(c...))
+
 @generated function _vcat(::Size{Sa}, ::Size{Sb}, a::StaticVecOrMat, b::StaticVecOrMat) where {Sa, Sb}
     if Size(Sa)[2] != Size(Sb)[2]
         throw(DimensionMismatch("Tried to vcat arrays of size $Sa and $Sb"))
@@ -118,8 +118,7 @@ end
 @inline hcat(a::StaticVector) = similar_type(a, Size(Size(a)[1],1))(a)
 @inline hcat(a::StaticMatrix) = a
 @inline hcat(a::StaticVecOrMat, b::StaticVecOrMat) = _hcat(Size(a), Size(b), a, b)
-@inline hcat(a::StaticVecOrMat, b::StaticVecOrMat, c::StaticVecOrMat...) =
-    hcat(hcat(a,b), hcat(c...))
+@inline hcat(a::StaticVecOrMat, b::StaticVecOrMat, c::StaticVecOrMat...) = hcat(hcat(a,b), hcat(c...))
 
 @generated function _hcat(::Size{Sa}, ::Size{Sb}, a::StaticVecOrMat, b::StaticVecOrMat) where {Sa, Sb}
     if Sa[1] != Sb[1]

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -161,6 +161,25 @@ using StaticArrays, Test, LinearAlgebra
 
         vcat(SVector(1.0f0), SVector(1.0)) === SVector(1.0, 1.0)
         hcat(SVector(1.0f0), SVector(1.0)) === SMatrix{1,2}(1.0, 1.0)
+
+        # issue #388
+        let x = SVector(1, 2, 3)
+            # current limit: 34 arguments
+            hcat(
+                x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x,
+                x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x)
+            allocs = @allocated hcat(
+                x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x,
+                x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x)
+            @test allocs == 0
+            vcat(
+                x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x,
+                x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x)
+            allocs = @allocated vcat(
+                x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x,
+                x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x)
+            @test allocs == 0
+        end
     end
 
     @testset "normalization" begin

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -164,21 +164,31 @@ using StaticArrays, Test, LinearAlgebra
 
         # issue #388
         let x = SVector(1, 2, 3)
-            # current limit: 34 arguments
-            hcat(
-                x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x,
-                x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x)
-            allocs = @allocated hcat(
-                x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x,
-                x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x)
-            @test allocs == 0
-            vcat(
-                x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x,
-                x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x)
-            allocs = @allocated vcat(
-                x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x,
-                x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x)
-            @test allocs == 0
+            if VERSION >= v"0.7.0-beta.47"
+                # current limit: 34 arguments
+                hcat(
+                    x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x,
+                    x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x)
+                allocs = @allocated hcat(
+                    x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x,
+                    x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x)
+                @test allocs == 0
+                vcat(
+                    x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x,
+                    x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x)
+                allocs = @allocated vcat(
+                    x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x,
+                    x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x)
+                @test allocs == 0
+            else
+                # current limit: 14 arguments
+                hcat(x, x, x, x, x, x, x, x, x, x, x, x, x, x)
+                allocs = @allocated hcat(x, x, x, x, x, x, x, x, x, x, x, x, x, x)
+                @test allocs == 0
+                vcat(x, x, x, x, x, x, x, x, x, x, x, x, x, x)
+                allocs = @allocated vcat(x, x, x, x, x, x, x, x, x, x, x, x, x, x)
+                @test allocs == 0
+            end
         end
     end
 


### PR DESCRIPTION
Apparently this is a bit easier on the compiler.

(also just use `StaticVecOrMat` instead of `Union{StaticVector,StaticMatrix}`)