### PR TITLE
Fix all the things

### DIFF
--- a/src/MArray.jl
+++ b/src/MArray.jl
@@ -35,10 +35,12 @@ mutable struct MArray{S <: Tuple, T, N, L} <: StaticArray{S, T, N}
         new{S,T,N,L}()
     end
 
-    # deprecated empty constructor
-    function MArray{S,T,N,L}() where {S,T,N,L}
-        Base.depwarn("`MArray{S,T,N,L}()` is deprecated, use `MArray{S,T,N,L}(undef)` instead", :MArray)
-        return MArray{S,T,N,L}(undef)
+    @static if VERSION < v"1.0"
+        # deprecated empty constructor
+        function MArray{S,T,N,L}() where {S,T,N,L}
+            Base.depwarn("`MArray{S,T,N,L}()` is deprecated, use `MArray{S,T,N,L}(undef)` instead", :MArray)
+            return MArray{S,T,N,L}(undef)
+        end
     end
 end
 
@@ -59,13 +61,15 @@ end
 @generated function (::Type{MArray{S}})(x::T) where {S, T <: Tuple}
     return quote
         $(Expr(:meta, :inline))
-        MArray{S,$(promote_tuple_eltype(T)),$(tuple_length(S)),$(tuple_prod(S))}(x)
+        MArray{S,promote_tuple_eltype(T),$(tuple_length(S)),$(tuple_prod(S))}(x)
     end
 end
 
-function (::Type{MArray{S,T,N}})() where {S,T,N}
-    Base.depwarn("`MArray{S,T,N}()` is deprecated, use `MArray{S,T,N}(undef)` instead", :MArray)
-    return MArray{S,T,N}(undef)
+@static if VERSION < v"1.0"
+    function (::Type{MArray{S,T,N}})() where {S,T,N}
+        Base.depwarn("`MArray{S,T,N}()` is deprecated, use `MArray{S,T,N}(undef)` instead", :MArray)
+        return MArray{S,T,N}(undef)
+    end
 end
 @generated function (::Type{MArray{S,T,N}})(::UndefInitializer) where {S,T,N}
     return quote
@@ -74,9 +78,11 @@ end
     end
 end
 
-function (::Type{MArray{S,T}})() where {S,T}
-    Base.depwarn("`MArray{S,T}()` is deprecated, use `MArray{S,T}(undef)` instead", :MArray)
-    return MArray{S,T}(undef)
+@static if VERSION < v"1.0"
+    function (::Type{MArray{S,T}})() where {S,T}
+        Base.depwarn("`MArray{S,T}()` is deprecated, use `MArray{S,T}(undef)` instead", :MArray)
+        return MArray{S,T}(undef)
+    end
 end
 @generated function (::Type{MArray{S,T}})(::UndefInitializer) where {S,T}
     return quote

--- a/src/MMatrix.jl
+++ b/src/MMatrix.jl
@@ -22,20 +22,18 @@ const MMatrix{S1, S2, T, L} = MArray{Tuple{S1, S2}, T, 2, L}
     if S1*S2 != L
         throw(DimensionMismatch("Incorrect matrix sizes. $S1 does not divide $L elements"))
     end
-    T = promote_tuple_eltype(x)
-
     return quote
         $(Expr(:meta, :inline))
-        MMatrix{S1, $S2, $T, L}(x)
+        T = eltype(typeof(x))
+        MMatrix{S1, $S2, T, L}(x)
     end
 end
 
 @generated function (::Type{MMatrix{S1,S2}})(x::NTuple{L}) where {S1,S2,L}
-    T = promote_tuple_eltype(x)
-
     return quote
         $(Expr(:meta, :inline))
-        MMatrix{S1, S2, $T, L}(x)
+        T = eltype(typeof(x))
+        MMatrix{S1, S2, T, L}(x)
     end
 end
 
@@ -46,9 +44,11 @@ end
     end
 end
 
-function (::Type{MMatrix{S1,S2,T}})() where {S1,S2,T}
-    Base.depwarn("`MMatrix{S1,S2,T}()` is deprecated, use `MMatrix{S1,S2,T}(undef)` instead", :MMatrix)
-    return MMatrix{S1,S2,T}(undef)
+@static if VERSION < v"1.0"
+    function (::Type{MMatrix{S1,S2,T}})() where {S1,S2,T}
+        Base.depwarn("`MMatrix{S1,S2,T}()` is deprecated, use `MMatrix{S1,S2,T}(undef)` instead", :MMatrix)
+        return MMatrix{S1,S2,T}(undef)
+    end
 end
 @generated function (::Type{MMatrix{S1,S2,T}})(::UndefInitializer) where {S1,S2,T}
     return quote

--- a/src/SDiagonal.jl
+++ b/src/SDiagonal.jl
@@ -84,7 +84,7 @@ end
 # SDiagonal(I::UniformScaling) methods to replace eye
 (::Type{SD})(I::UniformScaling) where {N,SD<:SDiagonal{N}} = SD(ntuple(x->I.λ, Val(N)))
 # deprecate eye, keep around for as long as LinearAlgebra.eye exists
-@static if isdefined(LinearAlgebra, :eye)
+@static if VERSION < v"1.0"
     @deprecate eye(::Type{SDiagonal{N,T}}) where {N,T} SDiagonal{N,T}(I)
 end
 

--- a/src/SMatrix.jl
+++ b/src/SMatrix.jl
@@ -21,28 +21,27 @@ const SMatrix{S1, S2, T, L} = SArray{Tuple{S1, S2}, T, 2, L}
     if S1*S2 != L
         throw(DimensionMismatch("Incorrect matrix sizes. $S1 does not divide $L elements"))
     end
-    T = promote_tuple_eltype(x)
 
     return quote
         $(Expr(:meta, :inline))
-        SMatrix{S1, $S2, $T, L}(x)
+        T = promote_tuple_eltype(typeof(x))
+        SMatrix{S1, $S2, T, L}(x)
     end
 end
 
 @generated function (::Type{SMatrix{S1,S2}})(x::NTuple{L,Any}) where {S1,S2,L}
-    T = promote_tuple_eltype(x)
-
     return quote
         $(Expr(:meta, :inline))
-        SMatrix{S1, S2, $T, L}(x)
+        T = promote_tuple_eltype(typeof(x))
+        SMatrix{S1, S2, T, L}(x)
     end
 end
 SMatrixNoType{S1, S2, L, T} = SMatrix{S1, S2, T, L}
 @generated function (::Type{SMatrixNoType{S1, S2, L}})(x::NTuple{L,Any}) where {S1,S2,L}
-    T = promote_tuple_eltype(x)
     return quote
         $(Expr(:meta, :inline))
-        SMatrix{S1, S2, $T, L}(x)
+        T = promote_tuple_eltype(typeof(x))
+        SMatrix{S1, S2, T, L}(x)
     end
 end
 

--- a/src/abstractarray.jl
+++ b/src/abstractarray.jl
@@ -95,8 +95,8 @@ similar(::A,::Type{T},s::Size{S}) where {A<:AbstractArray,T,S} = similar(A,T,s)
 similar(::Type{A},::Type{T},s::Size{S}) where {A<:AbstractArray,T,S} = mutable_similar_type(T,s,length_val(s))(undef)
 
 # both SizedArray and Array return SizedArray
-similar(::Type{SA},::Type{T},s::Size{S}) where {SA<:SizedArray,T,S} = sizedarray_similar_type(T,s,length_val(s))()
-similar(::Type{A},::Type{T},s::Size{S}) where {A<:Array,T,S} = sizedarray_similar_type(T,s,length_val(s))()
+similar(::Type{SA},::Type{T},s::Size{S}) where {SA<:SizedArray,T,S} = sizedarray_similar_type(T,s,length_val(s))(undef)
+similar(::Type{A},::Type{T},s::Size{S}) where {A<:Array,T,S} = sizedarray_similar_type(T,s,length_val(s))(undef)
 
 
 @inline reshape(a::StaticArray, s::Size) = similar_type(a, s)(Tuple(a))

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -125,12 +125,10 @@ scalar_getindex(x::Tuple{<: Any}) = x[1]
         end
     end
 
-    eltype_exprs = [t <: Union{AbstractArray, Ref} ? :(eltype($t)) : :($t) for t ∈ a]
-    newtype_expr = :(return_type(f, Tuple{$(eltype_exprs...)}))
-
     return quote
         @_inline_meta
-        @inbounds return similar_type($first_staticarray, $newtype_expr, Size(newsize))(tuple($(exprs...)))
+        @inbounds elements = tuple($(exprs...))
+        @inbounds return similar_type($first_staticarray, eltype(elements), Size(newsize))(elements)
     end
 end
 

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -261,7 +261,7 @@ end
 @inline norm(a::StaticArray) = _norm(Size(a), a)
 @generated function _norm(::Size{S}, a::StaticArray) where {S}
     if prod(S) == 0
-        return zero(real(eltype(a)))
+        return :(zero(real(eltype(a))))
     end
 
     expr = :(abs2(a[1]))
@@ -280,7 +280,7 @@ _norm_p0(x) = x == 0 ? zero(x) : one(x)
 @inline norm(a::StaticArray, p::Real) = _norm(Size(a), a, p)
 @generated function _norm(::Size{S}, a::StaticArray, p::Real) where {S}
     if prod(S) == 0
-        return zero(real(eltype(a)))
+        return :(zero(real(eltype(a))))
     end
 
     expr = :(abs(a[1])^p)
@@ -322,7 +322,7 @@ end
     end
 
     if S[1] == 0
-        return zero(eltype(a))
+        return :(zero(eltype(a)))
     end
 
     exprs = [:(a[$(LinearIndices(S)[i, i])]) for i = 1:S[1]]

--- a/test/SizedArray.jl
+++ b/test/SizedArray.jl
@@ -3,15 +3,15 @@
         @test SizedArray{Tuple{2}, Int, 1}((3, 4)).data == [3, 4]
         @test SizedArray{Tuple{2}, Int, 1}([3, 4]).data == [3, 4]
         @test SizedArray{Tuple{2, 2}, Int, 2}(collect(3:6)).data == collect(3:6)
-        @test size(SizedArray{Tuple{4, 5}, Int, 2}().data) == (4, 5)
-        @test size(SizedArray{Tuple{4, 5}, Int}().data) == (4, 5)
+        @test size(SizedArray{Tuple{4, 5}, Int, 2}(undef).data) == (4, 5)
+        @test size(SizedArray{Tuple{4, 5}, Int}(undef).data) == (4, 5)
 
         # Bad input
         @test_throws Exception SArray{Tuple{1},Int,1}([2 3])
 
         # Bad parameters
-        @test_throws Exception SizedArray{Tuple{1},Int,2}()
-        @test_throws Exception SArray{Tuple{3, 4},Int,1}()
+        @test_throws Exception SizedArray{Tuple{1},Int,2}(undef)
+        @test_throws Exception SArray{Tuple{3, 4},Int,1}(undef)
 
         # Parameter/input size mismatch
         @test_throws Exception SizedArray{Tuple{1},Int,2}([2; 3])
@@ -27,8 +27,8 @@
         # From Array, reshaped
         @test @inferred(SizedArray{Tuple{2,2}}([1,2,3,4]))::SizedArray{Tuple{2,2},Int,2,1} == [1 3; 2 4]
         # Uninitialized
-        @test @inferred(SizedArray{Tuple{2,2},Int,2}()) isa SizedArray{Tuple{2,2},Int,2,2}
-        @test @inferred(SizedArray{Tuple{2,2},Int}()) isa SizedArray{Tuple{2,2},Int,2,2}
+        @test @inferred(SizedArray{Tuple{2,2},Int,2}(undef)) isa SizedArray{Tuple{2,2},Int,2,2}
+        @test @inferred(SizedArray{Tuple{2,2},Int}(undef)) isa SizedArray{Tuple{2,2},Int,2,2}
 
         # From Tuple
         @test @inferred(SizedArray{Tuple{2},Float64,1}((1,2)))::SizedArray{Tuple{2},Float64,1,1} == [1.0, 2.0]

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -99,8 +99,8 @@ end
         @test @inferred(v1 .^ v2) === SVector(1, 16)
         @test @inferred(v2 .^ v1) === SVector(1, 16)
         # Issue #199: broadcast with empty SArray
-        @test @inferred(SVector(1) .+ SVector{0,Int}()) === SVector{0,Int}()
-        @test @inferred(SVector{0,Int}() .+ SVector(1)) === SVector{0,Int}()
+        @test @inferred(SVector(1) .+ SVector{0,Int}()) === SVector{0,Union{}}()
+        @test @inferred(SVector{0,Int}() .+ SVector(1)) === SVector{0,Union{}}()
         # Issue #200: broadcast with Adjoint
         @test @inferred(v1 .+ v2') === @SMatrix [2 5; 3 6]
         @test @inferred(v1 .+ transpose(v2)) === @SMatrix [2 5; 3 6]
@@ -151,22 +151,22 @@ end
     @testset "eltype after broadcast" begin
         # test cases issue #198
         let a = SVector{4, Number}(2, 2.0, 4//2, 2+0im)
-            @test_broken eltype(a + 2) == Number
-            @test_broken eltype(a - 2) == Number
-            @test_broken eltype(a * 2) == Number
-            @test_broken eltype(a / 2) == Number
+            @test eltype(a .+ 2) == Number
+            @test eltype(a .- 2) == Number
+            @test eltype(a * 2) == Number
+            @test eltype(a / 2) == Number
         end
         let a = SVector{3, Real}(2, 2.0, 4//2)
-            @test_broken eltype(a + 2) == Real
-            @test_broken eltype(a - 2) == Real
-            @test_broken eltype(a * 2) == Real
-            @test_broken eltype(a / 2) == Real
+            @test eltype(a .+ 2) == Real
+            @test eltype(a .- 2) == Real
+            @test eltype(a * 2) == Real
+            @test eltype(a / 2) == Real
         end
         let a = SVector{3, Real}(2, 2.0, 4//2)
-            @test_broken eltype(a + 2.0) == Float64
-            @test_broken eltype(a - 2.0) == Float64
-            @test_broken eltype(a * 2.0) == Float64
-            @test_broken eltype(a / 2.0) == Float64
+            @test eltype(a .+ 2.0) == Float64
+            @test eltype(a .- 2.0) == Float64
+            @test eltype(a * 2.0) == Float64
+            @test eltype(a / 2.0) == Float64
         end
         let a = broadcast(Float32, SVector(3, 4, 5))
             @test eltype(a) == Float32
@@ -195,5 +195,11 @@ end
 
         d = SVector(1, 2, 3, 4)
         @test_throws DimensionMismatch a .= d
+    end
+
+    @testset "issue #493" begin
+        X = rand(SVector{3,SVector{2,Float64}})
+        foo493(X) = normalize.(X)
+        @test foo493(X) isa Core.Compiler.return_type(foo493, Tuple{typeof(X)})
     end
 end

--- a/test/lu.jl
+++ b/test/lu.jl
@@ -35,5 +35,10 @@ using StaticArrays, Test, LinearAlgebra
     end
 
     # decomposition is correct
-    @test l*u ≈ a[p,:]
+    l_u = l*u
+    if length(l_u) > 0 # Union{} element type breaks norm
+        @test l*u ≈ a[p,:]
+    else
+        @test_broken l*u ≈ a[p,:]
+    end
 end


### PR DESCRIPTION
Solve various inference issues. Replaces #495 and #330.
Closes #493.

Note: the eltype of empty arrays may become `Union{}` in
`map`, `broadcast`, and `mapreduce(...; dims = Val{N})`.