### PR TITLE
add convenience wrappers for ccall(:jl_reshape_array,...)

### DIFF
--- a/src/StaticArrays.jl
+++ b/src/StaticArrays.jl
@@ -39,6 +39,7 @@ export @MVector, @MMatrix, @MArray
 
 export similar_type
 export push, pop, pushfirst, popfirst, insert, deleteat, setindex
+export unsafe_squashdims, unsafe_unsquash
 
 """
     abstract type StaticArray{S, T, N} <: AbstractArray{T, N} end


### PR DESCRIPTION
Reinterpreting between `Array{T}` and `Array{SVector{T}}` is one of the most common operations when using StaticArrays. This adds a convenient wrapper for the underlying runtime function. This does literally the same as the old reinterpret, but is now maybe unsafe due to type-based aliasing analysis. I am open for changing the name and the usage. This avoids the performance impact of [https://github.com/JuliaArrays/StaticArrays.jl/issues/410](https://github.com/JuliaArrays/StaticArrays.jl/issues/410).

Examples:

```
julia> using StaticArrays

julia> A=reshape(collect(1:8), (2,2,2))
2×2×2 Array{Int64,3}:
[:, :, 1] =
 1  3
 2  4

[:, :, 2] =
 5  7
 6  8

 julia> Asv = unsafe_squashdims(A,(:,:))
2-element Array{SArray{Tuple{2,2},Int64,2,4},1}:
 [1 3; 2 4]
 [5 7; 6 8]

 julia> A[2,2,1]=-1; A[2,2,1]==Asv[1][2,2]

ulia> MM=zeros(SVector{2,Int32},2)
2-element Array{SArray{Tuple{2},Int32,1,2},1}:
 [0, 0]
 [0, 0]

 julia> M=unsafe_unsquash(MM); M[1,1]=-1; M[2,1]=-2; M
2×2 Array{Int32,2}:
 -1  0
 -2  0

julia> MM
2-element Array{SArray{Tuple{2},Int32,1,2},1}:
 [-1, -2]
 [0, 0]  
```
