### PR TITLE
Doc update to reflect syntax change for parametric methods

### DIFF
--- a/docs/src/pages/api.md
+++ b/docs/src/pages/api.md
@@ -105,10 +105,10 @@ behaving just like `similar`, except that it returns a type. Relevant methods
 are:
 
 ```julia
-similar_type{A <: StaticArray}(::Type{A}) # defaults to A
-similar_type{A <: StaticArray, ElType}(::Type{A}, ::Type{ElType}) # Change element type
-similar_type{A <: AbstractArray}(::Type{A}, size::Size) # Change size
-similar_type{A <: AbstractArray, ElType}(::Type{A}, ::Type{ElType}, size::Size) # Change both
+similar_type(::Type{A}) where {A <: StaticArray} # defaults to A
+similar_type(::Type{A}, ::Type{ElType}) where {A <: StaticArray, ElType} # Change element type
+similar_type(::Type{A}, size::Size) where {A <: AbstractArray} # Change size
+similar_type(::Type{A}, ::Type{ElType}, size::Size) where {A <: AbstractArray, ElType} # Change both
 ```
 
 These setting will affect everything, from indexing, to matrix multiplication

--- a/src/abstractarray.jl
+++ b/src/abstractarray.jl
@@ -35,7 +35,7 @@ be *constructed* with its data.
 Note that the (optional) size *must* be specified as a static `Size` object (so the compiler
 can infer the result statically).
 
-New types should define the signature `similar_type{A<:MyType,T,S}(::Type{A},::Type{T},::Size{S})`
+New types should define the signature `similar_type(::Type{A},::Type{T},::Size{S}) where {A<:MyType,T,S}`
 if they wish to overload the default behavior.
 """
 function similar_type end


### PR DESCRIPTION
The old syntax seems to be deprecated now (https://github.com/JuliaLang/julia/blob/master/NEWS.md, first bullet point under "Language changes").