### PR TITLE
Enable linear indexing with multidimensional index

### DIFF
--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -9,6 +9,9 @@ using StaticArrays, Test
 
         # Colon
         @test (@inferred getindex(sv,:)) === sv
+
+        # SArray
+        @test (@inferred getindex(sv, SMatrix{2,2}(1,4,2,3))) === SMatrix{2,2}(4,7,5,6)
     end
 
     @testset "Linear getindex() on SMatrix" begin
@@ -20,6 +23,9 @@ using StaticArrays, Test
 
         # Colon
         @test (@inferred getindex(sm,:)) === sv
+
+        # SArray
+        @test (@inferred getindex(sm, SMatrix{2,2}(1,4,2,3))) === SMatrix{2,2}(4,7,5,6)
     end
 
     @testset "Linear getindex()/setindex!() on MVector" begin
@@ -38,6 +44,9 @@ using StaticArrays, Test
 
         mv = MVector(0,0,0)
         @test (mv[SVector(1,3)] = SVector(4, 5); (@inferred mv == MVector(4,0,5)))
+
+        mv = MVector(0,0,0)
+        @test (mv[SMatrix{2,1}(1,3)] = SMatrix{2,1}(4, 5); (@inferred mv == MVector(4,0,5)))
 
         # Colon
         mv = MVector{4,Int}(undef)
@@ -61,6 +70,12 @@ using StaticArrays, Test
         # Colon
         mm = MMatrix{2,2,Int}(undef)
         @test (mm[:] = vec; (@inferred getindex(mm, :))::MVector{4,Int} == MVector((4,5,6,7)))
+
+        # SMatrix
+        mm = MMatrix{2,2,Int}(undef)
+        mi = MMatrix{2,2}(4,2,1,3)
+        data = @SMatrix [4 5; 6 7]
+        @test (mm[mi] = data; (@inferred getindex(mm, :))::MVector{4,Int} == MVector((5,6,7,4)))
     end
 
     @testset "Linear getindex()/setindex!() with a SVector on an Array" begin


### PR DESCRIPTION
This PR attempts to allow indexing operations of the form `indexee[indexer]` where both *indexer* and *indexee* may be multidimensional.

This was previously possible if *indexer* was one-dimensional (seems to have gone down the linear indexing branch of the code) or if *indexee* was one-dimensional, but *indexer* may be multidimensional (this goes to the multidimensional indexing path, and there's a test for it so this must have been intentional).

This sends all `getindex(::StaticArray, ::StaticArray)` down the linear indexing path (where they belong, IMO) by updating the methods of form `getindex(::StaticArray, ::StaticVector)` to accept arrays for the second argument. The other changes are natural consequences. Of course the same goes for setindex.

Note, I had to change the second argument from `StaticVector{<:Any, Int}` to `StaticArray{<:Tuple, Int}`, otherwise Julia resolved the ambiguity with the multidimensional branch the wrong way. That branch only works if the number of indices are equal to the number of dimensions in the indexee. That can wait for another day.