### PR TITLE
Faster similar for SizedArray

### DIFF
--- a/src/SizedArray.jl
+++ b/src/SizedArray.jl
@@ -20,7 +20,7 @@ struct SizedArray{S <: Tuple, T, N, M} <: StaticArray{S, T, N}
     end
 
     function SizedArray{S, T, N, M}(::UndefInitializer) where {S, T, N, M}
-        new{S, T, N, M}(Array{T, M}(undef, S.parameters...))
+        new{S, T, N, M}(Array{T, M}(undef, size_to_tuple(S)...))
     end
 end
 

--- a/src/util.jl
+++ b/src/util.jl
@@ -43,7 +43,7 @@ end
 
 Converts a size given by `Tuple{N, M, ...}` into a tuple `(N, M, ...)`.
 """
-@generated function size_to_tuple(::Type{S}) where S<:Tuple
+@pure function size_to_tuple(::Type{S}) where S<:Tuple
     return tuple(S.parameters...)
 end
 

--- a/src/util.jl
+++ b/src/util.jl
@@ -38,6 +38,15 @@ end
 @pure tuple_minimum(T::Type{<:Tuple}) = length(T.parameters) == 0 ? 0 : minimum(tuple(T.parameters...))
 @pure tuple_minimum(T::Tuple) = minimum(T)
 
+"""
+    size_to_tuple(::Type{S}) where S<:Tuple
+
+Converts a size given by `Tuple{N, M, ...}` into a tuple `(N, M, ...)`.
+"""
+@generated function size_to_tuple(::Type{S}) where S<:Tuple
+    return tuple(S.parameters...)
+end
+
 # Something doesn't match up type wise
 function check_array_parameters(Size, T, N, L)
     (!isa(Size, DataType) || (Size.name !== Tuple.name)) && throw(ArgumentError("Static Array parameter Size must be a Tuple type, got $Size"))


### PR DESCRIPTION
This small change speeds up `similar` for `SizedArray`.

Before:
```julia
julia> using StaticArrays

julia> using BenchmarkTools

julia> a = SizedArray{Tuple{2,2}}([1.0 2.0; 3.0 4.0])
2×2 SizedArray{Tuple{2,2},Float64,2,2}:
 1.0  2.0
 3.0  4.0

julia> @benchmark similar($a)
BenchmarkTools.Trial: 
  memory estimate:  128 bytes
  allocs estimate:  2
  --------------
  minimum time:     177.235 ns (0.00% GC)
  median time:      179.944 ns (0.00% GC)
  mean time:        206.715 ns (8.87% GC)
  maximum time:     90.985 μs (99.74% GC)
  --------------
  samples:          10000
  evals/sample:     714
```

After:

```julia

julia> @benchmark similar($a)
BenchmarkTools.Trial: 
  memory estimate:  128 bytes
  allocs estimate:  2
  --------------
  minimum time:     40.421 ns (0.00% GC)
  median time:      45.254 ns (0.00% GC)
  mean time:        64.077 ns (24.18% GC)
  maximum time:     63.615 μs (99.86% GC)
  --------------
  samples:          10000
  evals/sample:     992
```

My `versioninfo`:
```
julia> versioninfo()
Julia Version 1.1.0
Commit 80516ca202 (2019-01-21 21:24 UTC)
Platform Info:
  OS: Linux (x86_64-pc-linux-gnu)
  CPU: Intel(R) Core(TM) i7-4800MQ CPU @ 2.70GHz
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-6.0.1 (ORCJIT, haswell)
```