### PR TITLE
No tuple creation for SizedArrays

### DIFF
--- a/src/StaticArrays.jl
+++ b/src/StaticArrays.jl
@@ -98,7 +98,6 @@ const StaticArrayNoEltype{S, N, T} = StaticArray{S, T, N}
 
 include("util.jl")
 include("traits.jl")
-include("convert.jl")
 
 include("SUnitRange.jl")
 include("FieldVector.jl")
@@ -111,6 +110,8 @@ include("MVector.jl")
 include("MMatrix.jl")
 include("SizedArray.jl")
 include("SDiagonal.jl")
+
+include("convert.jl")
 
 include("abstractarray.jl")
 include("indexing.jl")

--- a/src/abstractarray.jl
+++ b/src/abstractarray.jl
@@ -158,7 +158,7 @@ reshape(a::Array, s::Size{S}) where {S} = s(a)
 @inline vec(a::StaticArray) = reshape(a, Size(prod(Size(typeof(a)))))
 
 @inline copy(a::StaticArray) = typeof(a)(Tuple(a))
-@inline copy(a::SizedArray) = typeof(a)(a)
+@inline copy(a::SizedArray) = typeof(a)(copy(a.data))
 
 @inline reverse(v::StaticVector) = typeof(v)(reverse(Tuple(v)))
 

--- a/src/abstractarray.jl
+++ b/src/abstractarray.jl
@@ -154,6 +154,7 @@ reshape(a::Array, s::Size{S}) where {S} = s(a)
 @inline vec(a::StaticArray) = reshape(a, Size(prod(Size(typeof(a)))))
 
 @inline copy(a::StaticArray) = typeof(a)(Tuple(a))
+@inline copy(a::SizedArray) = typeof(a)(a)
 
 # TODO permutedims?
 

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -3,6 +3,7 @@
 
 @inline (::Type{SA})(x...) where {SA <: StaticArray} = SA(x)
 @inline (::Type{SA})(a::StaticArray) where {SA<:StaticArray} = SA(Tuple(a))
+@inline (::Type{SA})(a::StaticArray) where {SA<:SizedArray} = SA(a.data)
 @propagate_inbounds (::Type{SA})(a::AbstractArray) where {SA <: StaticArray} = convert(SA, a)
 
 # this covers most conversions and "statically-sized reshapes"

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -106,8 +106,14 @@ using StaticArrays, Test, LinearAlgebra
     end
 
     @testset "copy" begin
-        @test @inferred(copy(SMatrix{2, 2}([1 2; 3 4]))) === @SMatrix [1 2; 3 4]
-        @test @inferred(copy(MMatrix{2, 2}([1 2; 3 4])))::MMatrix == [1 2; 3 4]
+        M = [1 2; 3 4]
+        SM = SMatrix{2, 2}(M)
+        MM = MMatrix{2, 2}(M)
+        SizeM = Size(2,2)(M)
+        @test @inferred(copy(SM)) === @SMatrix [1 2; 3 4]
+        @test @inferred(copy(MM))::MMatrix == M
+        @test copy(SM).data !== M
+        @test copy(SizeM).data !== M
     end
 
     @testset "reverse" begin

--- a/test/convert.jl
+++ b/test/convert.jl
@@ -1,0 +1,7 @@
+using StaticArrays, Test
+
+@testset "Copy constructors" begin
+    M = [1 2; 3 4]
+    SizeM = Size(2,2)(M)
+    @test typeof(SizeM)(SizeM).data === M
+end # testset

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,6 +25,7 @@ include("SizedArray.jl")
 include("SDiagonal.jl")
 
 include("custom_types.jl")
+include("convert.jl")
 include("core.jl")
 include("abstractarray.jl")
 include("indexing.jl")


### PR DESCRIPTION
Tuple creation is unnecessary for SizedArrays and causes massive slowdown for big arrays.