### PR TITLE
Fix bug in module deprecation from 0.9.0 release

### DIFF
--- a/src/FixedSizeArrays.jl
+++ b/src/FixedSizeArrays.jl
@@ -10,6 +10,9 @@ module FixedSizeArraysWillBeRemoved
 
 using ..StaticArrays
 
+const FixedSizeArrays = FixedSizeArraysWillBeRemoved
+export FixedSizeArrays # Ensure deprecated module name is in scope after import
+
 export FixedArray
 export FixedVector
 export FixedMatrix
@@ -189,4 +192,4 @@ end
 end
 
 Base.@deprecate_binding FixedSizeArrays FixedSizeArraysWillBeRemoved #=
-    =# false "StaticArrays.FixedSizeArrays is deprecated. Use StaticArrays directly."
+    =# false ".  Use StaticArrays directly."

--- a/src/ImmutableArrays.jl
+++ b/src/ImmutableArrays.jl
@@ -2,6 +2,9 @@ module ImmutableArraysWillBeRemoved
 
 using ..StaticArrays
 
+const ImmutableArrays = ImmutableArraysWillBeRemoved
+export ImmutableArrays # Ensure deprecated module name is in scope after import
+
 Vector1{T} = SVector{1,T}
 Vector2{T} = SVector{2,T}
 Vector3{T} = SVector{3,T}
@@ -36,4 +39,4 @@ export Vector1,   Vector2,   Vector3,   Vector4,
 end # module
 
 Base.@deprecate_binding ImmutableArrays ImmutableArraysWillBeRemoved #=
-    =# false "StaticArrays.ImmutableArrays is deprecated. Use StaticArrays directly."
+    =# false ".  Use StaticArrays directly."


### PR DESCRIPTION
With the bug, `using StaticArrays.FixedSizeArrays` did not result in a
module name `FixedSizeArrays` in the current namespace, thus breaking
explicitly qualified name lookups like `FixedSizeArrays.Vec(1,2)`.

Provide a binding for this explicitly.

@fredrikekre — here's one possible fix. Thoughts?