### PR TITLE
Reshape with tuple of SOneTo

### DIFF
--- a/src/abstractarray.jl
+++ b/src/abstractarray.jl
@@ -137,7 +137,7 @@ homogenize_shape(shape::Tuple{Vararg{HeterogeneousShape}}) = map(last, shape)
 
 @inline reshape(a::StaticArray, s::Size) = similar_type(a, s)(Tuple(a))
 @inline reshape(a::AbstractArray, s::Size) = _reshape(a, IndexStyle(a), s)
-@inline reshape(a::StaticArray, s::Tuple{Vararg{SOneTo}}) = reshape(a, homogenize_shape(s))
+@inline reshape(a::StaticArray, s::Tuple{SOneTo,Vararg{SOneTo}}) = reshape(a, homogenize_shape(s))
 @generated function _reshape(a::AbstractArray, indexstyle, s::Size{S}) where {S}
     if indexstyle == IndexLinear
         exprs = [:(a[$i]) for i = 1:prod(S)]

--- a/src/abstractarray.jl
+++ b/src/abstractarray.jl
@@ -137,6 +137,7 @@ homogenize_shape(shape::Tuple{Vararg{HeterogeneousShape}}) = map(last, shape)
 
 @inline reshape(a::StaticArray, s::Size) = similar_type(a, s)(Tuple(a))
 @inline reshape(a::AbstractArray, s::Size) = _reshape(a, IndexStyle(a), s)
+@inline reshape(a::StaticArray, s::Tuple{Vararg{SOneTo}}) = reshape(a, homogenize_shape(s))
 @generated function _reshape(a::AbstractArray, indexstyle, s::Size{S}) where {S}
     if indexstyle == IndexLinear
         exprs = [:(a[$i]) for i = 1:prod(S)]

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -92,6 +92,7 @@ using StaticArrays, Test, LinearAlgebra
 
 
     @testset "reshape" begin
+        @test @inferred(reshape(SVector(1,2,3,4), axes(SMatrix{2,2}(1,2,3,4)))) === SMatrix{2,2}(1,2,3,4)
         @test @inferred(reshape(SVector(1,2,3,4), Size(2,2))) === SMatrix{2,2}(1,2,3,4)
         @test @inferred(reshape([1,2,3,4], Size(2,2)))::SizedArray{Tuple{2,2},Int,2,1} == [1 3; 2 4]
 


### PR DESCRIPTION
This PR fixes
```julia
using StaticArrays

X = @SVector [1, 2.5, 3]
reshape(X, axes(X))
```
which fails currently and causes test failures in LabelledArrays (see https://travis-ci.com/JuliaDiffEq/LabelledArrays.jl/jobs/178867473).