### PR TITLE
implement solve with mixed StaticArray/DynamicArray types

### DIFF
--- a/src/SDiagonal.jl
+++ b/src/SDiagonal.jl
@@ -28,6 +28,8 @@ size(::Type{<:SDiagonal{N}}, d::Int) where {N} = d > 2 ? 1 : N
 \(Da::SDiagonal, Db::SDiagonal) = SDiagonal(Db.diag ./ Da.diag)
 /(Da::SDiagonal, Db::SDiagonal) = SDiagonal(Da.diag ./ Db.diag )
 
+\(D::Diagonal, B::StaticMatrix) = ldiv!(D, Matrix(B))
+
 # override to avoid copying
 diag(D::SDiagonal) = D.diag
 

--- a/src/lu.jl
+++ b/src/lu.jl
@@ -138,3 +138,6 @@ end
 
 # Base.lufact() interface is fairly inherently type unstable.  Punt on
 # implementing that, for now...
+
+\(F::LU, v::AbstractVector) = F.U \ (F.L \ v[F.p])
+\(F::LU, B::AbstractMatrix) = F.U \ (F.L \ B[F.p,:])


### PR DESCRIPTION
Because of [this depot function](https://github.com/JuliaLang/julia/blob/eddcbd7585152c1e404ed0481ffe44c61d504e77/stdlib/LinearAlgebra/src/generic.jl#L891-L908) we need to handle a variety of different cases for `\`.

This doesn't work yet for a nominally-unrelated indexing reason: the `B[F.p, :]` fails. Out of time for tonight.