### PR TITLE
Fixes for new (map)reducedim API

### DIFF
--- a/src/FixedSizeArrays.jl
+++ b/src/FixedSizeArrays.jl
@@ -75,13 +75,13 @@ export unit
 
 function Base.extrema(a::AbstractVector{T}) where T <: StaticVector
     ET = eltype(T)
-    reduce((x, v)-> (min.(x[1], v), max.(x[2], v)), (T(typemax(ET)), T(typemin(ET))), a)
+    reduce((x, v)-> (min.(x[1], v), max.(x[2], v)), a, init=(T(typemax(ET)), T(typemin(ET))))
 end
 function Base.minimum(a::AbstractVector{T}) where T <: StaticVector
-    reduce((x, v)-> min.(x[1], v), T(typemax(eltype(T))), a)
+    reduce((x, v)-> min.(x[1], v), a, init=T(typemax(eltype(T))))
 end
 function Base.maximum(a::AbstractVector{T}) where T <: StaticVector
-    reduce((x, v)-> max.(x[1], v), T(typemin(eltype(T))), a)
+    reduce((x, v)-> max.(x[1], v), a, init=T(typemin(eltype(T))))
 end
 
 

--- a/src/StaticArrays.jl
+++ b/src/StaticArrays.jl
@@ -3,7 +3,7 @@ module StaticArrays
 import Base: @_inline_meta, @_propagate_inbounds_meta, @_pure_meta, @propagate_inbounds, @pure
 
 import Base: getindex, setindex!, size, similar, vec, show, length, convert, promote_op,
-             promote_rule, map, map!, reduce, reducedim, mapreducedim, mapreduce, broadcast,
+             promote_rule, map, map!, reduce, mapreduce, broadcast,
              broadcast!, conj, hcat, vcat, ones, zeros, one, reshape, fill, fill!, inv,
              iszero, sum, prod, count, any, all, minimum, maximum, extrema,
              copy, read, read!, write

--- a/src/StaticArrays.jl
+++ b/src/StaticArrays.jl
@@ -19,8 +19,8 @@ import Random: rand, randn, randexp, rand!, randn!, randexp!
 using Core.Compiler: return_type
 import Base: sqrt, exp, log
 using LinearAlgebra
-import LinearAlgebra: transpose, adjoint, vecdot, eigvals, eigen, lyap, tr,
-                      kron, diag, norm, dot, diagm, lu, svd, svdvals, svdfact,
+import LinearAlgebra: transpose, adjoint, eigvals, eigen, lyap, tr,
+                      kron, diag, norm, dot, diagm, lu, svd, svdvals,
                       factorize, ishermitian, issymmetric, isposdef, normalize,
                       normalize!, Eigen, det, logdet, cross, diff, qr
 # import eye for deprecation warnings

--- a/src/abstractarray.jl
+++ b/src/abstractarray.jl
@@ -8,6 +8,8 @@ length(a::Type{SA}) where {SA <: StaticArray} = prod(Size(SA))
 end
 @inline size(a::StaticArray) = size(typeof(a))
 @inline size(a::StaticArray, d::Int) = size(typeof(a), d)
+@inline size(a::StaticArray, ::Val{D}) where D = size(a, D)
+@inline size(a::StaticArray, ::Colon) = length(a)
 
 # This seems to confuse Julia a bit in certain circumstances (specifically for trailing 1's)
 @inline function Base.isassigned(a::StaticArray, i::Int...)

--- a/src/expm.jl
+++ b/src/expm.jl
@@ -54,7 +54,7 @@ end
     f = exp((a + d + z)/2)
     zr = inv(z)
 
-    m11 = (-e*(a - d - z) + f*(a - d + z)) * zr/2  
+    m11 = (-e*(a - d - z) + f*(a - d + z)) * zr/2
     m12 = (f-e) * b * zr
     m21 = (f-e) * c * zr
     m22 = (-e*(-a + d - z) + f*(-a + d + z)) * zr/2
@@ -68,7 +68,7 @@ function _exp(::Size, _A::StaticMatrix{<:Any,<:Any,T}) where T
     S = typeof((zero(T)*zero(T) + zero(T)*zero(T))/one(T))
     A = S.(_A)
     # omitted: matrix balancing, i.e., LAPACK.gebal!
-    nA = maximum(sum(abs.(A), Val{1}))    # marginally more performant than norm(A, 1)
+    nA = maximum(sum(abs.(A), dims=Val(1)))    # marginally more performant than norm(A, 1)
     ## For sufficiently small nA, use lower order Padé-Approximations
     if (nA <= 2.1)
         A2 = A*A

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -222,8 +222,7 @@ end
     @inbounds return similar_type(a, typeof(Signed(a[2]*b[3])-Signed(a[3]*b[2])))(((Signed(a[2]*b[3])-Signed(a[3]*b[2]), Signed(a[3]*b[1])-Signed(a[1]*b[3]), Signed(a[1]*b[2])-Signed(a[2]*b[1]))))
 end
 
-@inline dot(a::StaticVector, b::StaticVector) = _vecdot(same_size(a, b), a, b)
-@inline vecdot(a::StaticArray, b::StaticArray) = _vecdot(same_size(a, b), a, b)
+@inline dot(a::StaticArray, b::StaticArray) = _vecdot(same_size(a, b), a, b)
 @generated function _vecdot(::Size{S}, a::StaticArray, b::StaticArray) where {S}
     if prod(S) == 0
         return :(zero(promote_op(*, eltype(a), eltype(b))))
@@ -257,7 +256,7 @@ end
     end
 end
 
-@inline LinearAlgebra.norm_sqr(v::StaticVector) = mapreduce(abs2, +, zero(real(eltype(v))), v)
+@inline LinearAlgebra.norm_sqr(v::StaticVector) = mapreduce(abs2, +, v, init=zero(real(eltype(v))))
 
 @inline norm(a::StaticArray) = _norm(Size(a), a)
 @generated function _norm(::Size{S}, a::StaticArray) where {S}
@@ -297,13 +296,13 @@ _norm_p0(x) = x == 0 ? zero(x) : one(x)
     return quote
         $(Expr(:meta, :inline))
         if p == Inf
-            return mapreduce(abs, max, $(zero(real(eltype(a)))), a)
+            return mapreduce(abs, max, a, init=$(zero(real(eltype(a)))))
         elseif p == 1
             @inbounds return $expr_p1
         elseif p == 2
             return norm(a)
         elseif p == 0
-            return mapreduce(_norm_p0, +, $(zero(real(eltype(a)))), a)
+            return mapreduce(_norm_p0, +, a, init=$(zero(real(eltype(a)))))
         else
             @inbounds return ($expr)^(inv(p))
         end

--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -60,12 +60,8 @@ end
 ## mapreduce ##
 ###############
 
-@inline function mapreduce(f, op, a::StaticArray, b::StaticArray...)
-    _mapreduce(f, op, same_size(a, b...), a, b...)
-end
-
-@inline function mapreduce(f, op, v0, a::StaticArray, b::StaticArray...)
-    _mapreduce(f, op, v0, same_size(a, b...), a, b...)
+@inline function mapreduce(f, op, a::StaticArray, b::StaticArray...; init = nothing)
+    _mapreduce(f, op, init, same_size(a, b...), a, b...)
 end
 
 @generated function _mapreduce(f, op, ::Size{S}, a::StaticArray...) where {S}
@@ -93,6 +89,8 @@ end
     end
 end
 
+_mapreduce(f, op, v0::Nothing, ::Size{S}, a::StaticArray, b::StaticArray...) where {S} = _mapreduce(f, op, Size{S}(), a, b...)
+
 ##################
 ## mapreducedim ##
 ##################
@@ -100,15 +98,11 @@ end
 # I'm not sure why the signature for this from Base precludes multiple arrays?
 # (also, why not mutating `mapreducedim!` and `reducedim!`?)
 # (similarly, `broadcastreduce` and `broadcastreducedim` sounds useful)
-@inline function mapreducedim(f, op, a::StaticArray, ::Type{Val{D}}) where {D}
-    _mapreducedim(f, op, Size(a), a, Val{D})
+@inline function mapreduce(f, op, a::StaticArray; dims=:, init=nothing)
+    _mapreducedim(f, op, Size(a), a, dims, init)
 end
 
-@inline function mapreducedim(f, op, a::StaticArray, ::Type{Val{D}}, v0) where {D}
-    _mapreducedim(f, op, Size(a), a, Val{D}, v0)
-end
-
-@generated function _mapreducedim(f, op, ::Size{S}, a::StaticArray, ::Type{Val{D}}) where {S,D}
+@generated function _mapreducedim(f, op, ::Size{S}, a::StaticArray, ::Val{D}) where {S,D}
     N = length(S)
     Snew = ([n==D ? 1 : S[n] for n = 1:N]...,)
     T0 = eltype(a)
@@ -133,7 +127,7 @@ end
     end
 end
 
-@generated function _mapreducedim(f, op, ::Size{S}, a::StaticArray, ::Type{Val{D}}, v0::T) where {S,D,T}
+@generated function _mapreducedim(f, op, ::Size{S}, a::StaticArray, ::Val{D}, v0::T) where {S,D,T}
     N = length(S)
     Snew = ([n==D ? 1 : S[n] for n = 1:N]...,)
 
@@ -156,19 +150,15 @@ end
     end
 end
 
+@inline _mapreducedim(f, op, ::Size{S}, a::StaticArray, dims::Colon, v0::Nothing) where {S} = _mapreduce(f, op, Size{S}(), a::StaticArray)
+@inline _mapreducedim(f, op, ::Size{S}, a::StaticArray, dims::Colon, v0) where {S} = _mapreduce(f, op, v0, Size{S}(), a::StaticArray)
+@inline _mapreducedim(f, op, ::Size{S}, a::StaticArray, dims::Val{D}, v0::Nothing) where {D,S} = _mapreducedim(f, op, Size{S}(), a::StaticArray, dims)
+
 ############
 ## reduce ##
 ############
 
-@inline reduce(op, a::StaticArray) = mapreduce(identity, op, a)
-@inline reduce(op, v0, a::StaticArray) = mapreduce(identity, op, v0, a)
-
-###############
-## reducedim ##
-###############
-
-@inline reducedim(op, a::StaticArray, ::Type{Val{D}}) where {D} = mapreducedim(identity, op, a, Val{D})
-@inline reducedim(op, a::StaticArray, ::Type{Val{D}}, v0) where {D} = mapreducedim(identity, op, a, Val{D}, v0)
+@inline reduce(op, a::StaticArray; init=nothing, dims=:) = mapreduce(identity, op, a, init=init, dims=dims)
 
 #######################
 ## related functions ##
@@ -178,68 +168,47 @@ end
 #
 # Implementation notes:
 #
-# 1. When providing an initial value v0, note that its location is different in reduce and
-# reducedim: v0 comes earlier than collection in reduce, whereas it is the last argument in
-# reducedim.  The same difference exists between mapreduce and mapreducedim.
-#
-# 2. mapreduce and mapreducedim usually do not take initial value v0, because we don't
+# 1. mapreduce usually does not take initial value v0, because we don't
 # always know the return type of an arbitrary mapping function f.  (We usually want to use
 # some initial value such as one(T) or zero(T) as v0, where T is the return type of f, but
 # if users provide type-unstable f, its return type cannot be known.)  Therefore, mapped
 # versions of the functions implemented below usually require the collection to have at
 # least two entries.
 #
-# 3. Exceptions are the ones that require Boolean mapping functions.  For example, f in
+# 2. Exceptions are the ones that require Boolean mapping functions.  For example, f in
 # all and any must return Bool, so we know the appropriate v0 is true and false,
 # respectively.  Therefore, all(f, ...) and any(f, ...) are implemented by mapreduce(f, ...)
-# with an initial value v0 = true and false.
-@inline iszero(a::StaticArray{<:Any,T}) where {T} = reduce((x,y) -> x && (y==zero(T)), true, a)
+# with an initial value true and false.
+@inline iszero(a::StaticArray{<:Any,T}) where {T} = reduce((x,y) -> x && (y==zero(T)), a, init=true)
 
-@inline sum(a::StaticArray{<:Any,T}) where {T} = reduce(+, zero(T), a)
-@inline sum(f::Function, a::StaticArray) = mapreduce(f, +, a)
-@inline sum(a::StaticArray{<:Any,T}, ::Type{Val{D}}) where {T,D} = reducedim(+, a, Val{D}, zero(T))
-@inline sum(f::Function, a::StaticArray, ::Type{Val{D}}) where D = mapreducedim(f, +, a, Val{D})
+@inline sum(a::StaticArray{<:Any,T}; dims=:) where {T} = reduce(+, a, dims=dims, init=zero(T))
+@inline sum(f::Function, a::StaticArray; dims=:) = mapreduce(f, +, a, dims=dims)
 
-@inline prod(a::StaticArray{<:Any,T}) where {T} = reduce(*, one(T), a)
-@inline prod(f::Function, a::StaticArray{<:Any,T}) where {T} = mapreduce(f, *, a)
-@inline prod(a::StaticArray{<:Any,T}, ::Type{Val{D}}) where {T,D} = reducedim(*, a, Val{D}, one(T))
-@inline prod(f::Function, a::StaticArray{<:Any,T}, ::Type{Val{D}}) where {T,D} = mapreducedim(f, *, a, Val{D})
+@inline prod(a::StaticArray{<:Any,T}; dims=:) where {T} = reduce(*, a, dims=dims, init=one(T))
+@inline prod(f::Function, a::StaticArray{<:Any,T}; dims=:) where {T} = mapreduce(f, *, a, dims=dims)
 
-@inline count(a::StaticArray{<:Any,Bool}) = reduce(+, 0, a)
-@inline count(f::Function, a::StaticArray) = mapreduce(x->f(x)::Bool, +, 0, a)
-@inline count(a::StaticArray{<:Any,Bool}, ::Type{Val{D}}) where {D} = reducedim(+, a, Val{D}, 0)
-@inline count(f::Function, a::StaticArray, ::Type{Val{D}}) where {D} = mapreducedim(x->f(x)::Bool, +, a, Val{D}, 0)
+@inline count(a::StaticArray{<:Any,Bool}; dims=:) = reduce(+, a, dims=dims, init=0)
+@inline count(f::Function, a::StaticArray; dims=:) = mapreduce(x->f(x)::Bool, +, a, dims=dims, init=0)
 
-@inline all(a::StaticArray{<:Any,Bool}) = reduce(&, true, a)  # non-branching versions
-@inline all(f::Function, a::StaticArray) = mapreduce(x->f(x)::Bool, &, true, a)
-@inline all(a::StaticArray{<:Any,Bool}, ::Type{Val{D}}) where {D} = reducedim(&, a, Val{D}, true)
-@inline all(f::Function, a::StaticArray, ::Type{Val{D}}) where {D} = mapreducedim(x->f(x)::Bool, &, a, Val{D}, true)
+@inline all(a::StaticArray{<:Any,Bool}; dims=:) = reduce(&, a, dims=dims, init=true)
+@inline all(f::Function, a::StaticArray; dims=:) = mapreduce(x->f(x)::Bool, &, a, dims=dims, init=true)
 
-@inline any(a::StaticArray{<:Any,Bool}) = reduce(|, false, a) # (benchmarking needed)
-@inline any(f::Function, a::StaticArray) = mapreduce(x->f(x)::Bool, |, false, a) # (benchmarking needed)
-@inline any(a::StaticArray{<:Any,Bool}, ::Type{Val{D}}) where {D} = reducedim(|, a, Val{D}, false)
-@inline any(f::Function, a::StaticArray, ::Type{Val{D}}) where {D} = mapreducedim(x->f(x)::Bool, |, a, Val{D}, false)
+@inline any(a::StaticArray{<:Any,Bool}; dims=:) = reduce(|, a, dims=dims, init=false)
+@inline any(f::Function, a::StaticArray; dims=:) = mapreduce(x->f(x)::Bool, |, a, dims=dims, init=false)
 
-@inline mean(a::StaticArray) = sum(a) / length(a)
-@inline mean(f::Function, a::StaticArray) = sum(f, a) / length(a)
-@inline mean(a::StaticArray, ::Type{Val{D}}) where {D} = sum(a, Val{D}) / size(a, D)
-@inline mean(f::Function, a::StaticArray, ::Type{Val{D}}) where {D} = sum(f, a, Val{D}) / size(a, D)
+@inline mean(a::StaticArray; dims=:) = sum(a, dims=dims) / size(a, dims)
+@inline mean(f::Function, a::StaticArray; dims=:) = sum(f, a, dims=dims) / size(a, dims)
 
-@inline minimum(a::StaticArray) = reduce(min, a) # base has mapreduce(idenity, scalarmin, a)
-@inline minimum(f::Function, a::StaticArray) = mapreduce(f, min, a)
-@inline minimum(a::StaticArray, ::Type{Val{D}}) where {D} = reducedim(min, a, Val{D})
-@inline minimum(f::Function, a::StaticArray, ::Type{Val{D}}) where {D} = mapreducedim(f, min, a, Val{D})
+@inline minimum(a::StaticArray; dims=:) = reduce(min, a, dims=dims)
+@inline minimum(f::Function, a::StaticArray; dims=:) = mapreduce(f, min, a, dims=dims)
 
-@inline maximum(a::StaticArray) = reduce(max, a) # base has mapreduce(idenity, scalarmax, a)
-@inline maximum(f::Function, a::StaticArray) = mapreduce(f, max, a)
-@inline maximum(a::StaticArray, ::Type{Val{D}}) where {D} = reducedim(max, a, Val{D})
-@inline maximum(f::Function, a::StaticArray, ::Type{Val{D}}) where {D} = mapreducedim(f, max, a, Val{D})
+@inline maximum(a::StaticArray; dims=:) = reduce(max, a, dims=dims)
+@inline maximum(f::Function, a::StaticArray; dims=:) = mapreduce(f, max, a, dims=dims)
 
 # Diff is slightly different
-@inline diff(a::StaticArray) = diff(a, Val{1})
-@inline diff(a::StaticArray, ::Type{Val{D}}) where {D} = _diff(Size(a), a, Val{D})
+@inline diff(a::StaticArray; dims=Val(1)) = _diff(Size(a), a, dims)
 
-@generated function _diff(::Size{S}, a::StaticArray, ::Type{Val{D}}) where {S,D}
+@generated function _diff(::Size{S}, a::StaticArray, ::Val{D}) where {S,D}
     N = length(S)
     Snew = ([n==D ? S[n]-1 : S[n] for n = 1:N]...,)
 

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -217,7 +217,7 @@ using StaticArrays, Test, LinearAlgebra
     end
 
     @testset "size zero" begin
-        @test vecdot(SVector{0, Float64}(()), SVector{0, Float64}(())) === 0.
+        @test dot(SVector{0, Float64}(()), SVector{0, Float64}(())) === 0.
         @test StaticArrays.bilinear_vecdot(SVector{0, Float64}(()), SVector{0, Float64}(())) === 0.
         @test norm(SVector{0, Float64}(())) === 0.
         @test norm(SVector{0, Float64}(()), 1) === 0.

--- a/test/mapreduce.jl
+++ b/test/mapreduce.jl
@@ -28,20 +28,20 @@ end
         @test mv3 == @MVector [7, 9, 11, 13]
     end
 
-    @testset "[map]reduce and [map]reducedim" begin
+    @testset "[map]reduce" begin
         a = rand(4,3); sa = SMatrix{4,3}(a); (I,J) = size(a)
         v1 = [2,4,6,8]; sv1 = SVector{4}(v1)
         v2 = [4,3,2,1]; sv2 = SVector{4}(v2)
         @test reduce(+, sv1) === reduce(+, v1)
-        @test reduce(+, 0, sv1) === reduce(+, 0, v1)
-        @test reducedim(max, sa, Val{1}, -1.) === SMatrix{1,J}(reduce(max, -1., a, dims=1))
-        @test reducedim(max, sa, Val{2}, -1.) === SMatrix{I,1}(reduce(max, -1., a, dims=2))
+        @test reduce(+, sv1, init = 0) === reduce(+, v1, init = 0)
+        @test reduce(max, sa, dims=Val(1), init=-1.) === SMatrix{1,J}(reduce(max, a, dims=1, init=-1.))
+        @test reduce(max, sa, dims=Val(2), init=-1.) === SMatrix{I,1}(reduce(max, a, dims=2, init=-1.))
         @test mapreduce(-, +, sv1) === mapreduce(-, +, v1)
-        @test mapreduce(-, +, 0, sv1) === mapreduce(-, +, 0, v1)
+        @test mapreduce(-, +, sv1, init = 0) === mapreduce(-, +, v1, init = 0)
         @test mapreduce(*, +, sv1, sv2) === 40
-        @test mapreduce(*, +, 0, sv1, sv2) === 40
-        @test mapreducedim(x->x^2, max, sa, Val{1}, -1.) == SMatrix{1,J}(mapreduce(x->x^2, max, -1., a, dims=1))
-        @test mapreducedim(x->x^2, max, sa, Val{2}, -1.) == SMatrix{I,1}(mapreduce(x->x^2, max, -1., a, dims=2))
+        @test mapreduce(*, +, sv1, sv2, init = 0) === 40
+        @test mapreduce(x->x^2, max, sa, dims=Val(1), init=-1.) == SMatrix{1,J}(mapreduce(x->x^2, max, a, dims=1, init=-1.))
+        @test mapreduce(x->x^2, max, sa, dims=Val(2), init=-1.) == SMatrix{I,1}(mapreduce(x->x^2, max, a, dims=2, init=-1.))
     end
 
     @testset "implemented by [map]reduce and [map]reducedim" begin
@@ -58,52 +58,52 @@ end
 
         @test sum(sa) === sum(a)
         @test sum(abs2, sa) === sum(abs2, a)
-        @test sum(sa, Val{2}) === RSArray2(sum(a, dims=2))
-        @test sum(abs2, sa, Val{2}) === RSArray2(sum(abs2, a, dims=2))
+        @test sum(sa, dims=Val(2)) === RSArray2(sum(a, dims=2))
+        @test sum(abs2, sa, dims=Val(2)) === RSArray2(sum(abs2, a, dims=2))
 
         @test prod(sa) === prod(a)
         @test prod(abs2, sa) === prod(abs2, a)
-        @test prod(sa, Val{2}) === RSArray2(prod(a, dims=2))
-        @test prod(abs2, sa, Val{2}) === RSArray2(prod(abs2, a, dims=2))
+        @test prod(sa, dims=Val(2)) === RSArray2(prod(a, dims=2))
+        @test prod(abs2, sa, dims=Val(2)) === RSArray2(prod(abs2, a, dims=2))
 
         @test count(sb) === count(b)
         @test count(x->x>0, sa) === count(x->x>0, a)
-        @test count(sb, Val{2}) === RSArray2(reshape([count(b[i,:,k]) for i = 1:I, k = 1:K], (I,1,K)))
-        @test count(x->x>0, sa, Val{2}) === RSArray2(reshape([count(x->x>0, a[i,:,k]) for i = 1:I, k = 1:K], (I,1,K)))
+        @test count(sb, dims=Val(2)) === RSArray2(reshape([count(b[i,:,k]) for i = 1:I, k = 1:K], (I,1,K)))
+        @test count(x->x>0, sa, dims=Val(2)) === RSArray2(reshape([count(x->x>0, a[i,:,k]) for i = 1:I, k = 1:K], (I,1,K)))
 
         @test all(sb) === all(b)
         @test all(x->x>0, sa) === all(x->x>0, a)
-        @test all(sb, Val{2}) === RSArray2(all(b, dims=2))
-        @test all(x->x>0, sa, Val{2}) === RSArray2(all(x->x>0, a, dims=2))
+        @test all(sb, dims=Val(2)) === RSArray2(all(b, dims=2))
+        @test all(x->x>0, sa, dims=Val(2)) === RSArray2(all(x->x>0, a, dims=2))
 
         @test any(sb) === any(b)
         @test any(x->x>0, sa) === any(x->x>0, a)
-        @test any(sb, Val{2}) === RSArray2(any(b, dims=2))
-        @test any(x->x>0, sa, Val{2}) === RSArray2(any(x->x>0, a, dims=2))
+        @test any(sb, dims=Val(2)) === RSArray2(any(b, dims=2))
+        @test any(x->x>0, sa, dims=Val(2)) === RSArray2(any(x->x>0, a, dims=2))
 
         @test mean(sa) === mean(a)
         @test mean(abs2, sa) === mean(abs2, a)
-        @test mean(sa, Val{2}) === RSArray2(mean(a, dims=2))
-        @test mean(abs2, sa, Val{2}) === RSArray2(mean(abs2.(a), dims=2))
+        @test mean(sa, dims=Val(2)) === RSArray2(mean(a, dims=2))
+        @test mean(abs2, sa, dims=Val(2)) === RSArray2(mean(abs2.(a), dims=2))
 
         @test minimum(sa) === minimum(a)
         @test minimum(abs2, sa) === minimum(abs2, a)
-        @test minimum(sa, Val{2}) === RSArray2(minimum(a, dims=2))
-        @test minimum(abs2, sa, Val{2}) === RSArray2(minimum(abs2, a, dims=2))
+        @test minimum(sa, dims=Val(2)) === RSArray2(minimum(a, dims=2))
+        @test minimum(abs2, sa, dims=Val(2)) === RSArray2(minimum(abs2, a, dims=2))
 
         @test maximum(sa) === maximum(a)
         @test maximum(abs2, sa) === maximum(abs2, a)
-        @test maximum(sa, Val{2}) === RSArray2(maximum(a, dims=2))
-        @test maximum(abs2, sa, Val{2}) === RSArray2(maximum(abs2, a, dims=2))
+        @test maximum(sa, dims=Val(2)) === RSArray2(maximum(a, dims=2))
+        @test maximum(abs2, sa, dims=Val(2)) === RSArray2(maximum(abs2, a, dims=2))
 
-        @test diff(sa, Val{1}) === RSArray1(a[2:end,:,:] - a[1:end-1,:,:])
-        @test diff(sa, Val{2}) === RSArray2(a[:,2:end,:] - a[:,1:end-1,:])
-        @test diff(sa, Val{3}) === RSArray3(a[:,:,2:end] - a[:,:,1:end-1])
+        @test diff(sa, dims=Val(1)) === RSArray1(a[2:end,:,:] - a[1:end-1,:,:])
+        @test diff(sa, dims=Val(2)) === RSArray2(a[:,2:end,:] - a[:,1:end-1,:])
+        @test diff(sa, dims=Val(3)) === RSArray3(a[:,:,2:end] - a[:,:,1:end-1])
 
         # as of Julia v0.6, diff() for regular Array is defined only for vectors and matrices
         m = randn(4,3); sm = SMatrix{4,3}(m)
-        @test diff(sm, Val{1}) == diff(m, dims=1) == diff(sm)
-        @test diff(sm, Val{2}) == diff(m, dims=2)
+        @test diff(sm, dims=Val(1)) == diff(m, dims=1) == diff(sm)
+        @test diff(sm, dims=Val(2)) == diff(m, dims=2)
     end
 
     @testset "broadcast and broadcast!" begin


### PR DESCRIPTION
These are some quite fundamental changes to for these functions work and the new versions rely more on constant propagation. Since so much else is getting changed, I've also made the change to dispatch on `Val` values instead of `Val` types. @andyferris Maybe we should sit down and discuss this since we'll be in the same room tomorrow.