### PR TITLE
Drop Julia v0.7 support, remove deprecations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ os:
   - linux
   - osx
 julia:
-  - 0.7
   - 1.0
   - nightly
 notifications:
@@ -22,7 +21,7 @@ branches:
 #  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
 #  - julia -e 'Pkg.clone(pwd()); Pkg.build("StaticArrays"); Pkg.test("StaticArrays"; coverage=true)'
 after_success:
-  - if [ $TRAVIS_JULIA_VERSION = "0.7" ] && [ $TRAVIS_OS_NAME = "linux" ]; then
+  - if [ $TRAVIS_JULIA_VERSION = "1.0" ] && [ $TRAVIS_OS_NAME = "linux" ]; then
       julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder()); Codecov.submit(Codecov.process_folder())';
     fi
   - julia -e 'using Pkg; ps=Pkg.PackageSpec(name="Documenter", version="0.19"); Pkg.add(ps); Pkg.pin(ps)'

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,1 @@
-julia 0.7-rc2
+julia 1.0.0

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,5 @@
 environment:
   matrix:
-  - julia_version: 0.7
   - julia_version: 1.0
   - julia_version: latest
 

--- a/src/MArray.jl
+++ b/src/MArray.jl
@@ -34,14 +34,6 @@ mutable struct MArray{S <: Tuple, T, N, L} <: StaticArray{S, T, N}
         check_array_parameters(S, T, Val{N}, Val{L})
         new{S,T,N,L}()
     end
-
-    @static if VERSION < v"1.0"
-        # deprecated empty constructor
-        function MArray{S,T,N,L}() where {S,T,N,L}
-            Base.depwarn("`MArray{S,T,N,L}()` is deprecated, use `MArray{S,T,N,L}(undef)` instead", :MArray)
-            return MArray{S,T,N,L}(undef)
-        end
-    end
 end
 
 @generated function (::Type{MArray{S,T,N}})(x::Tuple) where {S,T,N}
@@ -65,12 +57,6 @@ end
     end
 end
 
-@static if VERSION < v"1.0"
-    function (::Type{MArray{S,T,N}})() where {S,T,N}
-        Base.depwarn("`MArray{S,T,N}()` is deprecated, use `MArray{S,T,N}(undef)` instead", :MArray)
-        return MArray{S,T,N}(undef)
-    end
-end
 @generated function (::Type{MArray{S,T,N}})(::UndefInitializer) where {S,T,N}
     return quote
         $(Expr(:meta, :inline))
@@ -78,12 +64,6 @@ end
     end
 end
 
-@static if VERSION < v"1.0"
-    function (::Type{MArray{S,T}})() where {S,T}
-        Base.depwarn("`MArray{S,T}()` is deprecated, use `MArray{S,T}(undef)` instead", :MArray)
-        return MArray{S,T}(undef)
-    end
-end
 @generated function (::Type{MArray{S,T}})(::UndefInitializer) where {S,T}
     return quote
         $(Expr(:meta, :inline))
@@ -102,11 +82,6 @@ end
 
 # MArray(I::UniformScaling) methods to replace eye
 (::Type{MA})(I::UniformScaling) where {MA<:MArray} = _eye(Size(MA), MA, I)
-# deprecate eye, keep around for as long as LinearAlgebra.eye exists
-@static if isdefined(LinearAlgebra, :eye)
-    @deprecate eye(::Type{MArray{S}}) where {S} MArray{S}(1.0I)
-    @deprecate eye(::Type{MArray{S,T}}) where {S,T} MArray{S,T}(I)
-end
 
 ####################
 ## MArray methods ##
@@ -139,9 +114,7 @@ end
 
 @inline Tuple(v::MArray) = v.data
 
-if isdefined(Base, :dataids) # v0.7-
-    Base.dataids(ma::MArray) = (UInt(pointer(ma)),)
-end
+Base.dataids(ma::MArray) = (UInt(pointer(ma)),)
 
 @inline function Base.unsafe_convert(::Type{Ptr{T}}, a::MArray{S,T}) where {S,T}
     Base.unsafe_convert(Ptr{T}, pointer_from_objref(a))

--- a/src/MMatrix.jl
+++ b/src/MMatrix.jl
@@ -44,12 +44,6 @@ end
     end
 end
 
-@static if VERSION < v"1.0"
-    function (::Type{MMatrix{S1,S2,T}})() where {S1,S2,T}
-        Base.depwarn("`MMatrix{S1,S2,T}()` is deprecated, use `MMatrix{S1,S2,T}(undef)` instead", :MMatrix)
-        return MMatrix{S1,S2,T}(undef)
-    end
-end
 @generated function (::Type{MMatrix{S1,S2,T}})(::UndefInitializer) where {S1,S2,T}
     return quote
         $(Expr(:meta, :inline))
@@ -65,11 +59,6 @@ end
 
 # Some more advanced constructor-like functions
 @inline one(::Type{MMatrix{N}}) where {N} = one(MMatrix{N,N})
-
-# deprecate eye, keep around for as long as LinearAlgebra.eye exists
-@static if isdefined(LinearAlgebra, :eye)
-    @deprecate eye(::Type{MMatrix{N}}) where {N} MMatrix{N,N}(1.0I)
-end
 
 #####################
 ## MMatrix methods ##

--- a/src/SArray.jl
+++ b/src/SArray.jl
@@ -61,11 +61,6 @@ end
 
 # SArray(I::UniformScaling) methods to replace eye
 (::Type{SA})(I::UniformScaling) where {SA<:SArray} = _eye(Size(SA), SA, I)
-# deprecate eye, keep around for as long as LinearAlgebra.eye exists
-@static if isdefined(LinearAlgebra, :eye)
-    @deprecate eye(::Type{SArray{S}}) where {S} SArray{S}(1.0I)
-    @deprecate eye(::Type{SArray{S,T}}) where {S,T} SArray{S,T}(I)
-end
 
 ####################
 ## SArray methods ##
@@ -77,9 +72,7 @@ end
 
 @inline Tuple(v::SArray) = v.data
 
-if isdefined(Base, :dataids) # v0.7-
-    Base.dataids(::SArray) = ()
-end
+Base.dataids(::SArray) = ()
 
 # See #53
 Base.cconvert(::Type{Ptr{T}}, a::SArray) where {T} = Base.RefValue(a)

--- a/src/SDiagonal.jl
+++ b/src/SDiagonal.jl
@@ -83,10 +83,6 @@ end
 
 # SDiagonal(I::UniformScaling) methods to replace eye
 (::Type{SD})(I::UniformScaling) where {N,SD<:SDiagonal{N}} = SD(ntuple(x->I.λ, Val(N)))
-# deprecate eye, keep around for as long as LinearAlgebra.eye exists
-@static if VERSION < v"1.0"
-    @deprecate eye(::Type{SDiagonal{N,T}}) where {N,T} SDiagonal{N,T}(I)
-end
 
 one(::Type{SDiagonal{N,T}}) where {N,T} = SDiagonal(ones(SVector{N,T}))
 one(::SDiagonal{N,T}) where {N,T} = SDiagonal(ones(SVector{N,T}))

--- a/src/SMatrix.jl
+++ b/src/SMatrix.jl
@@ -61,11 +61,6 @@ end
 # Some more advanced constructor-like functions
 @inline one(::Type{SMatrix{N}}) where {N} = one(SMatrix{N,N})
 
-# deprecate eye, keep around for as long as LinearAlgebra.eye exists
-@static if isdefined(LinearAlgebra, :eye)
-    @deprecate eye(::Type{SMatrix{N}}) where {N} SMatrix{N,N}(1.0I)
-end
-
 #####################
 ## SMatrix methods ##
 #####################

--- a/src/SizedArray.jl
+++ b/src/SizedArray.jl
@@ -19,13 +19,6 @@ struct SizedArray{S <: Tuple, T, N, M} <: StaticArray{S, T, N}
         new{S,T,N,M}(a)
     end
 
-    @static if VERSION < v"1.0"
-        function SizedArray{S, T, N, M}() where {S, T, N, M}
-            Base.depwarn("`SizedArray{S,T,N,M}()` is deprecated, use `SizedArray{S,T,N,M}(undef)` instead", :SizedArray)
-            new{S, T, N, M}(Array{T, M}(undef, S.parameters...))
-        end
-    end
-
     function SizedArray{S, T, N, M}(::UndefInitializer) where {S, T, N, M}
         new{S, T, N, M}(Array{T, M}(undef, S.parameters...))
     end
@@ -37,17 +30,6 @@ end
 
 @inline SizedArray{S,T,N}(::UndefInitializer) where {S,T,N} = SizedArray{S,T,N,N}(undef)
 @inline SizedArray{S,T}(::UndefInitializer) where {S,T} = SizedArray{S,T,tuple_length(S),tuple_length(S)}(undef)
-
-@static if VERSION < v"1.0"
-    @inline function SizedArray{S,T,N}(::UndefInitializer) where {S,T,N}
-        Base.depwarn("`SizedArray{S,T,N}()` is deprecated, use `SizedArray{S,T,N}(undef)` instead", :SizedArray)
-        SizedArray{S,T,N,N}(undef)
-    end
-    @inline function SizedArray{S,T}(::UndefInitializer) where {S,T}
-        Base.depwarn("`SizedArray{S,T}()` is deprecated, use `SizedArray{S,T}(undef)` instead", :SizedArray)
-        SizedArray{S,T,tuple_length(S),tuple_length(S)}(undef)
-    end
-end
 
 @generated function (::Type{SizedArray{S,T,N,M}})(x::NTuple{L,Any}) where {S,T,N,M,L}
     if L != tuple_prod(S)
@@ -90,9 +72,7 @@ SizedMatrix{S1,S2,T,M} = SizedArray{Tuple{S1,S2},T,2,M}
 @inline SizedMatrix{S1,S2}(a::Array{T,M}) where {S1,S2,T,M} = SizedArray{Tuple{S1,S2},T,2,M}(a)
 @inline SizedMatrix{S1,S2}(x::NTuple{L,T}) where {S1,S2,T,L} = SizedArray{Tuple{S1,S2},T,2,2}(x)
 
-if isdefined(Base, :dataids) # v0.7-
-    Base.dataids(sa::SizedArray) = Base.dataids(sa.data)
-end
+Base.dataids(sa::SizedArray) = Base.dataids(sa.data)
 
 """
     Size(dims)(array)

--- a/src/StaticArrays.jl
+++ b/src/StaticArrays.jl
@@ -20,11 +20,6 @@ import LinearAlgebra: transpose, adjoint, dot, eigvals, eigen, lyap, tr,
                       factorize, ishermitian, issymmetric, isposdef, normalize,
                       normalize!, Eigen, det, logdet, cross, diff, qr
 
-# import eye for deprecation warnings
-@static if isdefined(LinearAlgebra, :eye)
-    import LinearAlgebra: eye
-end
-
 export StaticScalar, StaticArray, StaticVector, StaticMatrix
 export Scalar, SArray, SVector, SMatrix
 export MArray, MVector, MMatrix

--- a/src/abstractarray.jl
+++ b/src/abstractarray.jl
@@ -124,10 +124,3 @@ reshape(a::Array, s::Size{S}) where {S} = s(a)
 @inline copy(a::StaticArray) = typeof(a)(Tuple(a))
 
 # TODO permutedims?
-
-# full deprecated in Base
-if isdefined(Base, :full)
-    import Base: full
-    @deprecate full(sym::Symmetric{T,SM}) where {T,SM <: StaticMatrix} SMatrix(sym)
-    @deprecate full(herm::Hermitian{T,SM}) where {T,SM <: StaticMatrix} SMatrix(sym)
-end

--- a/src/arraymath.jl
+++ b/src/arraymath.jl
@@ -1,4 +1,3 @@
-@deprecate zeros(A::StaticArray) zeros(typeof(A))
 @inline zeros(::Type{SA}) where {SA <: StaticArray} = _zeros(Size(SA), SA)
 @generated function _zeros(::Size{s}, ::Type{SA}) where {s, SA <: StaticArray}
     T = eltype(SA)
@@ -12,7 +11,6 @@
     end
 end
 
-@deprecate ones(A::StaticArray) ones(typeof(A))
 @inline ones(::Type{SA}) where {SA <: StaticArray} = _ones(Size(SA), SA)
 @generated function _ones(::Size{s}, ::Type{SA}) where {s, SA <: StaticArray}
     T = eltype(SA)

--- a/src/deque.jl
+++ b/src/deque.jl
@@ -8,7 +8,6 @@
     end
 end
 
-Base.@deprecate unshift pushfirst
 @inline pushfirst(vec::StaticVector, x) = _pushfirst(Size(vec), vec, x)
 @generated function _pushfirst(::Size{s}, vec::StaticVector, x) where {s}
     newlen = s[1] + 1
@@ -44,7 +43,6 @@ end
     end
 end
 
-@deprecate shift popfirst
 @inline popfirst(vec::StaticVector) = _popfirst(Size(vec), vec)
 @generated function _popfirst(::Size{s}, vec::StaticVector) where {s}
     newlen = s[1] - 1

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -156,12 +156,6 @@ end
     end
 end
 
-# deprecate eye, keep around for as long as LinearAlgebra.eye exists
-@static if isdefined(LinearAlgebra, :eye)
-    @deprecate eye(A::SM) where {SM<:StaticMatrix} typeof(A)(I)
-    @deprecate eye(::Type{SM}) where {SM<:StaticMatrix} SM(1.0I)
-end
-
 # StaticMatrix(I::UniformScaling) methods to replace eye
 (::Type{SM})(I::UniformScaling) where {N,M,SM<:StaticMatrix{N,M}} = _eye(Size(SM), SM, I)
 
@@ -190,8 +184,6 @@ end
         @inbounds return SMatrix{$N,$N,$T}(tuple($(exprs...)))
     end
 end
-
-@deprecate(diagm(v::StaticVector, k::Type{Val{D}}=Val{0}) where {D}, diagm(k() => v))
 
 @inline diag(m::StaticMatrix, k::Type{Val{D}}=Val{0}) where {D} = _diag(Size(m), m, k)
 @generated function _diag(::Size{S}, m::StaticMatrix, ::Type{Val{D}}) where {S,D}

--- a/src/matrix_multiply.jl
+++ b/src/matrix_multiply.jl
@@ -301,30 +301,16 @@ end
             gemm = :cgemm_
         end
 
-        if VERSION < v"0.7-"
-            blascall = quote
-                ccall((Base.BLAS.@blasfunc($gemm), Base.BLAS.libblas), Nothing,
-                    (Ref{UInt8}, Ref{UInt8}, Ref{Base.BLAS.BlasInt}, Ref{Base.BLAS.BlasInt},
-                     Ref{Base.BLAS.BlasInt}, Ref{$T}, Ptr{$T}, Ref{Base.BLAS.BlasInt},
-                     Ptr{$T}, Ref{Base.BLAS.BlasInt}, Ref{$T}, Ptr{$T},
-                     Ref{Base.BLAS.BlasInt}),
-                     transA, transB, m, n,
-                     ka, alpha, a, strideA,
-                     b, strideB, beta, c,
-                     strideC)
-             end
-         else
-             blascall = quote
-                 ccall((LinearAlgebra.BLAS.@blasfunc($gemm), LinearAlgebra.BLAS.libblas), Nothing,
-                     (Ref{UInt8}, Ref{UInt8}, Ref{LinearAlgebra.BLAS.BlasInt}, Ref{LinearAlgebra.BLAS.BlasInt},
-                      Ref{LinearAlgebra.BLAS.BlasInt}, Ref{$T}, Ptr{$T}, Ref{LinearAlgebra.BLAS.BlasInt},
-                      Ptr{$T}, Ref{LinearAlgebra.BLAS.BlasInt}, Ref{$T}, Ptr{$T},
-                      Ref{LinearAlgebra.BLAS.BlasInt}),
-                      transA, transB, m, n,
-                      ka, alpha, a, strideA,
-                      b, strideB, beta, c,
-                      strideC)
-            end
+        blascall = quote
+             ccall((LinearAlgebra.BLAS.@blasfunc($gemm), LinearAlgebra.BLAS.libblas), Nothing,
+                 (Ref{UInt8}, Ref{UInt8}, Ref{LinearAlgebra.BLAS.BlasInt}, Ref{LinearAlgebra.BLAS.BlasInt},
+                  Ref{LinearAlgebra.BLAS.BlasInt}, Ref{$T}, Ptr{$T}, Ref{LinearAlgebra.BLAS.BlasInt},
+                  Ptr{$T}, Ref{LinearAlgebra.BLAS.BlasInt}, Ref{$T}, Ptr{$T},
+                  Ref{LinearAlgebra.BLAS.BlasInt}),
+                  transA, transB, m, n,
+                  ka, alpha, a, strideA,
+                  b, strideB, beta, c,
+                  strideC)
         end
 
         return quote

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -125,10 +125,6 @@ Length(::Size{S}) where {S} = _Length(S...)
 
 @pure Base.prod(::Size{S}) where {S} = prod(S)
 
-if isdefined(Base, :sub2ind)
-    import Base: sub2ind
-    @deprecate sub2ind(s::Size, x::Int...) LinearIndices(s)[x...]
-end
 Base.LinearIndices(::Size{S}) where {S} = LinearIndices(S)
 
 @pure size_tuple(::Size{S}) where {S} = Tuple{S...}

--- a/test/MArray.jl
+++ b/test/MArray.jl
@@ -116,15 +116,11 @@
 
         @test length(m) === 4
 
-        if isdefined(Base, :mightalias) # v0.7-
-            @test Base.mightalias(m, m)
-            @test !Base.mightalias(m, copy(m))
-            @test Base.mightalias(m, view(m, :, 1))
-        end
-
-        if isdefined(Base, :dataids) # v0.7-
-            @test Base.dataids(m) == (UInt(pointer(m)),)
-        end
+        @test Base.mightalias(m, m)
+        @test !Base.mightalias(m, copy(m))
+        @test Base.mightalias(m, view(m, :, 1))
+        
+        @test Base.dataids(m) == (UInt(pointer(m)),)
     end
 
     @testset "setindex!" begin

--- a/test/SArray.jl
+++ b/test/SArray.jl
@@ -113,9 +113,7 @@
 
         @test_throws Exception m[1] = 1
 
-        if isdefined(Base, :dataids) # v0.7-
-            @test Base.dataids(m) === ()
-        end
+        @test Base.dataids(m) === ()
     end
 
     @testset "promotion" begin

--- a/test/SizedArray.jl
+++ b/test/SizedArray.jl
@@ -60,22 +60,20 @@
     sa[1] = 2
     @test sa.data == [2, 4]
 
-    if isdefined(Base, :mightalias) # v0.7-
-        @testset "aliasing" begin
-            a1 = rand(4)
-            a2 = copy(a1)
-            sa1 = SizedVector{4}(a1)
-            sa2 = SizedVector{4}(a2)
-            @test Base.mightalias(a1, sa1)
-            @test Base.mightalias(sa1, SizedVector{4}(a1))
-            @test !Base.mightalias(a2, sa1)
-            @test !Base.mightalias(sa1, SizedVector{4}(a2))
-            @test Base.mightalias(sa1, view(sa1, 1:2))
-            @test Base.mightalias(a1, view(sa1, 1:2))
-            @test Base.mightalias(sa1, view(a1, 1:2))
-        end
+    @testset "aliasing" begin
+        a1 = rand(4)
+        a2 = copy(a1)
+        sa1 = SizedVector{4}(a1)
+        sa2 = SizedVector{4}(a2)
+        @test Base.mightalias(a1, sa1)
+        @test Base.mightalias(sa1, SizedVector{4}(a1))
+        @test !Base.mightalias(a2, sa1)
+        @test !Base.mightalias(sa1, SizedVector{4}(a2))
+        @test Base.mightalias(sa1, view(sa1, 1:2))
+        @test Base.mightalias(a1, view(sa1, 1:2))
+        @test Base.mightalias(sa1, view(a1, 1:2))
     end
-
+    
     @testset "back to Array" begin
         @test Array(SizedArray{Tuple{2}, Int, 1}([3, 4])) == [3, 4]
         @test Array{Int}(SizedArray{Tuple{2}, Int, 1}([3, 4])) == [3, 4]

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -164,31 +164,21 @@ using StaticArrays, Test, LinearAlgebra
 
         # issue #388
         let x = SVector(1, 2, 3)
-            if VERSION >= v"0.7.0-beta.47"
-                # current limit: 34 arguments
-                hcat(
-                    x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x,
-                    x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x)
-                allocs = @allocated hcat(
-                    x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x,
-                    x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x)
-                @test allocs == 0
-                vcat(
-                    x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x,
-                    x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x)
-                allocs = @allocated vcat(
-                    x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x,
-                    x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x)
-                @test allocs == 0
-            else
-                # current limit: 14 arguments
-                hcat(x, x, x, x, x, x, x, x, x, x, x, x, x, x)
-                allocs = @allocated hcat(x, x, x, x, x, x, x, x, x, x, x, x, x, x)
-                @test allocs == 0
-                vcat(x, x, x, x, x, x, x, x, x, x, x, x, x, x)
-                allocs = @allocated vcat(x, x, x, x, x, x, x, x, x, x, x, x, x, x)
-                @test allocs == 0
-            end
+            # current limit: 34 arguments
+            hcat(
+                x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x,
+                x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x)
+            allocs = @allocated hcat(
+                x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x,
+                x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x)
+            @test allocs == 0
+            vcat(
+                x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x,
+                x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x)
+            allocs = @allocated vcat(
+                x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x,
+                x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x)
+            @test allocs == 0
         end
     end
 

--- a/test/mapreduce.jl
+++ b/test/mapreduce.jl
@@ -1,7 +1,5 @@
 using StaticArrays, Test
-if VERSION >= v"0.7.0-beta.85"
-    import Statistics: mean
-end
+import Statistics: mean
 
 @testset "Map, reduce, mapreduce, broadcast" begin
     @testset "map and map!" begin

--- a/test/triangular.jl
+++ b/test/triangular.jl
@@ -64,15 +64,9 @@ end
         @test (transpose(SA)*SB)::SMatrix{n,n} ≈ transpose(A)*transpose(B)
         @test (transpose(SA)*transpose(SB))::SVector{n} ≈ transpose(A)*B
         @test (transpose(SA)*SB')::SVector{n} ≈ transpose(A)*conj(B)
-        if VERSION < v"0.7-"
-            @test (SB*SA)::RowVector{<:Any,<:SVector{n}} ≈ transpose(B)*A
-            @test (SB*SA')::RowVector{<:Any,<:SVector{n}} ≈ transpose(B)*A'
-            @test (SB*transpose(SA))::RowVector{<:Any,<:SVector{n}} ≈ transpose(B)*transpose(A)
-        else
-            @test (SB*SA)::Transpose{<:Any,<:SVector{n}} ≈ transpose(B)*A
-            @test (SB*SA')::Transpose{<:Any,<:SVector{n}} ≈ transpose(B)*A'
-            @test (SB*transpose(SA))::Transpose{<:Any,<:SVector{n}} ≈ transpose(B)*transpose(A)
-        end
+        @test (SB*SA)::Transpose{<:Any,<:SVector{n}} ≈ transpose(B)*A
+        @test (SB*SA')::Transpose{<:Any,<:SVector{n}} ≈ transpose(B)*A'
+        @test (SB*transpose(SA))::Transpose{<:Any,<:SVector{n}} ≈ transpose(B)*transpose(A)
         @test (transpose(SB)*SA)::SMatrix{n,n} ≈ B*A
         @test (SB'*SA)::SMatrix{n,n} ≈ conj(B)*A
         @test (transpose(SB)*transpose(SA))::SMatrix{n,n} ≈ B*transpose(A)


### PR DESCRIPTION
We have a solid release for Julia v0.7, which should be good enough for users needing to upgrade to v1.0. Personally, I don't feel it is valuable keeping around the old fluff.

I'm interested in getting this in for #522