### PR TITLE
Add `SOneTo` as `AbstractUnitRange` to represent `axes(::StaticArray)`

### DIFF
--- a/src/SOneTo.jl
+++ b/src/SOneTo.jl
@@ -1,0 +1,60 @@
+"""
+    SOneTo(n)
+
+Return a statically-sized `AbstractUnitRange` starting at `1`, functioning as the `axes` of
+a `StaticArray`.
+"""
+struct SOneTo{n} <: AbstractUnitRange{Int}
+end
+
+SOneTo(n::Int) = SOneTo{n}()
+
+Base.axes(s::SOneTo) = (s,)
+Base.size(s::SOneTo) = (length(s),)
+Base.length(s::SOneTo{n}) where {n} = n
+
+function Base.getindex(s::SOneTo, i::Int) 
+    @boundscheck checkbounds(s, i)
+    return i
+end
+function Base.getindex(s::SOneTo, s2::SOneTo)
+    @boundscheck checkbounds(s, s2)
+    return s2
+end
+
+Base.first(::SOneTo) = 1
+Base.last(::SOneTo{n}) where {n} = n::Int
+
+@pure function Base.iterate(::SOneTo{n}) where {n}
+    if n::Int < 1
+        return nothing
+    else
+        (1, 1)
+    end
+end
+function Base.iterate(::SOneTo{n}, s::Int) where {n}
+    if s < n::Int
+        s2 = s + 1
+        return (s2, s2)
+    else
+        return nothing
+    end
+end
+
+function Base.getproperty(::SOneTo{n}, s::Symbol) where {n}
+    if s === :start
+        return 1
+    elseif s === :stop
+        return n::Int
+    else
+        error("type SOneTo has no property $s")
+    end
+end
+
+function Base.show(io::IO, ::SOneTo{n}) where {n}
+    print(io, "SOneTo(", n::Int, ")")
+end
+
+Base.@pure function Base.checkindex(::Type{Bool}, ::SOneTo{n1}, ::SOneTo{n2}) where {n1, n2}
+    return n1::Int >= n2::Int
+end

--- a/src/StaticArrays.jl
+++ b/src/StaticArrays.jl
@@ -25,6 +25,7 @@ import LinearAlgebra: transpose, adjoint, dot, eigvals, eigen, lyap, tr,
     import LinearAlgebra: eye
 end
 
+export SOneTo
 export StaticScalar, StaticArray, StaticVector, StaticMatrix
 export Scalar, SArray, SVector, SMatrix
 export MArray, MVector, MMatrix
@@ -39,6 +40,8 @@ export @MVector, @MMatrix, @MArray
 
 export similar_type
 export push, pop, pushfirst, popfirst, insert, deleteat, setindex
+
+include("SOneTo.jl")
 
 """
     abstract type StaticArray{S, T, N} <: AbstractArray{T, N} end


### PR DESCRIPTION
This has been on the to-do list for 2 years! :tada: 

Now `axes(::StaticArray)` will return a tuple of "static unit ranges / slices". The `SOneTo` type lives under `AbstractUnitRange` so it can work properly with `Base`, and is therefore not a `StaticArray` subtype.

One interesting side-effect is what happens to `collect`:

```julia
julia> v = SVector(1,2,3)
3-element SArray{Tuple{3},Int64,1,3}:
 1
 2
 3

julia> [x for x in v]
3-element SizedArray{Tuple{3},Int64,1,1}:
 1
 2
 3
```
This matches the *OffsetArrays* package... basically if you want to mess with `axes` your behavior is automatically used by `collect`, and in particular for offsets (`Slice`s) you kind of need to rely on this to work out properly. I guess we should roll with this for now. If we can get generator/comprehension syntax working fast (constructing `SVector`s with optimal code) that could be pretty neat.

I believe the benefits of this will eventually be far-reaching. In particular the `axes` and `keys` of an array can now be directly used as an indication of it's *static-sizedness*. This is more-or-less a trait that is already plumbed into many systems (like `collect`). Hopefully this will make dealing with "wrapped up" types like `Diagonal` with `SVector` more natural.

Closes #476 