### PR TITLE
Clean up indexing and dispatch

### DIFF
--- a/src/MMatrix.jl
+++ b/src/MMatrix.jl
@@ -57,7 +57,7 @@ end
     end
 end
 
-@inline convert(::Type{MMatrix{S1,S2}}, a::StaticArray{<:Any, T}) where {S1,S2,T} = MMatrix{S1,S2,T}(Tuple(a))
+@inline convert(::Type{MMatrix{S1,S2}}, a::StaticArray{<:Tuple, T}) where {S1,S2,T} = MMatrix{S1,S2,T}(Tuple(a))
 @inline MMatrix(a::StaticMatrix) = MMatrix{size(typeof(a),1),size(typeof(a),2)}(Tuple(a))
 
 # Simplified show for the type

--- a/src/SMatrix.jl
+++ b/src/SMatrix.jl
@@ -52,7 +52,7 @@ end
     end
 end
 
-@inline convert(::Type{SMatrix{S1,S2}}, a::StaticArray{<:Any, T}) where {S1,S2,T} = SMatrix{S1,S2,T}(Tuple(a))
+@inline convert(::Type{SMatrix{S1,S2}}, a::StaticArray{<:Tuple, T}) where {S1,S2,T} = SMatrix{S1,S2,T}(Tuple(a))
 @inline SMatrix(a::StaticMatrix) = SMatrix{size(typeof(a),1),size(typeof(a),2)}(Tuple(a))
 
 # Simplified show for the type

--- a/src/StaticArrays.jl
+++ b/src/StaticArrays.jl
@@ -91,7 +91,7 @@ const StaticMatrixLike{T} = Union{
     Diagonal{T, <:StaticVector{<:Any, T}}
 }
 const StaticVecOrMatLike{T} = Union{StaticVector{<:Any, T}, StaticMatrixLike{T}}
-const StaticArrayLike{T} = Union{StaticVecOrMatLike{T}, StaticArray{<:Any, T}}
+const StaticArrayLike{T} = Union{StaticVecOrMatLike{T}, StaticArray{<:Tuple, T}}
 
 const AbstractScalar{T} = AbstractArray{T, 0} # not exported, but useful none-the-less
 const StaticArrayNoEltype{S, N, T} = StaticArray{S, T, N}

--- a/src/arraymath.jl
+++ b/src/arraymath.jl
@@ -119,9 +119,7 @@ end
     end
 end
 
-# ambiguity with AbstractRNG and non-Float64... possibly an optimized form in Base?
-@inline rand!(rng::MersenneTwister, a::SA) where {SA <: StaticArray{<:Any, Float64}} = _rand!(rng, Size(SA), a)
-@inline rand!(rng::MersenneTwister, a::SA) where {SA <: StaticArray{<:Tuple, Float64, <:Any}} = _rand!(rng, Size(SA), a)
+@inline rand!(rng::MersenneTwister, a::SA) where {SA <: StaticArray{<:Tuple, Float64}} = _rand!(rng, Size(SA), a)
 
 @inline randn!(rng::AbstractRNG, a::SA) where {SA <: StaticArray} = _randn!(rng, Size(SA), a)
 @generated function _randn!(rng::AbstractRNG, ::Size{s}, a::SA) where {s, SA <: StaticArray}

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -10,9 +10,9 @@ using Base.Broadcast: _bcsm
 # A constructor that changes the style parameter N (array dimension) is also required
 struct StaticArrayStyle{N} <: AbstractArrayStyle{N} end
 StaticArrayStyle{M}(::Val{N}) where {M,N} = StaticArrayStyle{N}()
-BroadcastStyle(::Type{<:StaticArray{<:Any, <:Any, N}}) where {N} = StaticArrayStyle{N}()
-BroadcastStyle(::Type{<:Transpose{<:Any, <:StaticArray{<:Any, <:Any, N}}}) where {N} = StaticArrayStyle{N}()
-BroadcastStyle(::Type{<:Adjoint{<:Any, <:StaticArray{<:Any, <:Any, N}}}) where {N} = StaticArrayStyle{N}()
+BroadcastStyle(::Type{<:StaticArray{<:Tuple, <:Any, N}}) where {N} = StaticArrayStyle{N}()
+BroadcastStyle(::Type{<:Transpose{<:Any, <:StaticArray{<:Tuple, <:Any, N}}}) where {N} = StaticArrayStyle{N}()
+BroadcastStyle(::Type{<:Adjoint{<:Any, <:StaticArray{<:Tuple, <:Any, N}}}) where {N} = StaticArrayStyle{N}()
 # Precedence rules
 BroadcastStyle(::StaticArrayStyle{M}, ::DefaultArrayStyle{N}) where {M,N} =
     DefaultArrayStyle(Val(max(M, N)))

--- a/src/deque.jl
+++ b/src/deque.jl
@@ -76,7 +76,7 @@ end
 # could also be justified to live in src/indexing.jl
 import Base.setindex
 @propagate_inbounds setindex(a::StaticArray, x, index::Int) = _setindex(Length(a), a, convert(eltype(typeof(a)), x), index)
-@generated function _setindex(::Length{L}, a::StaticArray{<:Any,T}, x::T, index::Int) where {L, T}
+@generated function _setindex(::Length{L}, a::StaticArray{<:Tuple,T}, x::T, index::Int) where {L, T}
     exprs = [:(ifelse($i == index, x, a[$i])) for i = 1:L]
     return quote
         @_propagate_inbounds_meta

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -8,8 +8,8 @@ setindex!(a::StaticArray, value, i::Int) = error("setindex!(::$(typeof(a)), valu
 
 # Note: all indexing behavior defaults to dense, linear indexing
 
-@propagate_inbounds function getindex(a::StaticArray, inds::Int...)
-    @boundscheck checkbounds(a, inds...) 
+@propagate_inbounds function getindex(a::StaticArray{<:Tuple,<:Any,N}, inds::Vararg{Int,N}) where N
+    @boundscheck checkbounds(a, inds...)
     _getindex_scalar(Size(a), a, inds...)
 end
 
@@ -30,8 +30,8 @@ end
     end
 end
 
-@propagate_inbounds function setindex!(a::StaticArray, value, inds::Int...)
-    @boundscheck checkbounds(a, inds...) 
+@propagate_inbounds function setindex!(a::StaticArray{<:Tuple,<:Any,N}, value, inds::Vararg{Int,N}) where N
+    @boundscheck checkbounds(a, inds...)
     _setindex!_scalar(Size(a), a, value, inds...)
 end
 
@@ -182,46 +182,32 @@ end
 ## Multidimensional non-scalar indexing  ##
 ###########################################
 
+# To intercept `A[i1, ...]` where all `i` indexes have static sizes,
+# create a wrapper used to mark non-scalar indexing operations.
+# We insert this at a point in the dispatch hierarchy where we can intercept any
+# `typeof(A)` (specifically, including dynamic arrays) without triggering ambiguities.
+
+struct StaticIndexing{I}
+    ind::I
+end
+unwrap(i::StaticIndexing) = i.ind
+
+function Base.to_indices(A, I::Tuple{Vararg{Union{Integer, CartesianIndex, StaticArray{<:Tuple,Int}}}})
+    inds = to_indices(A, axes(A), I)
+    return map(StaticIndexing, inds)
+end
+
 # getindex
 
 @propagate_inbounds function getindex(a::StaticArray, inds::Union{Int, StaticArray{<:Any, Int}, Colon}...)
     _getindex(a, index_sizes(Size(a), inds...), inds)
 end
 
-# Hard to describe "Union{Int, StaticArray{<:Any, Int}} with at least one StaticArray{<:Any, Int}"
-# Here we require the first StaticArray{<:Any, Int} to be within the first four dimensions
-@propagate_inbounds function getindex(a::AbstractArray, i1::StaticArray{<:Any, Int}, inds::Union{Int, StaticArray{<:Any, Int}}...)
-    _getindex(a, index_sizes(i1, inds...), (i1, inds...))
+function Base._getindex(::IndexStyle, A::AbstractArray, i1::StaticIndexing, I::StaticIndexing...)
+    inds = (unwrap(i1), map(unwrap, I)...)
+    return StaticArrays._getindex(A, index_sizes(inds...), inds)
 end
 
-@propagate_inbounds function getindex(a::AbstractArray, i1::Int, i2::StaticArray{<:Any, Int}, inds::Union{Int, StaticArray{<:Any, Int}}...)
-    _getindex(a, index_sizes(i1, i2, inds...), (i1, i2, inds...))
-end
-
-@propagate_inbounds function getindex(a::AbstractArray, i1::Int, i2::Int, i3::StaticArray{<:Any, Int}, inds::Union{Int, StaticArray{<:Any, Int}}...)
-    _getindex(a, index_sizes(i1, i2, i3, inds...), (i1, i2, i3, inds...))
-end
-
-@propagate_inbounds function getindex(a::AbstractArray, i1::Int, i2::Int, i3::Int, i4::StaticArray{<:Any, Int}, inds::Union{Int, StaticArray{<:Any, Int}}...)
-    _getindex(a, index_sizes(i1, i2, i3, i4, inds...), (i1, i2, i3, i4, inds...))
-end
-
-# Disambuguity methods for the above
-@propagate_inbounds function getindex(a::StaticArray, i1::StaticArray{<:Any, Int}, inds::Union{Int, StaticArray{<:Any, Int}}...)
-    _getindex(a, index_sizes(i1, inds...), (i1, inds...))
-end
-
-@propagate_inbounds function getindex(a::StaticArray, i1::Int, i2::StaticArray{<:Any, Int}, inds::Union{Int, StaticArray{<:Any, Int}}...)
-    _getindex(a, index_sizes(i1, i2, inds...), (i1, i2, inds...))
-end
-
-@propagate_inbounds function getindex(a::StaticArray, i1::Int, i2::Int, i3::StaticArray{<:Any, Int}, inds::Union{Int, StaticArray{<:Any, Int}}...)
-    _getindex(a, index_sizes(i1, i2, i3, inds...), (i1, i2, i3, inds...))
-end
-
-@propagate_inbounds function getindex(a::StaticArray, i1::Int, i2::Int, i3::Int, i4::StaticArray{<:Any, Int}, inds::Union{Int, StaticArray{<:Any, Int}}...)
-    _getindex(a, index_sizes(i1, i2, i3, i4, inds...), (i1, i2, i3, i4, inds...))
-end
 
 @generated function _getindex(a::AbstractArray, ind_sizes::Tuple{Vararg{Size}}, inds)
     newsize = out_index_size(ind_sizes.parameters...)
@@ -265,64 +251,9 @@ end
     _setindex!(a, value, index_sizes(Size(a), inds...), inds)
 end
 
-# Hard to describe "Union{Int, StaticArray{<:Any, Int}} with at least one StaticArray{<:Any, Int}"
-# Here we require the first StaticArray{<:Any, Int} to be within the first four dimensions
-@propagate_inbounds function setindex!(a::AbstractArray, value, i1::StaticArray{<:Any, Int}, inds::Union{Int, StaticArray{<:Any, Int}}...)
-    _setindex!(a, value, index_sizes(i1, inds...), (i1, inds...))
-end
-
-@propagate_inbounds function setindex!(a::AbstractArray, value, i1::Int, i2::StaticArray{<:Any, Int}, inds::Union{Int, StaticArray{<:Any, Int}}...)
-    _setindex!(a, value, index_sizes(i1, i2, inds...), (i1, i2, inds...))
-end
-
-@propagate_inbounds function setindex!(a::AbstractArray, value, i1::Int, i2::Int, i3::StaticArray{<:Any, Int}, inds::Union{Int, StaticArray{<:Any, Int}}...)
-    _setindex!(a, value, index_sizes(i1, i2, i3, inds...), (i1, i2, i3, inds...))
-end
-
-@propagate_inbounds function setindex!(a::AbstractArray, value, i1::Int, i2::Int, i3::Int, i4::StaticArray{<:Any, Int}, inds::Union{Int, StaticArray{<:Any, Int}}...)
-    _setindex!(a, value, index_sizes(i1, i2, i3, i4, inds...), (i1, i2, i3, i4, inds...))
-end
-
-# Disambiguity methods for the above
-@propagate_inbounds function setindex!(a::StaticArray, value, i1::StaticArray{<:Any, Int}, inds::Union{Int, StaticArray{<:Any, Int}}...)
-    _setindex!(a, value, index_sizes(i1, inds...), (i1, inds...))
-end
-
-@propagate_inbounds function setindex!(a::StaticArray, value, i1::Int, i2::StaticArray{<:Any, Int}, inds::Union{Int, StaticArray{<:Any, Int}}...)
-    _setindex!(a, value, index_sizes(i1, i2, inds...), (i1, i2, inds...))
-end
-
-@propagate_inbounds function setindex!(a::StaticArray, value, i1::Int, i2::Int, i3::StaticArray{<:Any, Int}, inds::Union{Int, StaticArray{<:Any, Int}}...)
-    _setindex!(a, value, index_sizes(i1, i2, i3, inds...), (i1, i2, i3, inds...))
-end
-
-@propagate_inbounds function setindex!(a::StaticArray, value, i1::Int, i2::Int, i3::Int, i4::StaticArray{<:Any, Int}, inds::Union{Int, StaticArray{<:Any, Int}}...)
-    _setindex!(a, value, index_sizes(i1, i2, i3, i4, inds...), (i1, i2, i3, i4, inds...))
-end
-
-# disambiguities from Base
-@propagate_inbounds function setindex!(a::Array, value, i1::StaticVector{<:Any, Int})
-    _setindex!(a, value, index_sizes(i1), (i1,))
-end
-
-@propagate_inbounds function setindex!(a::Array, value::AbstractArray, i1::StaticVector{<:Any, Int})
-    _setindex!(a, value, index_sizes(i1), (i1,))
-end
-
-@propagate_inbounds function setindex!(a::Array, value::AbstractArray, i1::StaticArray{<:Any, Int}, inds::Union{Int, StaticArray{<:Any, Int}}...)
-    _setindex!(a, value, index_sizes(i1, inds...), (i1, inds...))
-end
-
-@propagate_inbounds function setindex!(a::Array, value::AbstractArray, i1::Int, i2::StaticArray{<:Any, Int}, inds::Union{Int, StaticArray{<:Any, Int}}...)
-    _setindex!(a, value, index_sizes(i1, i2, inds...), (i1, i2, inds...))
-end
-
-@propagate_inbounds function setindex!(a::Array, value::AbstractArray, i1::Int, i2::Int, i3::StaticArray{<:Any, Int}, inds::Union{Int, StaticArray{<:Any, Int}}...)
-    _setindex!(a, value, index_sizes(i1, i2, i3, inds...), (i1, i2, i3, inds...))
-end
-
-@propagate_inbounds function setindex!(a::Array, value::AbstractArray, i1::Int, i2::Int, i3::Int, i4::StaticArray{<:Any, Int}, inds::Union{Int, StaticArray{<:Any, Int}}...)
-    _setindex!(a, value, index_sizes(i1, i2, i3, i4, inds...), (i1, i2, i3, i4, inds...))
+function Base._setindex!(::IndexStyle, a::AbstractArray, value, i1::StaticIndexing, I::StaticIndexing...)
+    inds = (unwrap(i1), map(unwrap, I)...)
+    return StaticArrays._setindex!(a, value, index_sizes(inds...), inds)
 end
 
 # setindex! from a scalar

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -199,7 +199,7 @@ end
 
 # getindex
 
-@propagate_inbounds function getindex(a::StaticArray, inds::Union{Int, StaticArray{<:Any, Int}, Colon}...)
+@propagate_inbounds function getindex(a::StaticArray, inds::Union{Int, StaticArray{<:Tuple, Int}, Colon}...)
     _getindex(a, index_sizes(Size(a), inds...), inds)
 end
 
@@ -247,7 +247,7 @@ end
 
 # setindex!
 
-@propagate_inbounds function setindex!(a::StaticArray, value, inds::Union{Int, StaticArray{<:Any, Int}, Colon}...)
+@propagate_inbounds function setindex!(a::StaticArray, value, inds::Union{Int, StaticArray{<:Tuple, Int}, Colon}...)
     _setindex!(a, value, index_sizes(Size(a), inds...), inds)
 end
 

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -8,7 +8,7 @@ setindex!(a::StaticArray, value, i::Int) = error("setindex!(::$(typeof(a)), valu
 
 # Note: all indexing behavior defaults to dense, linear indexing
 
-@propagate_inbounds function getindex(a::StaticArray{<:Tuple,<:Any,N}, inds::Vararg{Int,N}) where N
+@propagate_inbounds function getindex(a::StaticArray, inds::Int...)
     @boundscheck checkbounds(a, inds...)
     _getindex_scalar(Size(a), a, inds...)
 end
@@ -30,7 +30,7 @@ end
     end
 end
 
-@propagate_inbounds function setindex!(a::StaticArray{<:Tuple,<:Any,N}, value, inds::Vararg{Int,N}) where N
+@propagate_inbounds function setindex!(a::StaticArray, value, inds::Int...)
     @boundscheck checkbounds(a, inds...)
     _setindex!_scalar(Size(a), a, value, inds...)
 end

--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -176,23 +176,23 @@ end
 # with an initial value v0 = true and false.
 #
 # TODO: change to use Base.reduce_empty/Base.reduce_first
-@inline iszero(a::StaticArray{<:Any,T}) where {T} = reduce((x,y) -> x && iszero(y), a, init=true)
+@inline iszero(a::StaticArray{<:Tuple,T}) where {T} = reduce((x,y) -> x && iszero(y), a, init=true)
 
-@inline sum(a::StaticArray{<:Any,T}; dims=:) where {T} = reduce(+, a; dims=dims)
-@inline sum(f, a::StaticArray{<:Any,T}; dims=:) where {T} = mapreduce(f, +, a; dims=dims)
-@inline sum(f::Union{Function, Type}, a::StaticArray{<:Any,T}; dims=:) where {T} = mapreduce(f, +, a; dims=dims) # avoid ambiguity
+@inline sum(a::StaticArray{<:Tuple,T}; dims=:) where {T} = reduce(+, a; dims=dims)
+@inline sum(f, a::StaticArray{<:Tuple,T}; dims=:) where {T} = mapreduce(f, +, a; dims=dims)
+@inline sum(f::Union{Function, Type}, a::StaticArray{<:Tuple,T}; dims=:) where {T} = mapreduce(f, +, a; dims=dims) # avoid ambiguity
 
-@inline prod(a::StaticArray{<:Any,T}; dims=:) where {T} = reduce(*, a; dims=dims)
-@inline prod(f, a::StaticArray{<:Any,T}; dims=:) where {T} = mapreduce(f, *, a; dims=dims)
-@inline prod(f::Union{Function, Type}, a::StaticArray{<:Any,T}; dims=:) where {T} = mapreduce(f, *, a; dims=dims)
+@inline prod(a::StaticArray{<:Tuple,T}; dims=:) where {T} = reduce(*, a; dims=dims)
+@inline prod(f, a::StaticArray{<:Tuple,T}; dims=:) where {T} = mapreduce(f, *, a; dims=dims)
+@inline prod(f::Union{Function, Type}, a::StaticArray{<:Tuple,T}; dims=:) where {T} = mapreduce(f, *, a; dims=dims)
 
-@inline count(a::StaticArray{<:Any,Bool}; dims=:) = reduce(+, a; dims=dims)
+@inline count(a::StaticArray{<:Tuple,Bool}; dims=:) = reduce(+, a; dims=dims)
 @inline count(f, a::StaticArray; dims=:) = mapreduce(x->f(x)::Bool, +, a; dims=dims)
 
-@inline all(a::StaticArray{<:Any,Bool}; dims=:) = reduce(&, a; dims=dims, init=true)  # non-branching versions
+@inline all(a::StaticArray{<:Tuple,Bool}; dims=:) = reduce(&, a; dims=dims, init=true)  # non-branching versions
 @inline all(f::Function, a::StaticArray; dims=:) = mapreduce(x->f(x)::Bool, &, a; dims=dims, init=true)
 
-@inline any(a::StaticArray{<:Any,Bool}; dims=:) = reduce(|, a; dims=dims, init=false) # (benchmarking needed)
+@inline any(a::StaticArray{<:Tuple,Bool}; dims=:) = reduce(|, a; dims=dims, init=false) # (benchmarking needed)
 @inline any(f::Function, a::StaticArray; dims=:) = mapreduce(x->f(x)::Bool, |, a; dims=dims, init=false) # (benchmarking needed)
 
 _mean_denom(a, dims::Colon) = length(a)

--- a/src/matrix_multiply.jl
+++ b/src/matrix_multiply.jl
@@ -193,7 +193,7 @@ end
     end
 end
 
-@generated function partly_unrolled_multiply(::Size{sa}, ::Size{sb}, a::StaticMatrix{<:Any, <:Any, Ta}, b::StaticArray{<:Any, Tb}) where {sa, sb, Ta, Tb}
+@generated function partly_unrolled_multiply(::Size{sa}, ::Size{sb}, a::StaticMatrix{<:Any, <:Any, Ta}, b::StaticArray{<:Tuple, Tb}) where {sa, sb, Ta, Tb}
     if sa[2] != sb[1]
         throw(DimensionMismatch("Tried to multiply arrays of size $sa and $sb"))
     end

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -193,7 +193,7 @@ end
     end
 end
 
-@generated function _A_mul_B(::Size{sa}, ::Size{sb}, A::StaticArray{<:Any,TA}, B::UpperTriangular{TB,<:StaticMatrix}) where {sa,sb,TA,TB}
+@generated function _A_mul_B(::Size{sa}, ::Size{sb}, A::StaticArray{<:Tuple,TA}, B::UpperTriangular{TB,<:StaticMatrix}) where {sa,sb,TA,TB}
     m = sa[1]
     if length(sa) == 1
         n = 1
@@ -225,7 +225,7 @@ end
     end
 end
 
-@generated function _A_mul_Bc(::Size{sa}, ::Size{sb}, A::StaticArray{<:Any,TA}, B::UpperTriangular{TB,<:StaticMatrix}) where {sa,sb,TA,TB}
+@generated function _A_mul_Bc(::Size{sa}, ::Size{sb}, A::StaticArray{<:Tuple,TA}, B::UpperTriangular{TB,<:StaticMatrix}) where {sa,sb,TA,TB}
     m = sa[1]
     if length(sa) == 1
         n = 1
@@ -284,7 +284,7 @@ end
     end
 end
 
-@generated function _A_mul_B(::Size{sa}, ::Size{sb}, A::StaticArray{<:Any,TA}, B::LowerTriangular{TB,<:StaticMatrix}) where {sa,sb,TA,TB}
+@generated function _A_mul_B(::Size{sa}, ::Size{sb}, A::StaticArray{<:Tuple,TA}, B::LowerTriangular{TB,<:StaticMatrix}) where {sa,sb,TA,TB}
     m = sa[1]
     if length(sa) == 1
         n = 1
@@ -316,7 +316,7 @@ end
     end
 end
 
-@generated function _A_mul_Bc(::Size{sa}, ::Size{sb}, A::StaticArray{<:Any,TA}, B::LowerTriangular{TB,<:StaticMatrix}) where {sa,sb,TA,TB}
+@generated function _A_mul_Bc(::Size{sa}, ::Size{sb}, A::StaticArray{<:Tuple,TA}, B::LowerTriangular{TB,<:StaticMatrix}) where {sa,sb,TA,TB}
     m = sa[1]
     if length(sa) == 1
         n = 1

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -73,6 +73,14 @@ using StaticArrays, Test
         @test @SVector([1,2,3,4])[@SMatrix([1 2; 3 4])] === @SMatrix([1 2; 3 4])
     end
 
+    @testset "2D getindex() on SVector" begin
+        v = @SVector [1,2]
+        @test v[1,1] == 1
+        @test v[2,1] == 2
+        @test_throws BoundsError v[1,2]
+        @test_throws BoundsError v[3,1]
+    end
+
     @testset "2D getindex() on SMatrix" begin
         sm = @SMatrix [1 3; 2 4]
 


### PR DESCRIPTION
Several aspects of indexing were not ideal:

- `getindex(a::StaticArray, inds::Int...)` violates the [AbstractArray interface](https://docs.julialang.org/en/latest/manual/interfaces/#man-interface-array-1)
- non-scalar static indexing of `AbstractArrays` only worked up to 4 dimensions
- there were a lot of `getindex` and `setindex!` ambiguities

The first commit here fixes all of these problems while also reducing `detect_ambiguities(Base, StaticArrays)` from 35 pairs to 9. Serious progress on #18 :fireworks: .

The second is boring but addresses https://github.com/JuliaLang/julia/issues/6383#issuecomment-448642771. A `sed` script to fix this is

```sh
sed -i "s/StaticArray{<:Any/StaticArray{<:Tuple/g" *.jl
```

if this ever creeps back in.