### PR TITLE
 Special case flatten of iterators of static arrays as done for tuples

### DIFF
--- a/src/StaticArrays.jl
+++ b/src/StaticArrays.jl
@@ -114,6 +114,7 @@ include("svd.jl")
 include("lu.jl")
 include("qr.jl")
 include("deque.jl")
+include("flatten.jl")
 include("io.jl")
 
 include("FixedSizeArrays.jl")

--- a/src/flatten.jl
+++ b/src/flatten.jl
@@ -1,0 +1,6 @@
+# Special case flatten of iterators of static arrays.
+import Base.Iterators: flatten_iteratorsize, flatten_length
+flatten_iteratorsize(::Union{Base.HasShape, Base.HasLength}, ::Type{<:Union{SArray,MArray}}) = Base.HasLength()
+function flatten_length(f, T::Type{<:Union{SArray,MArray}})
+    length(T)*length(f.it)
+end

--- a/src/flatten.jl
+++ b/src/flatten.jl
@@ -1,6 +1,6 @@
 # Special case flatten of iterators of static arrays.
 import Base.Iterators: flatten_iteratorsize, flatten_length
-flatten_iteratorsize(::Union{Base.HasShape, Base.HasLength}, ::Type{<:StaticArray}) = Base.HasLength()
-function flatten_length(f, T::Type{<:StaticArray})
+flatten_iteratorsize(::Union{Base.HasShape, Base.HasLength}, ::Type{<:StaticArray{S}}) where {S} = Base.HasLength()
+function flatten_length(f, T::Type{<:StaticArray{S}}) where {S}
     length(T)*length(f.it)
 end

--- a/src/flatten.jl
+++ b/src/flatten.jl
@@ -1,6 +1,6 @@
 # Special case flatten of iterators of static arrays.
 import Base.Iterators: flatten_iteratorsize, flatten_length
-flatten_iteratorsize(::Union{Base.HasShape, Base.HasLength}, ::Type{<:Union{SArray,MArray}}) = Base.HasLength()
-function flatten_length(f, T::Type{<:Union{SArray,MArray}})
+flatten_iteratorsize(::Union{Base.HasShape, Base.HasLength}, ::Type{<:StaticArray}) = Base.HasLength()
+function flatten_length(f, T::Type{<:StaticArray})
     length(T)*length(f.it)
 end

--- a/test/flatten.jl
+++ b/test/flatten.jl
@@ -10,4 +10,6 @@ using StaticArrays, Test
         @test collect(Iterators.flatten(typeof(x)[])) == []
         @test collect(Iterators.flatten(X)) == [x..., x..., x...]
     end
+    @test collect(Iterators.flatten([SVector(1,1), SVector(1)])) == [1,1,1]
+    @test_throws ArgumentError length(Iterators.flatten([SVector(1,1), SVector(1)]))
 end

--- a/test/flatten.jl
+++ b/test/flatten.jl
@@ -1,0 +1,13 @@
+using StaticArrays, Test
+
+@testset "Iterators.flatten" begin
+    for x in [SVector(1.0, 2.0), MVector(1.0, 2.0),
+            @SMatrix([1.0 2.0; 3.0 4.0]), @MMatrix([1.0 2.0]),
+            Size(1,2)([1.0 2.0])
+            ]
+        X = [x,x,x]
+        @test length(Iterators.flatten(X)) == length(X)*length(x)
+        @test collect(Iterators.flatten(typeof(x)[])) == []
+        @test collect(Iterators.flatten(X)) == [x..., x..., x...]
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -40,6 +40,7 @@ include("lu.jl")
 Random.seed!(42); include("qr.jl")
 Random.seed!(42); include("chol.jl") # hermitian_type(::Type{Any}) for block algorithm
 include("deque.jl")
+include("flatten.jl")
 include("io.jl")
 include("svd.jl")
 Random.seed!(42); include("fixed_size_arrays.jl")


### PR DESCRIPTION
Before: 
```
julia> X = [@SVector rand(10) for i in 1:10000]
julia> @btime collect(Iterators.flatten(X))
  1.402 ms (18 allocations: 2.00 MiB)
```
after 
```
julia> @btime collect(Iterators.flatten(Y))
  365.198 μs (3 allocations: 781.34 KiB)
```