### PR TITLE
Allow using static arrays as index for views

### DIFF
--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -346,3 +346,11 @@ end
         end
     end
 end
+
+# checkindex
+
+Base.checkindex(B::Type{Bool}, inds::AbstractUnitRange, i::StaticIndexing{T}) where T = Base.checkindex(B, inds, unwrap(i))
+
+# unsafe_view
+
+Base.unsafe_view(A::AbstractArray, i::StaticIndexing{T}) where T = Base.unsafe_view(A, unwrap(i))

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -181,4 +181,10 @@ using StaticArrays, Test
         @test (zeros(0,2)[SVector{0,Int}(),SVector(1)] = 0) == 0
         @test (zeros(2,0)[SVector(1),SVector{0,Int}()] = 0) == 0
     end
+
+    @testset "Using SArray as index for view" begin
+        a = collect(11:20)
+        @test view(a, SVector(1,2,3)) == [11,12,13]
+        @test_throws BoundsError view(a, SVector(1,11,3))
+    end
 end


### PR DESCRIPTION
The PR allows using static arras as index when using views, such as

~~~~julia
a = [10,20,30,40]
idx = SVector(2,4)
b = view(a, idx)
~~~~