### PR TITLE
Support for `svd(::StaticMatrix, full=true)`

### DIFF
--- a/src/svd.jl
+++ b/src/svd.jl
@@ -32,11 +32,26 @@ function svdvals(A::StaticMatrix)
     similar_type(A, T2, Size(diagsize(A)))(sv)
 end
 
-function svd(A::StaticMatrix)
-    # "Thin" SVD only for now.
-    f = svd(Matrix(A))
-    U = similar_type(A, eltype(f.U), Size(Size(A)[1], diagsize(A)))(f.U)
-    S = similar_type(A, eltype(f.S), Size(diagsize(A)))(f.S)
+function svd(A::StaticMatrix; full=Val(false))
+    _svd(A, full)
+end
+
+# Allow plain Bool in addition to Val
+_svd(A, full) = _svd(A, Val(convert(Bool, full)))
+
+function _svd(A, full::Val{false})
+    f = svd(Matrix(A), full=false)
+    U = similar_type(A,  eltype(f.U),  Size(Size(A)[1], diagsize(A)))(f.U)
+    S = similar_type(A,  eltype(f.S),  Size(diagsize(A)))(f.S)
     Vt = similar_type(A, eltype(f.Vt), Size(diagsize(A), Size(A)[2]))(f.Vt)
     SVD(U,S,Vt)
 end
+
+function _svd(A, full::Val{true})
+    f = svd(Matrix(A), full=true)
+    U = similar_type(A,  eltype(f.U),  Size(Size(A)[1], Size(A)[1]))(f.U)
+    S = similar_type(A,  eltype(f.S),  Size(diagsize(A)))(f.S)
+    Vt = similar_type(A, eltype(f.Vt), Size(Size(A)[2], Size(A)[2]))(f.Vt)
+    SVD(U,S,Vt)
+end
+

--- a/test/svd.jl
+++ b/test/svd.jl
@@ -33,6 +33,13 @@ using StaticArrays, Test, LinearAlgebra
         @testinf svd(m23').S  ≊ svd(Matrix(m23')).S
         @testinf svd(m23').Vt ≊ svd(Matrix(m23')).Vt
 
+        @testinf svd(m23, full=true).U::StaticMatrix  ≊ svd(Matrix(m23), full=true).U
+        @testinf svd(m23, full=true).S::StaticVector  ≊ svd(Matrix(m23), full=true).S
+        @testinf svd(m23, full=true).Vt::StaticMatrix ≊ svd(Matrix(m23), full=true).Vt
+        @testinf svd(m23', full=true).U::StaticMatrix  ≊ svd(Matrix(m23'), full=true).U
+        @testinf svd(m23', full=true).S::StaticVector  ≊ svd(Matrix(m23'), full=true).S
+        @testinf svd(m23', full=true).Vt::StaticMatrix ≊ svd(Matrix(m23'), full=true).Vt
+
         @testinf svd(transpose(m23)).U  ≊ svd(Matrix(transpose(m23))).U
         @testinf svd(transpose(m23)).S  ≊ svd(Matrix(transpose(m23))).S
         @testinf svd(transpose(m23)).Vt ≊ svd(Matrix(transpose(m23))).Vt


### PR DESCRIPTION
A small update to the `svd` wrapper so that `full=true` is supported. Code occasionally uses this, for example `nullspace`... in fact this is the only place `full=true` occurs in `LinearAlgebra`.

XRef: https://discourse.julialang.org/t/why-julia-and-linear-algebra-module-are-incredibly-slow-compare-to-c-and-eigen/21304/6