### PR TITLE
Return DimensionMismatch rather than ErrorException

### DIFF
--- a/src/convert.jl
+++ b/src/convert.jl
@@ -13,7 +13,7 @@
 @inline Tuple(a::StaticArray) = unroll_tuple(a, Length(a))
 
 @noinline function dimension_mismatch_fail(SA::Type, a::AbstractArray)
-    error("Dimension mismatch. Expected input array of length $(length(SA)), got length $(length(a))")
+    throw(DimensionMismatch("expected input array of length $(length(SA)), got length $(length(a))"))
 end
 
 @inline function convert(::Type{SA}, a::AbstractArray) where {SA <: StaticArray}


### PR DESCRIPTION
Seems reasonable to use the "official" exception type here. We don't seem to have a specific test for this (it's probably a `@test_throws Exception ...` test); I can make it more specific if desired.