### PR TITLE
(RFC) fix eigen in the diagonal 2x2-case

### DIFF
--- a/src/eigen.jl
+++ b/src/eigen.jl
@@ -136,19 +136,19 @@ end
     TA = eltype(A)
 
     @inbounds if A.uplo == 'U'
-        if a[3] == 0
+        if a[3] == 0 # A is diagonal
             A11 = a[1]
             A22 = a[4]
             if A11 < A22
                 vals = SVector(A11, A22)
-                vecs = @SMatrix [TA(1) TA(0);
-                                 TA(0) TA(1)]
+                vecs = @SMatrix [one(TA) zero(TA);
+                                 zero(TA) one(TA)]
             else # A22 <= A11
                 vals = SVector(A22, A11)
-                vecs = @SMatrix [TA(0) TA(1);
-                                 TA(1) TA(0)]
+                vecs = @SMatrix [zero(TA) one(TA);
+                                 one(TA) zero(TA)]
             end
-        else
+        else # A is not diagonal
             t_half = real(a[1] + a[4]) / 2
             d = real(a[1] * a[4] - a[3]' * a[3]) # Should be real
 
@@ -171,19 +171,19 @@ end
         end
         return (vals, vecs)
     else # A.uplo == 'L'
-        if a[2] == 0
+        if a[2] == 0 # A is diagonal
             A11 = a[1]
             A22 = a[4]
             if A11 < A22
                 vals = SVector(A11, A22)
-                vecs = @SMatrix [TA(1) TA(0);
-                                 TA(0) TA(1)]
+                vecs = @SMatrix [one(TA) zero(TA);
+                                 zero(TA) one(TA)]
             else # A22 <= A11
                 vals = SVector(A22, A11)
-                vecs = @SMatrix [TA(0) TA(1);
-                                 TA(1) TA(0)]
+                vecs = @SMatrix [zero(TA) one(TA);
+                                 one(TA) zero(TA)]
             end
-        else
+        else # A is not diagonal
             t_half = real(a[1] + a[4]) / 2
             d = real(a[1] * a[4] - a[2]' * a[2]) # Should be real
 

--- a/src/eigen.jl
+++ b/src/eigen.jl
@@ -136,7 +136,7 @@ end
     TA = eltype(A)
 
     @inbounds if A.uplo == 'U'
-        if a[3] == 0 # A is diagonal
+        if a[3] == zero(TA) # A is diagonal
             A11 = a[1]
             A22 = a[4]
             if A11 < A22
@@ -171,7 +171,7 @@ end
         end
         return (vals, vecs)
     else # A.uplo == 'L'
-        if a[2] == 0 # A is diagonal
+        if a[2] == zero(TA) # A is diagonal
             A11 = a[1]
             A22 = a[4]
             if A11 < A22

--- a/src/eigen.jl
+++ b/src/eigen.jl
@@ -134,14 +134,11 @@ end
 @inline function _eig(::Size{(2,2)}, A::LinearAlgebra.RealHermSymComplexHerm{T}, permute, scale) where {T <: Real}
     a = A.data
     TA = eltype(A)
-    lower = A.uplo === 'L'
 
-    @inbounds begin
-        A11 = a[1]
-        A22 = a[4]
-        A2112 = lower ? a[2] : a[3]
-
-        if A2112 == 0 # A is diagonal
+    @inbounds if A.uplo == 'U'
+        if a[3] == 0 # A is diagonal
+            A11 = a[1]
+            A22 = a[4]
             if A11 < A22
                 vals = SVector(A11, A22)
                 vecs = @SMatrix [one(TA) zero(TA);
@@ -152,28 +149,63 @@ end
                                  one(TA) zero(TA)]
             end
         else # A is not diagonal
-            t_half = real(A11 + A22) / 2
-            d = real(A11 * A22 - A2112' * A2112) # Should be real
+            t_half = real(a[1] + a[4]) / 2
+            d = real(a[1] * a[4] - a[3]' * a[3]) # Should be real
 
             tmp2 = t_half * t_half - d
-            tmp  = tmp2 < 0 ? zero(tmp2) : sqrt(tmp2) # Numerically stable for identity matrices, etc.
+            tmp = tmp2 < 0 ? zero(tmp2) : sqrt(tmp2) # Numerically stable for identity matrices, etc.
             vals = SVector(t_half - tmp, t_half + tmp)
 
-            v11 = vals[1] - A22
-            n1  = sqrt(v11' * v11 + A2112' * A2112)
+            v11 = vals[1] - a[4]
+            n1 = sqrt(v11' * v11 + a[3]' * a[3])
             v11 = v11 / n1
-            v12 = (lower ? A2112 : A2112') / n1
+            v12 = a[3]' / n1
 
-            v21 = vals[2] - A22
-            n2  = sqrt(v21' * v21 + A2112' * A2112)
+            v21 = vals[2] - a[4]
+            n2 = sqrt(v21' * v21 + a[3]' * a[3])
             v21 = v21 / n2
-            v22 = (lower ? A2112 : A2112') / n2
+            v22 = a[3]' / n2
 
             vecs = @SMatrix [ v11  v21 ;
                               v12  v22 ]
         end
+        return (vals, vecs)
+    else # A.uplo == 'L'
+        if a[2] == 0 # A is diagonal
+            A11 = a[1]
+            A22 = a[4]
+            if A11 < A22
+                vals = SVector(A11, A22)
+                vecs = @SMatrix [one(TA) zero(TA);
+                                 zero(TA) one(TA)]
+            else # A22 <= A11
+                vals = SVector(A22, A11)
+                vecs = @SMatrix [zero(TA) one(TA);
+                                 one(TA) zero(TA)]
+            end
+        else # A is not diagonal
+            t_half = real(a[1] + a[4]) / 2
+            d = real(a[1] * a[4] - a[2]' * a[2]) # Should be real
+
+            tmp2 = t_half * t_half - d
+            tmp = tmp2 < 0 ? zero(tmp2) : sqrt(tmp2) # Numerically stable for identity matrices, etc.
+            vals = SVector(t_half - tmp, t_half + tmp)
+
+            v11 = vals[1] - a[4]
+            n1 = sqrt(v11' * v11 + a[2]' * a[2])
+            v11 = v11 / n1
+            v12 = a[2] / n1
+
+            v21 = vals[2] - a[4]
+            n2 = sqrt(v21' * v21 + a[2]' * a[2])
+            v21 = v21 / n2
+            v22 = a[2] / n2
+
+            vecs = @SMatrix [ v11  v21 ;
+                              v12  v22 ]
+        end
+        return (vals,vecs)
     end
-    return (vals, vecs)
 end
 
 # A small part of the code in the following method was inspired by works of David

--- a/src/eigen.jl
+++ b/src/eigen.jl
@@ -136,17 +136,17 @@ end
     TA = eltype(A)
 
     @inbounds if A.uplo == 'U'
-        if a[3] == zero(TA) # A is diagonal
+        if a[3] == 0 # A is diagonal
             A11 = a[1]
             A22 = a[4]
             if A11 < A22
                 vals = SVector(A11, A22)
-                vecs = @SMatrix [one(TA) zero(TA);
-                                 zero(TA) one(TA)]
+                vecs = @SMatrix [convert(TA, 1) convert(TA, 0);
+                                 convert(TA, 0) convert(TA, 1)]
             else # A22 <= A11
                 vals = SVector(A22, A11)
-                vecs = @SMatrix [zero(TA) one(TA);
-                                 one(TA) zero(TA)]
+                vecs = @SMatrix [convert(TA, 0) convert(TA, 1);
+                                 convert(TA, 1) convert(TA, 0)]
             end
         else # A is not diagonal
             t_half = real(a[1] + a[4]) / 2
@@ -171,17 +171,17 @@ end
         end
         return (vals, vecs)
     else # A.uplo == 'L'
-        if a[2] == zero(TA) # A is diagonal
+        if a[2] == 0 # A is diagonal
             A11 = a[1]
             A22 = a[4]
             if A11 < A22
                 vals = SVector(A11, A22)
-                vecs = @SMatrix [one(TA) zero(TA);
-                                 zero(TA) one(TA)]
+                vecs = @SMatrix [convert(TA, 1) convert(TA, 0);
+                                 convert(TA, 0) convert(TA, 1)]
             else # A22 <= A11
                 vals = SVector(A22, A11)
-                vecs = @SMatrix [zero(TA) one(TA);
-                                 one(TA) zero(TA)]
+                vecs = @SMatrix [convert(TA, 0) convert(TA, 1);
+                                 convert(TA, 1) convert(TA, 0)]
             end
         else # A is not diagonal
             t_half = real(a[1] + a[4]) / 2

--- a/test/eigen.jl
+++ b/test/eigen.jl
@@ -67,6 +67,13 @@ using StaticArrays, Test, LinearAlgebra
         @test vals::SVector ≈ sort(m_d)
         @test eigvals(m) ≈ sort(m_d)
         @test eigvals(Hermitian(m)) ≈ sort(m_d)
+
+        # issue #523
+        for (i, j) in ((1, 2), (2, 1)), uplo in (:U, :L)
+            A = SMatrix{2,2,Float64}((i, 0, 0, j))
+            E = eigen(Symmetric(A, uplo))
+            @test eigvecs(E) * SDiagonal(eigvals(E)) * eigvecs(E)' ≈ A
+        end
     end
 
     @testset "3×3" for i = 1:100


### PR DESCRIPTION
Fixes #523. I also reduced the amount of `@inbounds` by tearing it to the outside. I think it should apply everywhere in the following block.

Some questions:
* Is `T` equal to `eltype(A)`?
* Is there a noticeable difference between `TA(1)`, `TA(0)` and `one(TA)`, `zero(TA)`?

TODO: add tests for the diagonal 2x2 case.