### PR TITLE
make dot recursive like Base

### DIFF
--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -228,9 +228,9 @@ end
         return :(zero(promote_op(*, eltype(a), eltype(b))))
     end
 
-    expr = :(conj(a[1]) * b[1])
+    expr = :(adjoint(a[1]) * b[1])
     for j = 2:prod(S)
-        expr = :($expr + conj(a[$j]) * b[$j])
+        expr = :($expr + adjoint(a[$j]) * b[$j])
     end
 
     return quote

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -116,6 +116,10 @@ using StaticArrays, Test, LinearAlgebra
         @test @inferred(dot(v1, -v2)) === -40
         @test @inferred(dot(v1*im, v2*im)) === 40*im*conj(im)
         @test @inferred(StaticArrays.bilinear_vecdot(v1*im, v2*im)) === 40*im*im
+        # inner product, whether via `dot` or written out as `x'*y`, should be recursive like Base:
+        @test @inferred(dot(@SVector[[1,2],[3,4]], @SVector[[1,2],[3,4]])) === 30
+        @test @inferred(@SVector[[1,2],[3,4]]' * @SVector[[1,2],[3,4]]) === 30
+
     end
 
     @testset "transpose() and conj()" begin


### PR DESCRIPTION
For reference, Base does:
```
julia> using LinearAlgebra

julia> dot([[1,2], [3,4]], [[1,2], [3,4]])
30

julia> [[1,2], [3,4]]' * [[1,2], [3,4]]
30
```

whereas StaticArrays before this PR:
```

julia> dot(@SVector[[1,2],[3,4]], @SVector[[1,2],[3,4]])
ERROR: MethodError: no method matching *(::Array{Int64,1}, ::Array{Int64,1})
Stacktrace:
 [1] macro expansion at /home/marius/.julia/packages/StaticArrays/3ENSR/src/linalg.jl:238 [inlined]
 [2] _vecdot at /home/marius/.julia/packages/StaticArrays/3ENSR/src/linalg.jl:227 [inlined]
 [3] dot(::SArray{Tuple{2},Array{Int64,1},1,2}, ::SArray{Tuple{2},Array{Int64,1},1,2}) at /home/marius/.julia/packages/StaticArrays/3ENSR/src/linalg.jl:225
 [4] top-level scope at none:0

julia> @SVector[[1,2],[3,4]]' * @SVector[[1,2],[3,4]]
ERROR: MethodError: no method matching *(::Array{Int64,1}, ::Array{Int64,1})
Stacktrace:
 [1] macro expansion at /home/marius/.julia/packages/StaticArrays/3ENSR/src/linalg.jl:238 [inlined]
 [2] _vecdot at /home/marius/.julia/packages/StaticArrays/3ENSR/src/linalg.jl:227 [inlined]
 [3] dot at /home/marius/.julia/packages/StaticArrays/3ENSR/src/linalg.jl:225 [inlined]
 [4] *(::Adjoint{Adjoint{Int64,Array{Int64,1}},SArray{Tuple{2},Array{Int64,1},1,2}}, ::SArray{Tuple{2},Array{Int64,1},1,2}) at /home/marius/src/julia/1.0/usr/share/julia/stdlib/v1.0/LinearAlgebra/src/adjtrans.jl:197
 [5] top-level scope at none:0
```

and after:
```
julia> dot(@SVector[[1,2],[3,4]], @SVector[[1,2],[3,4]])
30

julia> @SVector[[1,2],[3,4]]' * @SVector[[1,2],[3,4]]
30
```