### PR TITLE
Determine `broadcast` element type based on actual values

### DIFF
--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -125,12 +125,17 @@ scalar_getindex(x::Tuple{<: Any}) = x[1]
         end
     end
 
-    eltype_exprs = [t <: Union{AbstractArray, Ref} ? :(eltype($t)) : :($t) for t ∈ a]
-    newtype_expr = :(return_type(f, Tuple{$(eltype_exprs...)}))
+    if isempty(exprs)
+        eltype_exprs = [t <: Union{AbstractArray, Ref} ? :(eltype($t)) : :($t) for t ∈ a]
+        newtype_expr = :(return_type(f, Tuple{$(eltype_exprs...)}))
+    else
+        newtype_expr = :(eltype(vals))
+    end
 
     return quote
         @_inline_meta
-        @inbounds return similar_type($first_staticarray, $newtype_expr, Size(newsize))(tuple($(exprs...)))
+        vals = tuple($(exprs...))
+        @inbounds return similar_type($first_staticarray, $newtype_expr, Size(newsize))(vals)
     end
 end
 

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -151,22 +151,22 @@ end
     @testset "eltype after broadcast" begin
         # test cases issue #198
         let a = SVector{4, Number}(2, 2.0, 4//2, 2+0im)
-            @test_broken eltype(a + 2) == Number
-            @test_broken eltype(a - 2) == Number
-            @test_broken eltype(a * 2) == Number
-            @test_broken eltype(a / 2) == Number
+            @test eltype(a + 2) == Number
+            @test eltype(a - 2) == Number
+            @test eltype(a * 2) == Number
+            @test eltype(a / 2) == Number
         end
         let a = SVector{3, Real}(2, 2.0, 4//2)
-            @test_broken eltype(a + 2) == Real
-            @test_broken eltype(a - 2) == Real
-            @test_broken eltype(a * 2) == Real
-            @test_broken eltype(a / 2) == Real
+            @test eltype(a + 2) == Real
+            @test eltype(a - 2) == Real
+            @test eltype(a * 2) == Real
+            @test eltype(a / 2) == Real
         end
         let a = SVector{3, Real}(2, 2.0, 4//2)
-            @test_broken eltype(a + 2.0) == Float64
-            @test_broken eltype(a - 2.0) == Float64
-            @test_broken eltype(a * 2.0) == Float64
-            @test_broken eltype(a / 2.0) == Float64
+            @test eltype(a + 2.0) == Float64
+            @test eltype(a - 2.0) == Float64
+            @test eltype(a * 2.0) == Float64
+            @test eltype(a / 2.0) == Float64
         end
         let a = broadcast(Float32, SVector(3, 4, 5))
             @test eltype(a) == Float32
@@ -195,5 +195,11 @@ end
 
         d = SVector(1, 2, 3, 4)
         @test_throws DimensionMismatch a .= d
+    end
+
+    @testset "issue #493" begin
+        X = rand(SVector{3,SVector{2,Float64}})
+        foo493(X) = normalize.(X)
+        @test foo493(X) isa Core.Compiler.return_type(foo493, Tuple{typeof(X)})
     end
 end


### PR DESCRIPTION
Mimic the behavior for `Array`s and only use `return_type` in the empty case. I wonder, however, whether we shouldn't use `Union{}` in the empty case. We don't have to worry about the type-instability as the size is part of the type, too, and cannot e.g. `push!` to an `SVector`. So there seems to be little harm. Opinions?

Ref. JuliaLang/julia#28981, closes #493. But note that nested broadcasts will still suffer from incomplete inference due to the recursion limiting heuristics.