### PR TITLE
Fix default error message for getindex(::StaticArray, ::Int)

### DIFF
--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -1,5 +1,5 @@
 # Default error messages to help users with new types and to avoid subsequent stack overflows
-getindex(a::StaticArray, i::Int) = error("getindex(::$typeof(a), ::Int) is not defined.")
+getindex(a::StaticArray, i::Int) = error("getindex(::$(typeof(a)), ::Int) is not defined.")
 setindex!(a::StaticArray, value, i::Int) = error("setindex!(::$(typeof(a)), value, ::Int) is not defined.")
 
 #######################################


### PR DESCRIPTION
It was somewhat confusing to be told that I need to implement `getindex(::typeof(a), ::Int)` :-)