### PR TITLE
Update traits.jl

### DIFF
--- a/src/traits.jl
+++ b/src/traits.jl
@@ -78,8 +78,9 @@ function missing_size_error(::Type{SA}) where SA
         example, you might try
 
             m = zeros(3,3)
-            SMatrix(m)      # this error
-            SMatrix{3,3}(m) # correct - size is inferrable
+            SMatrix(m)            # this error
+            SMatrix{3,3}(m)       # correct - size is inferrable
+            SArray{Tuple{3,3}}(m) # correct, note Tuple{3,3}
         """)
 end
 


### PR DESCRIPTION
Right now calls `SArray(rand(3,3,4))` produces this error. `SMatrix{3,3}` works but `SArray{3,3}` doesn't; this change makes the requirement of `SArray{Tuple{3,3}}` explicit. 

Maybe a better solution is to provide a convenience constructor for `SArray`, but that pull request takes more effort :)