### PR TITLE
added static bitsets

### DIFF
--- a/src/SBitSet.jl
+++ b/src/SBitSet.jl
@@ -1,0 +1,38 @@
+struct SBitSet{N}<:AbstractSet{Int64}
+    chunks::SVector{N,UInt64}
+end
+
+@inline function Base.iterate(B::SBitSet{N}) where N
+    N==0 && return nothing
+    return iterate(B, (1, @inbounds B.chunks[1]))
+end
+
+@inline function Base.iterate(B::SBitSet{N}, s) where N
+    N==0 && return nothing
+    i1, c = s
+    while c==0
+        i1 % UInt >= N % UInt && return nothing
+        i1 += 1
+        @inbounds c = B.chunks[i1]
+    end
+    tz = trailing_zeros(c) + 1
+    c = _blsr(c)
+    return ((i1-1)<<6 + tz, (i1, c))
+end
+
+@inline Base.isempty(B::SBitSet) = iszero(B.chunks)
+@inline Base.length(B::SBitSet) = count_ones(B.chunks)
+@inline Base.union(B::SBitSet, C::SBitSet) = SBitSet(B.chunks | C.chunks)
+@inline Base.intersect(B::SBitSet, C::SBitSet) = SBitSet(B.chunks & C.chunks)
+@inline Base.symdiff(B::SBitSet, C::SBitSet) = SBitSet(xor(B.chunks, C.chunks))
+@inline Base.setdiff(B::SBitSet, C::SBitSet) = SBitSet(B.chunks & ~C.chunks)
+@inline Base.issubset(B::SBitSet, C::SBitSet) = iszero(B.chunks & ~C.chunks)
+
+@inline function Base.in(B::SBitSet{N}, k::Integer) where N
+    (0%UInt < k%UInt <= (N<<6)) || return false
+    i1,i2 = Base.get_chunks_id(k)
+    return !iszero(B.chunks[i1] & (1<<i2))
+end
+
+Base.show(io::IO, ::MIME{Symbol("text/plain")}, B::SBitSet) = show(io, B)
+Base.show(io::IO, B::SBitSet{N}) where N = print(io, "SBitSet{$N}($(collect(B)))")

--- a/src/StaticArrays.jl
+++ b/src/StaticArrays.jl
@@ -6,7 +6,7 @@ import Base: getindex, setindex!, size, similar, vec, show, length, convert, pro
              promote_rule, map, map!, reduce, mapreduce, broadcast,
              broadcast!, conj, hcat, vcat, ones, zeros, one, reshape, fill, fill!, inv,
              iszero, sum, prod, count, any, all, minimum, maximum, extrema,
-             copy, read, read!, write
+             copy, read, read!, write, count_ones
 
 import Statistics: mean
 
@@ -24,6 +24,12 @@ import LinearAlgebra: transpose, adjoint, dot, eigvals, eigen, lyap, tr,
 @static if isdefined(LinearAlgebra, :eye)
     import LinearAlgebra: eye
 end
+#needed for SBitSet
+@static if isdefined(Base, :_blsr)
+    import Base: _blsr
+else
+    @inline _blsr(x::UInt64) = x & (x-1)
+end
 
 export SOneTo
 export StaticScalar, StaticArray, StaticVector, StaticMatrix
@@ -32,6 +38,7 @@ export MArray, MVector, MMatrix
 export FieldVector
 export SizedArray, SizedVector, SizedMatrix
 export SDiagonal
+export SBitSet
 
 export Size, Length
 
@@ -96,6 +103,7 @@ include("MVector.jl")
 include("MMatrix.jl")
 include("SizedArray.jl")
 include("SDiagonal.jl")
+include("SBitSet.jl")
 
 include("abstractarray.jl")
 include("indexing.jl")

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -1,19 +1,22 @@
-import Base: +, -, *, /, \
+import Base: +, -, *, /, \, &, |, xor, ~
 
 # TODO: more operators, like AbstractArray
 
 # Unary ops
 @inline -(a::StaticArray) = map(-, a)
+@inline ~(a::StaticArray) = map(~, a)
 
 # Binary ops
 # Between arrays
-@inline +(a::StaticArray, b::StaticArray) = map(+, a, b)
-@inline +(a::AbstractArray, b::StaticArray) = map(+, a, b)
-@inline +(a::StaticArray, b::AbstractArray) = map(+, a, b)
-
-@inline -(a::StaticArray, b::StaticArray) = map(-, a, b)
-@inline -(a::AbstractArray, b::StaticArray) = map(-, a, b)
-@inline -(a::StaticArray, b::AbstractArray) = map(-, a, b)
+let
+    ops = [:+, :-, :&, :|, :xor]
+    type_combinations = [(StaticArray, StaticArray), (StaticArray, AbstractArray), (AbstractArray, StaticArray)]
+    for op in ops
+        for (_L, _R) in type_combinations
+            @eval @inline $op(a::$(_L), b::$(_R) )=map($op, a, b) 
+        end
+    end
+end
 
 # Scalar-array
 @inline +(a::Number, b::StaticArray) = broadcast(+, a, b)

--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -188,6 +188,7 @@ end
 
 @inline count(a::StaticArray{<:Any,Bool}; dims=:) = reduce(+, a; dims=dims)
 @inline count(f, a::StaticArray; dims=:) = mapreduce(x->f(x)::Bool, +, a; dims=dims)
+@inline count_ones(a::StaticArray{<:Any, <:Union{Int128, Int16, Int32, Int64, Int8, UInt128, UInt16, UInt32, UInt64, UInt8}}; dims=:) = mapreduce(count_ones, +, a; dims=dims)
 
 @inline all(a::StaticArray{<:Any,Bool}; dims=:) = reduce(&, a; dims=dims, init=true)  # non-branching versions
 @inline all(f::Function, a::StaticArray; dims=:) = mapreduce(x->f(x)::Bool, &, a; dims=dims, init=true)

--- a/test/SBitSet.jl
+++ b/test/SBitSet.jl
@@ -1,0 +1,41 @@
+using StaticArrays, Test
+
+@testset "SBitSet" begin
+    v1 = @SVector UInt64[2,4,6,8]
+    v2 = @SVector UInt64[4,3,2,1]
+    sbs1 = SBitSet(v1)
+    sbs2 = SBitSet(v2)
+    z = SBitSet(xor(v1,v1))
+
+
+    @test isempty(sbs1) === false
+    @test isempty(z) === true
+
+    @test length(sbs1) === 5
+    @test length(z) === 0
+    @test in(67,sbs1) == true
+    @test in(135, sbs1) == false
+
+    z = SBitSet(@SVector [-Int64(1)%UInt64])
+    @test in(64, z)==true
+    @test in(1, z)==true
+    @test in(0, z)==false
+    @test in(65, z)==false
+    @test in(-1, z)==false
+
+
+    @test collect(sbs1)::Vector{Int64} == [2, 64+3, 128+2, 128+3, 192+4]
+    @test collect(sbs2) == [3, 64+1, 64+2, 128+2, 192+1]
+    @test collect(intersect(sbs1,sbs2)) == [128+2]
+    @test collect(union(sbs1,sbs2)) == [2, 3, 64+1, 64+2, 64+3, 128+2, 128+3, 192+1, 192+4]
+    @test collect(setdiff(sbs1,sbs2)) == [2, 64+3, 128+3, 192+4]
+    @test collect(symdiff(sbs1,sbs2)) == [2, 3, 64+1, 64+2, 64+3, 128+3, 192+1, 192+4]
+
+    @test issubset(sbs1, sbs2) == false
+    z = intersect(sbs1,sbs2)
+    @test issubset(z,sbs1) == true
+    @test issubset(sbs1,z) == false
+    @test issubset(sbs1,sbs1) == true
+
+    @inferred collect(sbs1)
+end

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -7,6 +7,9 @@ using StaticArrays, Test, LinearAlgebra
         v1 = @SVector [2,4,6,8]
         v2 = @SVector [4,3,2,1]
 
+        @test @inferred(-v1) === @SVector [-2,-4,-6,-8]
+        @test @inferred(~v1) === @SVector [-3,-5,-7,-9]
+
         @test @inferred(v1 + c) === @SVector [4,6,8,10]
         @test @inferred(v1 - c) === @SVector [0,2,4,6]
         @test @inferred(v1 * c) === @SVector [4,8,12,16]
@@ -15,6 +18,11 @@ using StaticArrays, Test, LinearAlgebra
 
         @test @inferred(v1 + v2) === @SVector [6, 7, 8, 9]
         @test @inferred(v1 - v2) === @SVector [-2, 1, 4, 7]
+        @test @inferred(v1 & v2) === @SVector [0,0,2,0]
+        @test @inferred(v1 | v2) === @SVector [6,7,6,9]
+        @test @inferred(v1 ⊻ v2) === @SVector [6,7,4,9]
+
+
 
         # TODO Decide what to do about this stuff:
         #v3 = [2,4,6,8]

--- a/test/mapreduce.jl
+++ b/test/mapreduce.jl
@@ -44,6 +44,7 @@ end
         @test mapreduce(x->x^2, max, sa; dims=Val(1), init=-1.) == SMatrix{1,J}(mapreduce(x->x^2, max, a, dims=1, init=-1.))
         @test mapreduce(x->x^2, max, sa; dims=1, init=-1.) == SMatrix{1,J}(mapreduce(x->x^2, max, a, dims=1, init=-1.))
         @test mapreduce(x->x^2, max, sa; dims=2, init=-1.) == SMatrix{I,1}(mapreduce(x->x^2, max, a, dims=2, init=-1.))
+        @test count_ones(sv1) == mapreduce(count_ones, +, v1)
     end
 
     @testset "implemented by [map]reduce and [map]reducedim" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,7 @@ Random.seed!(42)
 
 include("testutil.jl")
 include("SVector.jl")
+include("SBitSet.jl")
 include("MVector.jl")
 include("SMatrix.jl")
 include("MMatrix.jl")


### PR DESCRIPTION
This PR adds bitwise operations for SVectors and a `<:AbstractSet{Int}` view of `SVector{N, UInt64} where {N}`. 

This set view is mainly interesting as an iterator over the set bits, as well as nice pretty printing. I am intentionally not storing the length, so that conversion from SVector is a no-op.

Tests are included, docs are missing. Also, is this the right way of polyfilling `Base._blsr`?