### PR TITLE
Wrapper for Matrix/Vector of SVector

### DIFF
--- a/src/SVecMat.jl
+++ b/src/SVecMat.jl
@@ -1,0 +1,62 @@
+struct SVecMat{N, T, Mtyp<:AbstractMatrix{T}} <: AbstractMatrix{T}
+    parent::Mtyp
+end
+
+Base.@propagate_inbounds function SVecMat(::Val{N}, mat) where N 
+    @boundscheck begin 
+        size(mat, 1) != N && throw(DimensionMismatch("Cannot construct N=$N dimensional SvecMat from s=$(size(mat,1)) columns"))
+    end
+    return SVecMat{N}(mat)
+end
+
+@inline SVecMat(mat::AbstractArray{T}) where T = SVecMat{size(mat,1), T, typeof(mat)}(mat)
+
+Base.@propagate_inbounds Base.getindex(M::SVecMat, idxs...) = getindex(M.parent, idxs...)
+Base.@propagate_inbounds Base.setindex!(M::SVecMat, v, idxs...) = setindex!(M.parent, v, idxs...)
+@inline Base.length(M::SVecMat) = length(M.parent)
+@inline Base.size(M::SVecMat{N}) where N = (N, size(M.parent, 2) )
+Base.IndexStyle(::SVecMat{N, T, Mtyp}) where {N,T,Mtyp} = IndexStyle(Mtyp)
+Base.IndexStyle(::Type{SVecMat{N, T, Mtyp}}) where {N,T,Mtyp} = IndexStyle(Mtyp)
+Base.eltype(M::SVecMat) = eltype(M.parent)
+
+
+@inline function Base.getindex(M::SVecMat{N}, ::Colon, j::Integer) where N
+    @boundscheck checkbounds(M, 1, j)
+    return SVector(ntuple(i-> (@inbounds M.parent[i,j]) , N))
+end
+
+@inline function Base.setindex!(M::SVecMat{N,T}, v::SVector{N,T}, ::Colon, j::Integer) where {N,T}
+    @boundscheck checkbounds(M, 1, j)
+    for i=1:N
+        @inbounds M[i,j] = v[i]
+    end
+    v
+end
+
+
+
+Base.@propagate_inbounds function getbit(B::SVecMat{N,UInt64}, i) where N
+    i1,i2 = Base.get_chunks_id(i)
+    return !iszero(B.parent[i1] & (1<<i2))
+end
+
+Base.@propagate_inbounds function getbit(B::SVecMat{N,UInt64}, i, j) where N
+    i1,i2 = Base.get_chunks_id(i)
+    return !iszero(B.parent[i1,j] & (1<<i2))
+end
+
+Base.@propagate_inbounds function setbit!(B::SVecMat{N,UInt64}, b::Bool, i) where N
+    i1, i2 = Base.get_chunks_id(i)
+    u = UInt64(1) << i2
+    c = B.parent[i1]
+    B.parent[i1] = ifelse(b, c | u, c & ~u)
+    b
+end
+
+Base.@propagate_inbounds function setbit!(B::SVecMat{N,UInt64}, b::Bool, i, j) where N
+    i1, i2 = Base.get_chunks_id(i)
+    u = UInt64(1) << i2
+    c = B.parent[i1, j]
+    B.parent[i1, j] = ifelse(b, c | u, c & ~u)
+    b
+end

--- a/src/StaticArrays.jl
+++ b/src/StaticArrays.jl
@@ -32,6 +32,7 @@ export MArray, MVector, MMatrix
 export FieldVector
 export SizedArray, SizedVector, SizedMatrix
 export SDiagonal
+export SVecMat
 
 export Size, Length
 
@@ -122,5 +123,6 @@ include("io.jl")
 
 include("FixedSizeArrays.jl")
 include("ImmutableArrays.jl")
+include("SVecMat.jl")
 
 end # module


### PR DESCRIPTION
This is my attempt at a julian way of mixing Vector{SVector} and Matrix code. Especially important if one wants to mutate single entries, which is otherwise very annoying. 

Use:
```
julia> r=rand(3, 1000);
julia> s=SVecMat(r);
julia> s[:,678]
3-element SArray{Tuple{3},Float64,1,3}:
 0.274480584707264 
 0.8911180705798702
 0.7139000141428269
julia> s[1,678]=0.1;
julia> s[:,678]
3-element SArray{Tuple{3},Float64,1,3}:
 0.1               
 0.8911180705798702
 0.7139000141428269
```
There is no dirty memory punning involved. This constructor is obviously type-unstable, so one needs a function boundary or use the `Val{N}` constructor. The `getbit` and `setbit` for `UInt64` matrices was the original point of the implementation and combines well with the static bitsets. 

But I think that the API (encode `ncols` in the type, overload `getindex(a,::Colon, j)` and `setindex`) works pretty nice for a lot of `SVector` situations.

Needs tests, needs docs, may need some bugfixes. I think the boundscheck elision works.

What do you think about this kind of convenience wrapper? Offer something like this in `StaticArrays` or not?