### PR TITLE
Change SOneTo indexing and support \ for svd(M; full=true)

### DIFF
--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -75,6 +75,7 @@ end
 @inline index_size(::Size, ::Int) = Size()
 @inline index_size(::Size, a::StaticArray) = Size(a)
 @inline index_size(s::Size, ::Colon) = s
+@inline index_size(s::Size, a::SOneTo{n}) where n = Size(n,)
 
 @inline index_sizes(::S, inds...) where {S<:Size} = map(index_size, unpack_size(S), inds)
 
@@ -93,6 +94,7 @@ linear_index_size(ind_sizes::Type{<:Size}...) = _linear_index_size((), ind_sizes
 _ind(i::Int, ::Int, ::Type{Int}) = :(inds[$i])
 _ind(i::Int, j::Int, ::Type{<:StaticArray}) = :(inds[$i][$j])
 _ind(i::Int, j::Int, ::Type{Colon}) = j
+_ind(i::Int, j::Int, ::Type{<:SOneTo}) = j
 
 ################################
 ## Non-scalar linear indexing ##
@@ -213,7 +215,7 @@ end
 
 # getindex
 
-@propagate_inbounds function getindex(a::StaticArray, inds::Union{Int, StaticArray{<:Tuple, Int}, Colon}...)
+@propagate_inbounds function getindex(a::StaticArray, inds::Union{Int, StaticArray{<:Tuple, Int}, SOneTo, Colon}...)
     _getindex(a, index_sizes(Size(a), inds...), inds)
 end
 

--- a/src/svd.jl
+++ b/src/svd.jl
@@ -58,5 +58,17 @@ end
 function \(F::SVD, B::StaticVecOrMat)
     sthresh = eps(F.S[1])
     Sinv = map(s->s < sthresh ? zero(1/sthresh) : 1/s, F.S)
-    return F.Vt' * (Diagonal(Sinv) * (F.U'*B))
+    return transposemult(F.Vt, diagmult(Sinv, transposemult(F.U, B)))
+end
+
+transposemult(U, B) = transposemult(Size(U), Size(B), U, B)
+function transposemult(sU, sB, U, B)
+    sU[1] == sB[1] && return U'*B
+    return U[SOneTo(sB[1]),:]'*B
+end
+diagmult(d, B) = diagmult(Size(d), Size(B), d, B)
+function diagmult(sd, sB, d, B)
+    sd[1] == sB[1] && return Diagonal(d)*B
+    ind = SOneTo(sd[1])
+    return isa(B, AbstractVector) ? Diagonal(d)*B[ind] : Diagonal(d)*B[ind,:]
 end

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -80,7 +80,7 @@ using StaticArrays, Test, LinearAlgebra
 
         @test m[:, 1:2] isa Matrix
         @test m[:, [true, false, false]] isa Matrix
-        @test m[:, SOneTo(2)] isa MMatrix{2, 2, Int}
+        @test m[:, SOneTo(2)] isa SMatrix{2, 2, Int}
         @test m[:, :] isa SMatrix{2, 3, Int}
         @test m[:, 1] isa SVector{2, Int}
         @test m[2, :] isa SVector{3, Int}

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -101,6 +101,10 @@ using StaticArrays, Test
         @test (@inferred getindex(sm, :, SVector(2,1))) === @SMatrix [3 1; 4 2]
         @test (@inferred getindex(sm, 1, :)) === @SVector [1,3]
         @test (@inferred getindex(sm, :, 1)) === @SVector [1,2]
+
+        # SOneTo
+        @testinf sm[SOneTo(1),:] === @SMatrix [1 3]
+        @testinf sm[:,SOneTo(1)] === @SMatrix [1;2]
     end
 
     @testset "2D getindex()/setindex! on MMatrix" begin

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -121,6 +121,10 @@ using StaticArrays, Test
         @test (mm = MMatrix{2,2,Int}(undef); mm[:,SVector(2,1)] = sm[:,SVector(2,1)]; (@inferred getindex(mm, :, SVector(2,1)))::MMatrix == @MMatrix [3 1; 4 2])
         @test (mm = MMatrix{2,2,Int}(undef); mm[1,:] = sm[1,:]; (@inferred getindex(mm, 1, :))::MVector == @MVector [1,3])
         @test (mm = MMatrix{2,2,Int}(undef); mm[:,1] = sm[:,1]; (@inferred getindex(mm, :, 1))::MVector == @MVector [1,2])
+
+        # SOneTo
+        @test (mm = MMatrix{2,2,Int}(undef); mm[SOneTo(1),:] = sm[SOneTo(1),:]; (@inferred getindex(mm, SOneTo(1), :))::MMatrix == @MMatrix [1 3])
+        @test (mm = MMatrix{2,2,Int}(undef); mm[:,SOneTo(1)] = sm[:,SOneTo(1)]; (@inferred getindex(mm, :, SOneTo(1)))::MMatrix == @MMatrix [1;2])
     end
 
     @testset "3D scalar indexing" begin

--- a/test/svd.jl
+++ b/test/svd.jl
@@ -4,10 +4,14 @@ using StaticArrays, Test, LinearAlgebra
     m3 = @SMatrix Float64[3 9 4; 6 6 2; 3 7 9]
     m3c = ComplexF64.(m3)
     m23 = @SMatrix Float64[3 9 4; 6 6 2]
-    m_sing = @SMatrix [2.0 3.0 5.0; 4.0 9.0 10.0; 1.0 1.0 1.0]
+    m_sing = @SMatrix [2.0 3.0 5.0; 4.0 6.0 10.0; 1.0 1.0 1.0]
+    m_sing2 = @SMatrix [1 1; 1 0; 0 1]
     v = @SVector [1, 2, 3]
+    v2 = @SVector [1, 2]
     mc_sing = @SMatrix [1.0+0.1im 0 0; 2.0+0.2im 0 0; 3.0 0.1im 0]
+    mc_sing2 = @SMatrix [1.0+0.1im 0; 2.0+0.2im 1; 3.0 0.1im]
     vc = @SVector [1.0f0+8.0f0im, 0.2f0im, 2.5f0]
+    vc2 = @SVector [1.0f0+8.0f0im, 0.2f0im]
 
     @testset "svd" begin
         @testinf svdvals(@SMatrix [2 0; 0 0])::StaticVector ≊ [2, 0]
@@ -58,11 +62,28 @@ using StaticArrays, Test, LinearAlgebra
 
         @testinf svd(m3) \ v ≈ svd(Matrix(m3)) \ Vector(v)
         @testinf svd(m_sing) \ v ≈ svd(Matrix(m_sing)) \ Vector(v)
+        @testinf svd(m_sing2) \ v ≈ svd(Matrix(m_sing2)) \ Vector(v)
+        @testinf svd(m_sing2') \ v2 ≈ svd(Matrix(m_sing2')) \ Vector(v2)
         @testinf svd(m3) \ m23' ≈ svd(Matrix(m3)) \ Matrix(m23')
         @testinf svd(m_sing) \ m23' ≈ svd(Matrix(m_sing)) \ Matrix(m23')
+        @testinf svd(m_sing2) \ m23' ≈ svd(Matrix(m_sing2)) \ Matrix(m23')
+        @testinf svd(m_sing2; full=Val(true)) \ v ≈ svd(Matrix(m_sing2); full=true) \ Vector(v)
+        @testinf svd(m_sing2'; full=Val(true)) \ v2 ≈ svd(Matrix(m_sing2'); full=true) \ Vector(v2)
+        @testinf svd(m_sing2; full=Val(true)) \ m23' ≈ svd(Matrix(m_sing2); full=true) \ Matrix(m23')
+        @testinf svd(m_sing2'; full=Val(true)) \ m23 ≈ svd(Matrix(m_sing2'); full=true) \ Matrix(m23)
 
         @testinf svd(mc_sing) \ v ≈ svd(Matrix(mc_sing)) \ Vector(v)
         @testinf svd(mc_sing) \ vc ≈ svd(Matrix(mc_sing)) \ Vector(vc)
         @testinf svd(mc_sing) \ m23' ≈ svd(Matrix(mc_sing)) \ Matrix(m23')
+        @testinf svd(mc_sing2) \ v ≈ svd(Matrix(mc_sing2)) \ Vector(v)
+        @testinf svd(mc_sing2) \ vc ≈ svd(Matrix(mc_sing2)) \ Vector(vc)
+        @testinf svd(mc_sing2') \ vc2 ≈ svd(Matrix(mc_sing2')) \ Vector(vc2)
+        @testinf svd(mc_sing2) \ m23' ≈ svd(Matrix(mc_sing2)) \ Matrix(m23')
+        @testinf svd(mc_sing2') \ m23 ≈ svd(Matrix(mc_sing2')) \ Matrix(m23)
+        @testinf svd(mc_sing2; full=Val(true)) \ v ≈ svd(Matrix(mc_sing2); full=true) \ Vector(v)
+        @testinf svd(mc_sing2; full=Val(true)) \ vc ≈ svd(Matrix(mc_sing2); full=true) \ Vector(vc)
+        @testinf svd(mc_sing2'; full=Val(true)) \ vc2 ≈ svd(Matrix(mc_sing2'); full=true) \ Vector(vc2)
+        @testinf svd(mc_sing2; full=Val(true)) \ m23' ≈ svd(Matrix(mc_sing2); full=true) \ Matrix(m23')
+        @testinf svd(mc_sing2'; full=Val(true)) \ m23 ≈ svd(Matrix(mc_sing2'); full=true) \ Matrix(m23)
     end
 end


### PR DESCRIPTION
#613 didn't have adequate test coverage for solving problems like `svd(A) \ v` when `A` is non-square. It worked for the "thin" decomposition, but `svd(A; full=Val(true)) \ v` failed.

While implementing this I noticed what appeared to be missing support for indexing StaticArrays with `SOneTo`. This led to a change in one test result (see bea22b412c1f1330823f060cebfdf7515ac48d2d), so this is worth thinking about carefully and is a breaking change.