### PR TITLE
Increase Performance of \ (and /) for small square matrix

### DIFF
--- a/src/solve.jl
+++ b/src/solve.jl
@@ -28,15 +28,15 @@ end
 
 for Sa in 2:3  # not needed for Sa = 1;
     @eval begin
-    @inline function solve(::Size{($Sa,$Sa)}, ::Size{Sb}, a::StaticMatrix{<:Any, <:Any, Ta}, b::StaticMatrix{<:Any, <:Any, Tb}) where {Sb, Ta, Tb}
-        d = det(a)
-        T = typeof((one(Ta)*zero(Tb) + one(Ta)*zero(Tb))/d)
-        c = similar(b, T)
-        for col = 1:Sb[2]
-            @inbounds c[:, col] = solve(Size($Sa,$Sa), Size($Sa,), a, b[:, col])
+        @inline function solve(::Size{($Sa,$Sa)}, ::Size{Sb}, a::StaticMatrix{<:Any, <:Any, Ta}, b::StaticMatrix{<:Any, <:Any, Tb}) where {Sb, Ta, Tb}
+            d = det(a)
+            T = typeof((one(Ta)*zero(Tb) + one(Ta)*zero(Tb))/d)
+            c = similar(b, T)
+            for col = 1:Sb[2]
+                @inbounds c[:, col] = solve(Size($Sa,$Sa), Size($Sa,), a, b[:, col])
+            end
+            return similar_type(b, T)(c)
         end
-        return similar_type(b, T)(c)
-    end
     end # @eval
 end
 

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -26,14 +26,14 @@ end
             (a[1,1]*a[2,2] - a[1,2]*a[2,1])*b[3]) / d )
 end
 
-for Sa in 2:3  # not needed for Sa = 1;
+for Sa in [(2,2), (3,3)]  # not needed for Sa = 1;
     @eval begin
-        @inline function solve(::Size{($Sa,$Sa)}, ::Size{Sb}, a::StaticMatrix{<:Any, <:Any, Ta}, b::StaticMatrix{<:Any, <:Any, Tb}) where {Sb, Ta, Tb}
+        @inline function solve(::Size{$Sa}, ::Size{Sb}, a::StaticMatrix{<:Any, <:Any, Ta}, b::StaticMatrix{<:Any, <:Any, Tb}) where {Sb, Ta, Tb}
             d = det(a)
             T = typeof((one(Ta)*zero(Tb) + one(Ta)*zero(Tb))/d)
             c = similar(b, T)
             for col = 1:Sb[2]
-                @inbounds c[:, col] = solve(Size($Sa,$Sa), Size($Sa,), a, b[:, col])
+                @inbounds c[:, col] = solve(Size($Sa), Size($Sa[1],), a, b[:, col])
             end
             return similar_type(b, T)(c)
         end

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -26,6 +26,22 @@ end
             (a[1,1]*a[2,2] - a[1,2]*a[2,1])*b[3]) / d )
 end
 
+for Dim in 2:3  # no improvements for Dim = 1 and if no specialized solve is available
+    @eval begin
+    @inline function solve(::Size{($Dim,$Dim)}, ::Size{Sb}, a::StaticMatrix{<:Any, <:Any, Ta}, b::StaticMatrix{<:Any, <:Any, Tb}) where {Sb, Ta, Tb}
+        d = det(a)
+        T = typeof((one(Ta)*zero(Tb) + one(Ta)*zero(Tb))/d)
+        c = similar(b, T)
+        for col = 1:Sb[2]
+            @inbounds c[:, col] = solve(Size($Dim,$Dim), Size($Dim,), a, b[:, col])
+        end
+        return c
+    end
+    end # @eval
+end
+
+
+
 @generated function solve(::Size{Sa}, ::Size{Sb}, a::StaticMatrix{<:Any, <:Any, Ta}, b::StaticVecOrMat{Tb}) where {Sa, Sb, Ta, Tb}
     if Sa[end] != Sb[1]
         throw(DimensionMismatch("right hand side B needs first dimension of size $(Sa[end]), has size $Sb"))

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -26,7 +26,7 @@ end
             (a[1,1]*a[2,2] - a[1,2]*a[2,1])*b[3]) / d )
 end
 
-for Sa in [(2,2), (3,3)]  # not needed for Sa = 1;
+for Sa in [(2,2), (3,3)]  # not needed for Sa = (1, 1);
     @eval begin
         @inline function solve(::Size{$Sa}, ::Size{Sb}, a::StaticMatrix{<:Any, <:Any, Ta}, b::StaticMatrix{<:Any, <:Any, Tb}) where {Sb, Ta, Tb}
             d = det(a)

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -26,16 +26,16 @@ end
             (a[1,1]*a[2,2] - a[1,2]*a[2,1])*b[3]) / d )
 end
 
-for Dim in 2:3  # no improvements for Dim = 1 and if no specialized solve is available
+for Sa in 2:3  # not needed for Sa = 1;
     @eval begin
-    @inline function solve(::Size{($Dim,$Dim)}, ::Size{Sb}, a::StaticMatrix{<:Any, <:Any, Ta}, b::StaticMatrix{<:Any, <:Any, Tb}) where {Sb, Ta, Tb}
+    @inline function solve(::Size{($Sa,$Sa)}, ::Size{Sb}, a::StaticMatrix{<:Any, <:Any, Ta}, b::StaticMatrix{<:Any, <:Any, Tb}) where {Sb, Ta, Tb}
         d = det(a)
         T = typeof((one(Ta)*zero(Tb) + one(Ta)*zero(Tb))/d)
         c = similar(b, T)
         for col = 1:Sb[2]
-            @inbounds c[:, col] = solve(Size($Dim,$Dim), Size($Dim,), a, b[:, col])
+            @inbounds c[:, col] = solve(Size($Sa,$Sa), Size($Sa,), a, b[:, col])
         end
-        return c
+        return similar_type(b, T)(c)
     end
     end # @eval
 end


### PR DESCRIPTION
Concerning [this issue](https://github.com/JuliaArrays/StaticArrays.jl/issues/582#issue-398546390).
My proposal for increased performance of A/B if A is 2x2 or 3x3 and B is 2or3xn.
There is an [ongoing discussion](https://discourse.julialang.org/t/performance-of-matrix-division/19477?u=judober) about this.