### PR TITLE
fix for zero-dimensional broadcast bug in generated function

### DIFF
--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -164,19 +164,23 @@ end
         exprs[current_ind...] = :(dest[$j] = f($(exprs_vals...)))
 
         # increment current_ind (maybe use CartesianIndices?)
-        current_ind[1] += 1
-        for i ∈ 1:length(newsize)
-            if current_ind[i] > newsize[i]
-                if i == length(newsize)
-                    more = false
-                    break
+	if length(current_ind) >= 1
+            current_ind[1] += 1
+            for i ∈ 1:length(newsize)
+                if current_ind[i] > newsize[i]
+                    if i == length(newsize)
+                        more = false
+                        break
+                    else
+                        current_ind[i] = 1
+                        current_ind[i+1] += 1
+                    end
                 else
-                    current_ind[i] = 1
-                    current_ind[i+1] += 1
+                    break
                 end
-            else
-                break
             end
+        else
+            break
         end
         j += 1
     end

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -35,6 +35,12 @@ end
         @test @inferred(v2 .* 1.0)::typeof(v) == v
     end
 
+    @testset "0-dimensional Array broadcast" begin
+        x = Array{Int, 0}(undef)
+        x .= Scalar(4)
+        @test x[] == 4
+    end
+
     @testset "2x2 StaticMatrix with StaticVector" begin
         m = @SMatrix [1 2; 3 4]
         v = SVector(1, 4)


### PR DESCRIPTION
The problem can be replicated on master with `Array{Int, 0}(undef) .= Scalar(42)`. The fix just adds a quick check for a zero-dimensional case.