### PR TITLE
Deprecate ImmutableArrays and FixedSizeArrays compatibility interfaces

### DIFF
--- a/src/FixedSizeArrays.jl
+++ b/src/FixedSizeArrays.jl
@@ -6,7 +6,7 @@ etc, using StaticArrays as a backend.
 The type definitions are not "perfect" matches because the type parameters are
 different. However, it should cover common method signatures and constructors.
 """
-module FixedSizeArrays
+module FixedSizeArraysWillBeRemoved
 
 using ..StaticArrays
 
@@ -187,3 +187,6 @@ end
 @fixed_vector Point StaticVector
 
 end
+
+Base.@deprecate_binding FixedSizeArrays FixedSizeArraysWillBeRemoved #=
+    =# false "StaticArrays.FixedSizeArrays is deprecated. Use StaticArrays directly."

--- a/src/ImmutableArrays.jl
+++ b/src/ImmutableArrays.jl
@@ -1,4 +1,4 @@
-module ImmutableArrays
+module ImmutableArraysWillBeRemoved
 
 using ..StaticArrays
 
@@ -34,3 +34,6 @@ export Vector1,   Vector2,   Vector3,   Vector4,
        Matrix4x1, Matrix4x2, Matrix4x3, Matrix4x4
 
 end # module
+
+Base.@deprecate_binding ImmutableArrays ImmutableArraysWillBeRemoved #=
+    =# false "StaticArrays.ImmutableArrays is deprecated. Use StaticArrays directly."


### PR DESCRIPTION
As briefly mentioned in #503 

At this stage, people should use the StaticArrays APIs directly. If there's anything useful left in StaticArrays.FixedSizeArrays we should fold it into the main API, or move it to other packages where it fits more neatly.

CC @andyferris @SimonDanisch 

[edit] Closes https://github.com/JuliaArrays/StaticArrays.jl/issues/459