### PR TITLE
Fix mixed indexing like `a[v, :]` where `v::SVector` and `a` is dynamic

### DIFF
--- a/src/abstractarray.jl
+++ b/src/abstractarray.jl
@@ -126,6 +126,11 @@ similar(::Type{A}, shape::Tuple{SOneTo, Vararg{SOneTo}}) where {A<:AbstractArray
 similar(::A,::Type{T}, shape::Tuple{SOneTo, Vararg{SOneTo}}) where {A<:AbstractArray,T} = similar(A, T, Size(last.(shape)))
 similar(::Type{A},::Type{T}, shape::Tuple{SOneTo, Vararg{SOneTo}}) where {A<:AbstractArray,T} = similar(A, T, Size(last.(shape)))
 
+# When all sizes are SOneTo, preserve
+Base.to_shape(shp::Tuple{SOneTo, Vararg{SOneTo}}) = shp
+# If you have a mixture of SOneTo and other ranges, fall back to Base types
+Base.to_shape(s::SOneTo{n}) where n = n
+
 const SOneToLike{n} = Union{SOneTo{n}, Base.Slice{SOneTo{n}}}
 deslice(ax::SOneTo) = ax
 deslice(ax::Base.Slice) = ax.indices

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -69,6 +69,12 @@ using StaticArrays, Test
         @test (v[SVector(2,3)] = [22,23]; (v[2] == 22) & (v[3] == 23))
     end
 
+    @testset "Cartesian getindex() with an SVector on an Array" begin
+        a = rand(2, 2)
+        p = @SVector([1,2])
+        @test a[p, :] == a[:, p] == a[p, p] == a[Vector(p), p] == a[p, Vector(p)] == a
+    end
+
     @testset "Fancy APL indexing" begin
         @test @SVector([1,2,3,4])[@SMatrix([1 2; 3 4])] === @SMatrix([1 2; 3 4])
     end


### PR DESCRIPTION
Ref #570