### PR TITLE
changed mul_heuristic for non-float

### DIFF
--- a/src/matrix_multiply.jl
+++ b/src/matrix_multiply.jl
@@ -72,21 +72,9 @@ end
 
 @generated function _mul(Sa::Size{sa}, Sb::Size{sb}, a::StaticMatrix{<:Any, <:Any, Ta}, b::StaticMatrix{<:Any, <:Any, Tb}) where {sa, sb, Ta, Tb}
     # Heuristic choice for amount of codegen
-    if sa[1]*sa[2]*sb[2] <= 8*8*8
-        return quote
-            @_inline_meta
-            return mul_unrolled(Sa, Sb, a, b)
-        end
-    elseif sa[1] <= 14 && sa[2] <= 14 && sb[2] <= 14
-        return quote
-            @_inline_meta
-            return mul_unrolled_chunks(Sa, Sb, a, b)
-        end
-    else
-        return quote
-            @_inline_meta
-            return mul_loop(Sa, Sb, a, b)
-        end
+    return quote
+        @_inline_meta
+        return mul_loop(Sa, Sb, a, b)
     end
 end
 


### PR DESCRIPTION
Motivated by #513, This PR changes the multiplication heuristic for non-float types. This should fix a performance issue that affects `Dual`.

Although I didn't do it on this PR because it would be too controversial, I think that the same heuristic should be used for floats. Maybe the compiler has come a long way, but it seems to be able to do the right thing most of the time (`mul_loop` outperforms the current heuristic on average). Given the [current state of the compiler](https://docs.julialang.org/en/v0.7.0/NEWS/#Compiler/Runtime-improvements-1) (see item 4), I think that we should reconsider if this is something we still need to do?