### PR TITLE
Add docstrings for push, pop, pushfirst, popfirst, insert, deleteat

### DIFF
--- a/src/deque.jl
+++ b/src/deque.jl
@@ -1,3 +1,18 @@
+"""
+    push(vec::StaticVector, item)
+
+Return a new `StaticVector` with `item` inserted on the end of `vec`.
+
+# Examples
+```jldoctest
+julia> push(@SVector[1, 2, 3], 4)
+4-element SArray{Tuple{4},Int64,1,4} with indices SOneTo(4):
+ 1
+ 2
+ 3
+ 4
+```
+"""
 @inline push(vec::StaticVector, x) = _push(Size(vec), vec, x)
 @generated function _push(::Size{s}, vec::StaticVector, x) where {s}
     newlen = s[1] + 1
@@ -8,6 +23,22 @@
     end
 end
 
+"""
+    pushfirst(vec::StaticVector, item)
+
+Return a new `StaticVector` with `item` inserted at the beginning of `vec`.
+
+# Examples
+```jldoctest
+julia> pushfirst(@SVector[1, 2, 3, 4], 5)
+5-element SArray{Tuple{5},Int64,1,5} with indices SOneTo(5):
+ 5
+ 1
+ 2
+ 3
+ 4
+```
+"""
 @inline pushfirst(vec::StaticVector, x) = _pushfirst(Size(vec), vec, x)
 @generated function _pushfirst(::Size{s}, vec::StaticVector, x) where {s}
     newlen = s[1] + 1
@@ -18,6 +49,23 @@ end
     end
 end
 
+"""
+    insert(vec::StaticVector, index::Integer, item)
+
+Return a new vector with `item` inserted into `vec` at the given `index`.
+
+# Examples
+```jldoctest
+julia> insert(@SVector[6, 5, 4, 2, 1], 4, 3)
+6-element SArray{Tuple{6},Int64,1,6} with indices SOneTo(6):
+ 6
+ 5
+ 4
+ 3
+ 2
+ 1
+```
+"""
 @propagate_inbounds insert(vec::StaticVector, index, x) = _insert(Size(vec), vec, index, x)
 @generated function _insert(::Size{s}, vec::StaticVector, index, x) where {s}
     newlen = s[1] + 1
@@ -33,6 +81,19 @@ end
     end
 end
 
+"""
+    pop(vec::StaticVector)
+
+Return a new vector with the last item in `vec` removed.
+
+# Examples
+```jldoctest
+julia> pop(@SVector[1,2,3])
+2-element SArray{Tuple{2},Int64,1,2} with indices SOneTo(2):
+ 1
+ 2
+```
+"""
 @inline pop(vec::StaticVector) = _pop(Size(vec), vec)
 @generated function _pop(::Size{s}, vec::StaticVector) where {s}
     newlen = s[1] - 1
@@ -43,6 +104,19 @@ end
     end
 end
 
+"""
+    popfirst(vec::StaticVector)
+
+Return a new vector with the first item in `vec` removed.
+
+# Examples
+```jldoctest
+julia> popfirst(@SVector[1,2,3])
+2-element SArray{Tuple{2},Int64,1,2} with indices SOneTo(2):
+ 2
+ 3
+```
+"""
 @inline popfirst(vec::StaticVector) = _popfirst(Size(vec), vec)
 @generated function _popfirst(::Size{s}, vec::StaticVector) where {s}
     newlen = s[1] - 1
@@ -53,6 +127,22 @@ end
     end
 end
 
+"""
+    deleteat(vec::StaticVector, index::Integer)
+
+Return a new vector with the item at the given `index` removed.
+
+# Examples
+```jldoctest
+julia> deleteat(@SVector[6, 5, 4, 3, 2, 1], 2)
+5-element SArray{Tuple{5},Int64,1,5} with indices SOneTo(5):
+ 6
+ 4
+ 3
+ 2
+ 1
+```
+"""
 @propagate_inbounds deleteat(vec::StaticVector, index) = _deleteat(Size(vec), vec, index)
 @generated function _deleteat(::Size{s}, vec::StaticVector, index) where {s}
     newlen = s[1] - 1
@@ -73,6 +163,25 @@ end
 # Immutable version of setindex!(). Seems similar in nature to the above, but
 # could also be justified to live in src/indexing.jl
 import Base.setindex
+"""
+    setindex(vec::StaticArray, x, index::Int)
+
+Return a new array with the item at `index` replaced by `x`.
+
+# Examples
+```jldoctest
+julia> setindex(@SVector[1,2,3], 4, 2)
+3-element SArray{Tuple{3},Int64,1,3} with indices SOneTo(3):
+ 1
+ 4
+ 3
+
+julia> setindex(@SMatrix[2 4; 6 8], 1, 2)
+2×2 SArray{Tuple{2,2},Int64,2,4} with indices SOneTo(2)×SOneTo(2):
+ 2  4
+ 1  8
+```
+"""
 @propagate_inbounds setindex(a::StaticArray, x, index::Int) = _setindex(Length(a), a, convert(eltype(typeof(a)), x), index)
 @generated function _setindex(::Length{L}, a::StaticArray{<:Tuple,T}, x::T, index::Int) where {L, T}
     exprs = [:(ifelse($i == index, x, a[$i])) for i = 1:L]


### PR DESCRIPTION
Also tested the new docstrings locally

The main "critique" I could make is that putting `-> vec` may imply the original `vec` is returned rather than a modified one.  Suggestions welcome for making this more clear.