### PR TITLE
Adopt examples in README to current Julia version

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ julia 0.5 with default optimizations.
 ```julia
 Pkg.add("StaticArrays")  # or Pkg.clone("https://github.com/JuliaArrays/StaticArrays.jl")
 using StaticArrays
+using LinearAlgebra
 
 # Create an SVector using various forms, using constructors, functions or macros
 v1 = SVector(1, 2, 3)
@@ -81,7 +82,7 @@ size(typeof(v1)) == (3,)
 m1 = SMatrix{2,2}(1, 2, 3, 4) # flat, column-major storage, equal to m2:
 m2 = @SMatrix [ 1  3 ;
                 2  4 ]
-m3 = eye(SMatrix{3,3})
+m3 = SMatrix{3,3}(1I)
 m4 = @SMatrix randn(4,4)
 m5 = SMatrix{2,2}([1 3 ; 2 4]) # Array conversions must specify size
 
@@ -91,7 +92,7 @@ a = @SArray randn(2, 2, 2, 2, 2, 2)
 # Supports all the common operations of AbstractArray
 v7 = v1 + v2
 v8 = sin.(v3)
-v3 == m3 * v3 # recall that m3 = eye(SMatrix{3,3})
+v3 == m3 * v3 # recall that m3 = SMatrix{3,3}(1I)
 # map, reduce, broadcast, map!, broadcast!, etc...
 
 # Indexing can also be done using static arrays of integers
@@ -102,14 +103,14 @@ typeof(v1[[1,2,3]]) <: Vector # Can't determine size from the type of [1,2,3]
 
 # Is (partially) hooked into BLAS, LAPACK, etc:
 rand(MMatrix{20,20}) * rand(MMatrix{20,20}) # large matrices can use BLAS
-eig(m3) # eig(), etc uses specialized algorithms up to 3×3, or else LAPACK
+eigvecs(m3) # eigvecs(), etc uses specialized algorithms up to 3×3, or else LAPACK
 
 # Static arrays stay statically sized, even when used by Base functions, etc:
-typeof(eig(m3)) == Tuple{SVector{3,Float64}, SMatrix{3,3,Float64,9}}
+typeof(eigvecs(m3) == SArray{Tuple{3,3},Float64,2,9})
 
 # similar() returns a mutable container, while similar_type() returns a constructor:
-typeof(similar(m3)) == MMatrix{3,3,Float64,9} # (final parameter is length = 9)
-similar_type(m3) == SMatrix{3,3,Float64,9}
+typeof(similar(m3)) == MArray{Tuple{3,3},Int64,2,9} # (final parameter is length = 9)
+similar_type(m3) == SArray{Tuple{3,3},Int64,2,9}
 
 # The Size trait is a compile-time constant representing the size
 Size(m3) === Size(3,3)
@@ -121,7 +122,7 @@ inv(m4) # Take advantage of specialized fast methods
 # reshape() uses Size() or types to specify size:
 reshape([1,2,3,4], Size(2,2)) == @SMatrix [ 1  3 ;
                                             2  4 ]
-typeof(reshape([1,2,3,4], Size(2,2))) === SizedArray{(2, 2),Int64,2,1}
+typeof(reshape([1,2,3,4], Size(2,2))) === SizedArray{Tuple{2, 2},Int64,2,1}
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -103,10 +103,10 @@ typeof(v1[[1,2,3]]) <: Vector # Can't determine size from the type of [1,2,3]
 
 # Is (partially) hooked into BLAS, LAPACK, etc:
 rand(MMatrix{20,20}) * rand(MMatrix{20,20}) # large matrices can use BLAS
-eigvecs(m3) # eigvecs(), etc uses specialized algorithms up to 3×3, or else LAPACK
+eigen(m3) # eigen(), etc uses specialized algorithms up to 3×3, or else LAPACK
 
 # Static arrays stay statically sized, even when used by Base functions, etc:
-typeof(eigvecs(m3) == SArray{Tuple{3,3},Float64,2,9})
+typeof(eigen(m3)) == Eigen{Float64,Float64,SArray{Tuple{3,3},Float64,2,9},SArray{Tuple{3},Float64,1,3}}
 
 # similar() returns a mutable container, while similar_type() returns a constructor:
 typeof(similar(m3)) == MArray{Tuple{3,3},Int64,2,9} # (final parameter is length = 9)

--- a/docs/src/pages/quickstart.md
+++ b/docs/src/pages/quickstart.md
@@ -44,10 +44,10 @@ typeof(v1[[1,2,3]]) <: Vector # Can't determine size from the type of [1,2,3]
 
 # Is (partially) hooked into BLAS, LAPACK, etc:
 rand(MMatrix{20,20}) * rand(MMatrix{20,20}) # large matrices can use BLAS
-eigvecs(m3) # eigvecs(), etc uses specialized algorithms up to 3×3, or else LAPACK
+eigen(m3) # eigen(), etc uses specialized algorithms up to 3×3, or else LAPACK
 
 # Static arrays stay statically sized, even when used by Base functions, etc:
-typeof(eigvecs(m3) == SArray{Tuple{3,3},Float64,2,9})
+typeof(eigen(m3)) == Eigen{Float64,Float64,SArray{Tuple{3,3},Float64,2,9},SArray{Tuple{3},Float64,1,3}}
 
 # similar() returns a mutable container, while similar_type() returns a constructor:
 typeof(similar(m3)) == MArray{Tuple{3,3},Int64,2,9} # (final parameter is length = 9)

--- a/docs/src/pages/quickstart.md
+++ b/docs/src/pages/quickstart.md
@@ -3,6 +3,7 @@
 ```julia
 Pkg.add("StaticArrays")  # or Pkg.clone("https://github.com/JuliaArrays/StaticArrays.jl")
 using StaticArrays
+using LinearAlgebra
 
 # Create an SVector using various forms, using constructors, functions or macros
 v1 = SVector(1, 2, 3)
@@ -22,7 +23,7 @@ size(typeof(v1)) == (3,)
 m1 = SMatrix{2,2}(1, 2, 3, 4) # flat, column-major storage, equal to m2:
 m2 = @SMatrix [ 1  3 ;
                 2  4 ]
-m3 = eye(SMatrix{3,3})
+m3 = SMatrix{3,3}(1I)
 m4 = @SMatrix randn(4,4)
 m5 = SMatrix{2,2}([1 3 ; 2 4]) # Array conversions must specify size
 
@@ -43,14 +44,14 @@ typeof(v1[[1,2,3]]) <: Vector # Can't determine size from the type of [1,2,3]
 
 # Is (partially) hooked into BLAS, LAPACK, etc:
 rand(MMatrix{20,20}) * rand(MMatrix{20,20}) # large matrices can use BLAS
-eig(m3) # eig(), etc uses specialized algorithms up to 3×3, or else LAPACK
+eigvecs(m3) # eigvecs(), etc uses specialized algorithms up to 3×3, or else LAPACK
 
 # Static arrays stay statically sized, even when used by Base functions, etc:
-typeof(eig(m3)) == Tuple{SVector{3,Float64}, SMatrix{3,3,Float64,9}}
+typeof(eigvecs(m3) == SArray{Tuple{3,3},Float64,2,9})
 
 # similar() returns a mutable container, while similar_type() returns a constructor:
-typeof(similar(m3)) == MMatrix{3,3,Float64,9} # (final parameter is length = 9)
-similar_type(m3) == SMatrix{3,3,Float64,9}
+typeof(similar(m3)) == MArray{Tuple{3,3},Int64,2,9} # (final parameter is length = 9)
+similar_type(m3) == SArray{Tuple{3,3},Int64,2,9}
 
 # The Size trait is a compile-time constant representing the size
 Size(m3) === Size(3,3)
@@ -62,6 +63,6 @@ inv(m4) # Take advantage of specialized fast methods
 # reshape() uses Size() or types to specify size:
 reshape([1,2,3,4], Size(2,2)) == @SMatrix [ 1  3 ;
                                             2  4 ]
-typeof(reshape([1,2,3,4], Size(2,2))) === SizedArray{(2, 2),Int64,2,1}
+typeof(reshape([1,2,3,4], Size(2,2))) === SizedArray{Tuple{2, 2},Int64,2,1}
 
 ```


### PR DESCRIPTION
I have noticed, that some of the code examples in the `Quick start` section of the README don't work because they were designed for an older version of Julia. This PR modifies these examples to make them work with Julia v1.1.1.