### PR TITLE
Improve inferability of resursive `map` on nested `StaticArray`s

### DIFF
--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -22,6 +22,12 @@ end
     if i === nothing
         return :(throw(ArgumentError("No StaticArray found in argument list")))
     end
+    # Passing the Size as an argument to _map leads to inference issues when
+    # recursively mapping over nested StaticArrays (see issue #593). Calling
+    # Size in the generator here is valid because a[i] is known to be a
+    # StaticArray for which the default Size method is correct. If wrapped
+    # StaticArrays (with a custom Size method) are to be supported, this will
+    # no longer be valid.
     S = Size(a[i])
     exprs = Vector{Expr}(undef, prod(S))
     for i ∈ 1:prod(S)

--- a/test/mapreduce.jl
+++ b/test/mapreduce.jl
@@ -149,4 +149,11 @@ end
 
         @test ((@SVector Int64[]) + (@SVector Int64[])) == (@SVector Int64[])
     end
+    @testset "Nested SVectors" begin
+        # issue #593
+        v = SVector(SVector(3, 2), SVector(5, 7))
+        @test @inferred(v + v) == SVector(SVector(6, 4), SVector(10, 14))
+        v = SVector(SVector(3, 2, 1), SVector(5, 7, 9))
+        @test @inferred(v + v) == SVector(SVector(6, 4, 2), SVector(10, 14, 18))
+    end
 end


### PR DESCRIPTION
Fixes #593. Note that run-time behavior should be unaffected (in cases where inference is unaffected) as the `same_size` call is merely moved.