### PR TITLE
Simplify broadcast code generation

### DIFF
--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -9,6 +9,8 @@ Broadcast.broadcastable(x::ScalarTest) = Ref(x)
         @test x == @inferred(x .+ ScalarTest())
         @test x .+ 1 == @inferred(x .+ Ref(1))
     end
+
+    @test Scalar(3) == @inferred(Scalar(1) .+ 2)
 end
 
 @testset "Broadcast sizes" begin


### PR DESCRIPTION
This simplifies code according to a tip left in a comment, by using `CartesianIndices` instead of generating indices manually. This also fixes #642 by not trying to increment an empty index.

I broke a long line there according to personal taste, if that's okay.