### PR TITLE
Reinstate read(::IO, ::Type{<:StaticArray})

### DIFF
--- a/src/io.jl
+++ b/src/io.jl
@@ -1,5 +1,5 @@
 
-@inline function read!(io::IO, ::Type{SA}) where {SA<:StaticArray}
+@inline function read(io::IO, ::Type{SA}) where {SA<:StaticArray}
     elements = Ref{NTuple{length(SA),eltype(SA)}}()
     read!(io, elements)
     SA(elements[])
@@ -9,6 +9,8 @@ end
     unsafe_read(io, Base.unsafe_convert(Ptr{eltype(SA)}, a), sizeof(a))
     a
 end
+
+@deprecate read!(io::IO, SA::Type{<:StaticArray}) read(io, SA)
 
 @inline function write(io::IO, a::SA) where {SA<:StaticArray}
     write(io, Ref(Tuple(a)))

--- a/test/io.jl
+++ b/test/io.jl
@@ -13,10 +13,10 @@ end
 @testset "Binary IO" begin
     @testset "read!" begin
         # Read static arrays from a stream which was serialized elementwise
-        @test read!(write_buf(UInt8, 1,2,3), SVector{3,UInt8})         === SVector{3,UInt8}(1,2,3)
-        @test read!(write_buf(Int32, -1,2,3), SVector{3,Int32})        === SVector{3,Int32}(-1,2,3)
-        @test read!(write_buf(Float64, 1,2,3), SVector{3,Float64})     === SVector{3,Float64}(1,2,3)
-        @test read!(write_buf(Float64, 1,2,3,4), SMatrix{2,2,Float64}) === @SMatrix [1.0 3.0; 2.0 4.0]
+        @test read(write_buf(UInt8, 1,2,3), SVector{3,UInt8})         === SVector{3,UInt8}(1,2,3)
+        @test read(write_buf(Int32, -1,2,3), SVector{3,Int32})        === SVector{3,Int32}(-1,2,3)
+        @test read(write_buf(Float64, 1,2,3), SVector{3,Float64})     === SVector{3,Float64}(1,2,3)
+        @test read(write_buf(Float64, 1,2,3,4), SMatrix{2,2,Float64}) === @SMatrix [1.0 3.0; 2.0 4.0]
     end
 
     @testset "write" begin
@@ -33,6 +33,10 @@ end
         @test read!(write_buf(Int32, -1,2,3),    zeros(MVector{3,Int32}))     == MVector{3,Int32}(-1,2,3)
         @test read!(write_buf(Float64, 1,2,3),   zeros(MVector{3,Float64}))   == MVector{3,Float64}(1,2,3)
         @test read!(write_buf(Float64, 1,2,3,4), zeros(MMatrix{2,2,Float64})) == @MMatrix [1.0 3.0; 2.0 4.0]
+        # Test that read! does, in fact, modify an MVector rather than return a copy.
+        m = zeros(MVector{3,UInt8})
+        read!(write_buf(UInt8, 1,2,3), m)
+        @test m == MVector{3,UInt8}(1,2,3)
     end
 end
 


### PR DESCRIPTION
This was removed in the rush to 0.7 compatibility

Fixes #505, replaces #510