### PR TITLE
fixed MMatrix boundschecks, faster getindex

### DIFF
--- a/src/MArray.jl
+++ b/src/MArray.jl
@@ -106,8 +106,13 @@ end
 ## MArray methods ##
 ####################
 
-function getindex(v::MArray, i::Int)
-    Base.@_inline_meta
+@propagate_inbounds function getindex(v::MArray, i::Int)
+    if isbitstype(T)
+        @boundscheck if i < 1 || i > length(v)
+            throw(BoundsError())
+        end
+        return unsafe_load(Base.unsafe_convert(Ptr{T}, pointer_from_objref(v)), i)
+    end
     v.data[i]
 end
 

--- a/src/MArray.jl
+++ b/src/MArray.jl
@@ -107,22 +107,19 @@ end
 ####################
 
 @propagate_inbounds function getindex(v::MArray, i::Int)
+    @boundscheck checkbounds(v,i) 
     T = eltype(v)
+    
     if isbitstype(T)
-        @boundscheck if i < 1 || i > length(v)
-            throw(BoundsError(v,i))
-        end
         return unsafe_load(Base.unsafe_convert(Ptr{T}, pointer_from_objref(v)), i)
     end
     v.data[i]
 end
 
 @inline function setindex!(v::MArray, val, i::Int)
-    @boundscheck if i < 1 || i > length(v)
-        throw(BoundsError(v,i))
-    end
-
+    @boundscheck checkbounds(v,i) 
     T = eltype(v)
+
     if isbitstype(T)
         unsafe_store!(Base.unsafe_convert(Ptr{T}, pointer_from_objref(v)), convert(T, val), i)
     else

--- a/src/MArray.jl
+++ b/src/MArray.jl
@@ -107,9 +107,10 @@ end
 ####################
 
 @propagate_inbounds function getindex(v::MArray, i::Int)
+    T = eltype(v)
     if isbitstype(T)
         @boundscheck if i < 1 || i > length(v)
-            throw(BoundsError())
+            throw(BoundsError(v,i))
         end
         return unsafe_load(Base.unsafe_convert(Ptr{T}, pointer_from_objref(v)), i)
     end
@@ -118,7 +119,7 @@ end
 
 @inline function setindex!(v::MArray, val, i::Int)
     @boundscheck if i < 1 || i > length(v)
-        throw(BoundsError())
+        throw(BoundsError(v,i))
     end
 
     T = eltype(v)

--- a/src/MMatrix.jl
+++ b/src/MMatrix.jl
@@ -75,33 +75,6 @@ end
 ## MMatrix methods ##
 #####################
 
-@propagate_inbounds function getindex(v::MMatrix{S1,S2,T}, i::Int) where {S1,S2,T}
-    if isbitstype(T)
-        @boundscheck if i < 1 || i > length(v)
-            throw(BoundsError())
-        end
-        return unsafe_load(Base.unsafe_convert(Ptr{T}, pointer_from_objref(v)), i)
-    end
-    v.data[i]
-end
-
-@propagate_inbounds setindex!(m::MMatrix{S1,S2,T}, val, i::Int) where {S1,S2,T} = setindex!(m, convert(T, val), i)
-@propagate_inbounds function setindex!(m::MMatrix{S1,S2,T}, val::T, i::Int) where {S1,S2,T}
-    #@boundscheck if i < 1 || i > length(m)
-    #    throw(BoundsError(m,i))
-    #end
-
-    if isbitstype(T)
-        unsafe_store!(Base.unsafe_convert(Ptr{T}, pointer_from_objref(m)), val, i)
-    else # TODO check that this isn't crazy. Also, check it doesn't cause problems with GC...
-        # This one is unsafe (#27)
-        # unsafe_store!(Base.unsafe_convert(Ptr{Ptr{Nothing}}, pointer_from_objref(m.data)), pointer_from_objref(val), i)
-        error("setindex!() with non-isbitstype eltype is not supported by StaticArrays. Consider using SizedArray.")
-    end
-
-    return val
-end
-
 macro MMatrix(ex)
     if !isa(ex, Expr)
         error("Bad input for @MMatrix")

--- a/src/MMatrix.jl
+++ b/src/MMatrix.jl
@@ -75,19 +75,14 @@ end
 ## MMatrix methods ##
 #####################
 
-@propagate_inbounds function getindex(m::MMatrix{S1,S2,T}, i::Int) where {S1,S2,T}
-    #@boundscheck if i < 1 || i > length(m)
-    #    throw(BoundsError(m,i))
-    #end
-
-    # This is nasty... but it turns out Julia will literally copy the whole tuple to the stack otherwise!
+@propagate_inbounds function getindex(v::MMatrix{S1,S2,T}, i::Int) where {S1,S2,T}
     if isbitstype(T)
-        unsafe_load(Base.unsafe_convert(Ptr{T}, pointer_from_objref(m)), i)
-    else
-        # Not sure about this... slow option for now...
-        m.data[i]
-        #unsafe_load(Base.unsafe_convert(Ptr{Ptr{Nothing}}, pointer_from_objref(m.data)), i)
+        @boundscheck if i < 1 || i > length(v)
+            throw(BoundsError())
+        end
+        return unsafe_load(Base.unsafe_convert(Ptr{T}, pointer_from_objref(v)), i)
     end
+    v.data[i]
 end
 
 @propagate_inbounds setindex!(m::MMatrix{S1,S2,T}, val, i::Int) where {S1,S2,T} = setindex!(m, convert(T, val), i)

--- a/src/MVector.jl
+++ b/src/MVector.jl
@@ -31,34 +31,6 @@ const MVector{S, T} = MArray{Tuple{S}, T, 1, S}
 ## MVector methods ##
 #####################
 
-@propagate_inbounds function getindex(v::MVector, i::Int)
-    if false #isbitstype(T)
-        @boundscheck if i < 1 || i > length(v)
-            throw(BoundsError())
-        end
-        return unsafe_load(Base.unsafe_convert(Ptr{T}, pointer_from_objref(v)), i)
-    end
-    v.data[i]
-end
-
-# Mutating setindex!
-@propagate_inbounds setindex!(v::MVector{S,T}, val, i::Int) where {S,T} = setindex!(v, convert(T, val), i)
-@inline function setindex!(v::MVector{S,T}, val::T, i::Int) where {S,T}
-    @boundscheck if i < 1 || i > length(v)
-        throw(BoundsError())
-    end
-
-    if isbitstype(T)
-        unsafe_store!(Base.unsafe_convert(Ptr{T}, pointer_from_objref(v)), val, i)
-    else
-        # This one is unsafe (#27)
-        #unsafe_store!(Base.unsafe_convert(Ptr{Ptr{Nothing}}, pointer_from_objref(v.data)), pointer_from_objref(val), i)
-        error("setindex!() with non-isbitstype eltype is not supported by StaticArrays. Consider using SizedArray.")
-    end
-
-    return val
-end
-
 macro MVector(ex)
     if isa(ex, Expr) && ex.head == :vect
         return esc(Expr(:call, MVector{length(ex.args)}, Expr(:tuple, ex.args...)))

--- a/src/MVector.jl
+++ b/src/MVector.jl
@@ -32,6 +32,12 @@ const MVector{S, T} = MArray{Tuple{S}, T, 1, S}
 #####################
 
 @propagate_inbounds function getindex(v::MVector, i::Int)
+    if false #isbitstype(T)
+        @boundscheck if i < 1 || i > length(v)
+            throw(BoundsError())
+        end
+        return unsafe_load(Base.unsafe_convert(Ptr{T}, pointer_from_objref(v)), i)
+    end
     v.data[i]
 end
 

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -9,6 +9,7 @@ setindex!(a::StaticArray, value, i::Int) = error("setindex!(::$(typeof(a)), valu
 # Note: all indexing behavior defaults to dense, linear indexing
 
 @propagate_inbounds function getindex(a::StaticArray, inds::Int...)
+    @boundscheck checkbounds(a, inds...) 
     _getindex_scalar(Size(a), a, inds...)
 end
 
@@ -30,6 +31,7 @@ end
 end
 
 @propagate_inbounds function setindex!(a::StaticArray, value, inds::Int...)
+    @boundscheck checkbounds(a, inds...) 
     _setindex!_scalar(Size(a), a, value, inds...)
 end
 


### PR DESCRIPTION
As remarked on [https://github.com/JuliaLang/julia/issues/29000](https://github.com/JuliaLang/julia/issues/29000), accessing an `MArray`, `MMatrix`, `MVector` sometimes pulls a stack copy. This patch avoids the stack copy, by using the pointer for `getindex` as well, not just for `setindex`.