### PR TITLE
add `in` method

### DIFF
--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -203,6 +203,8 @@ end
 @inline any(a::StaticArray{<:Tuple,Bool}; dims=:) = reduce(|, a; dims=dims, init=false) # (benchmarking needed)
 @inline any(f::Function, a::StaticArray; dims=:) = mapreduce(x->f(x)::Bool, |, a; dims=dims, init=false) # (benchmarking needed)
 
+@inline Base.in(x, a::StaticArray) = mapreduce(==(x), |, a, init=false)
+
 _mean_denom(a, dims::Colon) = length(a)
 _mean_denom(a, dims::Int) = size(a, dims)
 _mean_denom(a, ::Val{D}) where {D} = size(a, D)

--- a/test/mapreduce.jl
+++ b/test/mapreduce.jl
@@ -83,6 +83,9 @@ using Statistics: mean
         @test any(sb, dims=Val(2)) === RSArray2(any(b, dims=2))
         @test any(x->x>0, sa, dims=Val(2)) === RSArray2(any(x->x>0, a, dims=2))
 
+        @test all(in(x, sa) for x in sa)
+        @test all(in(x, sa) === in(x, a) for x in randn(10))
+
         @test mean(sa) === mean(a)
         @test mean(abs2, sa) === mean(abs2, a)
         @test mean(sa, dims=Val(2)) === RSArray2(mean(a, dims=2))


### PR DESCRIPTION
This change makes `in` unroll the loop (compared to `Base.in`) and is
significantly faster.