### PR TITLE
Support construction/conversion of UnitRange->SOneTo

### DIFF
--- a/src/SOneTo.jl
+++ b/src/SOneTo.jl
@@ -8,12 +8,18 @@ struct SOneTo{n} <: AbstractUnitRange{Int}
 end
 
 SOneTo(n::Int) = SOneTo{n}()
+function SOneTo{n}(r::AbstractUnitRange) where n
+    ((first(r) == 1) & (last(r) == n)) && return SOneTo{n}()
+
+    errmsg(r) = throw(DimensionMismatch("$r is inconsistent with SOneTo{$n}")) # avoid GC frame
+    errmsg(r)
+end
 
 Base.axes(s::SOneTo) = (s,)
 Base.size(s::SOneTo) = (length(s),)
 Base.length(s::SOneTo{n}) where {n} = n
 
-function Base.getindex(s::SOneTo, i::Int) 
+function Base.getindex(s::SOneTo, i::Int)
     @boundscheck checkbounds(s, i)
     return i
 end

--- a/test/core.jl
+++ b/test/core.jl
@@ -189,5 +189,10 @@
         b = StaticArrays.SOneTo{2}()
         @test @inferred(promote(a, b)) === (a, Base.OneTo(2))
         @test @inferred(promote(b, a)) === (Base.OneTo(2), a)
+
+        @test StaticArrays.SOneTo{2}(1:2) === StaticArrays.SOneTo{2}()
+        @test convert(StaticArrays.SOneTo{2}, 1:2) === StaticArrays.SOneTo{2}()
+        @test_throws DimensionMismatch StaticArrays.SOneTo{2}(1:3)
+        @test_throws DimensionMismatch StaticArrays.SOneTo{2}(1:1)
     end
 end


### PR DESCRIPTION
Discovered in the context of

```julia
julia> a = SVector(SVector(1,2), SVector(3,4))
2-element SArray{Tuple{2},SArray{Tuple{2},Int64,1,2},1,2}:                                                                                                                                                                                                                     
 [1, 2]                                                                                                                                                                                                                                                                        
 [3, 4]                                                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                             
julia> a'
1×2 LinearAlgebra.Adjoint{LinearAlgebra.Adjoint{Int64,SArray{Tuple{2},Int64,1,2}},SArray{Tuple{2},SArray{Tuple{2},Int64,1,2},1,2}}:                                                                                                                                                                                          
 [1 2]  [3 4]                                                                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                             
julia> reinterpret(Int, a')
Error showing value of type Base.ReinterpretArray{Int64,2,LinearAlgebra.Adjoint{Int64,SArray{Tuple{2},Int64,1,2}},LinearAlgebra.Adjoint{LinearAlgebra.Adjoint{Int64,SArray{Tuple{2},Int64,1,2}},SArray{Tuple{2},SArray{Tuple{2},Int64,1,2},1,2}}}:                                                                           
ERROR: MethodError: no method matching SOneTo{1}(::UnitRange{Int64})                                                                                                                                                                                                                                                         
Closest candidates are:                                                                                                                                                                                                                                                                                                      
  SOneTo{1}() where n at /home/tim/.julia/packages/StaticArrays/3ENSR/src/SOneTo.jl:8                                                                                                                                                                                                                                        
Stacktrace:                                                                                                                                                                                                                                                                                                                  
 [1] convert(::Type{SOneTo{1}}, ::UnitRange{Int64}) at ./range.jl:123                                                                                                                                                                                                                                                        
 [2] oftype(::SOneTo{1}, ::UnitRange{Int64}) at ./essentials.jl:334                                                                                                                                                                                                                                                          
 [3] axes(::Base.ReinterpretArray{Int64,2,LinearAlgebra.Adjoint{Int64,SArray{Tuple{2},Int64,1,2}},LinearAlgebra.Adjoint{LinearAlgebra.Adjoint{Int64,SArray{Tuple{2},Int64,1,2}},SArray{Tuple{2},SArray{Tuple{2},Int64,1,2},1,2}}}) at ./reinterpretarray.jl:82                                                               
 [4] summary(::IOContext{REPL.Terminals.TTYTerminal}, ::Base.ReinterpretArray{Int64,2,LinearAlgebra.Adjoint{Int64,SArray{Tuple{2},Int64,1,2}},LinearAlgebra.Adjoint{LinearAlgebra.Adjoint{Int64,SArray{Tuple{2},Int64,1,2}},SArray{Tuple{2},SArray{Tuple{2},Int64,1,2},1,2}}}) at ./show.jl:1824                             
...
```