### PR TITLE
Added an `eigvals` specialization

### DIFF
--- a/src/StaticArrays.jl
+++ b/src/StaticArrays.jl
@@ -6,8 +6,9 @@ import Base: @pure, @propagate_inbounds, getindex, setindex!, size, similar,
              length, convert, promote_op, map, map!, reduce, mapreduce,
              broadcast, broadcast!, conj, transpose, ctranspose, hcat, vcat,
              ones, zeros, eye, one, cross, vecdot, reshape, fill, fill!, det,
-             inv, eig, trace, vecnorm, norm, dot, diagm, sum, prod, count, any,
-             all, sumabs, sumabs2, minimum, maximum, extrema, mean, copy
+             inv, eig, eigvals, trace, vecnorm, norm, dot, diagm, sum, prod,
+             count, any, all, sumabs, sumabs2, minimum, maximum, extrema, mean,
+             copy
 
 export StaticScalar, StaticArray, StaticVector, StaticMatrix
 export Scalar, SArray, SVector, SMatrix

--- a/test/eigen.jl
+++ b/test/eigen.jl
@@ -3,10 +3,12 @@
         m = @SMatrix [2.0]
         (vals, vecs) = eig(m)
         @test vals === SVector(2.0)
+        @test eigvals(m) === SVector(2.0)
         @test vecs === SMatrix{1,1}(1.0)
 
         (vals, vecs) = eig(Symmetric(m))
         @test vals === SVector(2.0)
+        @test eigvals(Symmetric(m)) === SVector(2.0)
         @test vecs === SMatrix{1,1}(1.0)
     end
 
@@ -18,10 +20,12 @@
         (vals_a, vecs_a) = eig(m)
         (vals, vecs) = eig(m)
         @test vals::SVector ≈ vals_a
+        @test eigvals(m)::SVector ≈ vals_a
         @test (vecs*diagm(vals)*vecs')::SMatrix ≈ m
 
         (vals, vecs) = eig(Symmetric(m))
         @test vals::SVector ≈ vals_a
+        @test eigvals(Symmetric(m))::SVector ≈ vals_a
         @test (vecs*diagm(vals)*vecs')::SMatrix ≈ m
     end
 
@@ -33,10 +37,12 @@
         (vals_a, vecs_a) = eig(m)
         (vals, vecs) = eig(m)
         @test vals::SVector ≈ vals_a
+        @test eigvals(m)::SVector ≈ vals_a
         @test (vecs*diagm(vals)*vecs')::SMatrix ≈ m
 
         (vals, vecs) = eig(Symmetric(m))
         @test vals::SVector ≈ vals_a
+        @test eigvals(Symmetric(m))::SVector ≈ vals_a
         @test (vecs*diagm(vals)*vecs')::SMatrix ≈ m
     end
 
@@ -75,5 +81,30 @@
 
         @test isapprox(eigvecs'*eigvecs, eye(SMatrix{3,3,Float64}); atol = 1e-4)
         @test eigvals ≈ SVector(1e-2, 1e-2, 1.01)
+
+        # Block diagonal
+        m = @SMatrix [1.0 0.0 0.0;
+                      0.0 1.0 1.0;
+                      0.0 1.0 1.0]
+        eigvals, eigvecs = eig(m)::Tuple{SVector,SMatrix}
+
+        @test eigvals ≈ [0.0, 1.0, 2.0]
+        @test eigvecs*diagm(eigvals)*eigvecs' ≈ m
+
+        m = @SMatrix [1.0 0.0 1.0;
+                      0.0 1.0 0.0;
+                      1.0 0.0 1.0]
+        eigvals, eigvecs = eig(m)::Tuple{SVector,SMatrix}
+
+        @test eigvals ≈ [0.0, 1.0, 2.0]
+        @test eigvecs*diagm(eigvals)*eigvecs' ≈ m
+
+        m = @SMatrix [1.0 1.0 0.0;
+                      1.0 1.0 0.0;
+                      0.0 0.0 1.0]
+        eigvals, eigvecs = eig(m)::Tuple{SVector,SMatrix}
+
+        @test eigvals ≈ [0.0, 1.0, 2.0]
+        @test eigvecs*diagm(eigvals)*eigvecs' ≈ m
     end
 end


### PR DESCRIPTION
Cheaper to calculate eigenvalues too
Added test cases for block-diagonal 3x3 matrices that expose holes in
the 3x3 eigenvector routines. Need to find a way of specializing these.