### PR TITLE
SA type aliases for constructors with precise eltype

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,13 @@ Pkg.add("StaticArrays")  # or Pkg.clone("https://github.com/JuliaArrays/StaticAr
 using StaticArrays
 using LinearAlgebra
 
+# Use the convenience constructor type `SA` to create vectors and matrices
+SA[1, 2, 3]     isa SVector{3,Int}
+SA_F64[1, 2, 3] isa SVector{3,Float64}
+SA_F32[1, 2, 3] isa SVector{3,Float32}
+SA[1 2; 3 4]     isa SMatrix{2,2,Int}
+SA_F64[1 2; 3 4] isa SMatrix{2,2,Float64}
+
 # Create an SVector using various forms, using constructors, functions or macros
 v1 = SVector(1, 2, 3)
 v1.data === (1, 2, 3) # SVector uses a tuple for internal storage

--- a/docs/src/pages/quickstart.md
+++ b/docs/src/pages/quickstart.md
@@ -5,6 +5,13 @@ Pkg.add("StaticArrays")  # or Pkg.clone("https://github.com/JuliaArrays/StaticAr
 using StaticArrays
 using LinearAlgebra
 
+# Use the convenience constructor type `SA` to create vectors and matrices
+SA[1, 2, 3]     isa SVector{3,Int}
+SA_F64[1, 2, 3] isa SVector{3,Float64}
+SA_F32[1, 2, 3] isa SVector{3,Float32}
+SA[1 2; 3 4]     isa SMatrix{2,2,Int}
+SA_F64[1 2; 3 4] isa SMatrix{2,2,Float64}
+
 # Create an SVector using various forms, using constructors, functions or macros
 v1 = SVector(1, 2, 3)
 v1.data === (1, 2, 3) # SVector uses a tuple for internal storage

--- a/src/StaticArrays.jl
+++ b/src/StaticArrays.jl
@@ -36,7 +36,7 @@ export SHermitianCompact
 
 export Size, Length
 
-export SA
+export SA, SA_F32, SA_F64
 export @SVector, @SMatrix, @SArray
 export @MVector, @MMatrix, @MArray
 

--- a/src/initializers.jl
+++ b/src/initializers.jl
@@ -12,8 +12,16 @@ provided explicitly.
 * `SA[1 2; 3 4]` creates a 2×2 SMatrix of `Int`s.
 * `SA[1 2]` creates a 1×2 SMatrix of `Int`s.
 * `SA{Float32}[1, 2]` creates a length-2 `SVector` of `Float32` elements.
+
+A couple of helpful type aliases are also provided:
+
+* `SA_F64[1, 2]` creates a lenght-2 `SVector` of `Float64` elements
+* `SA_F32[1, 2]` creates a lenght-2 `SVector` of `Float32` elements
 """
 struct SA{T} ; end
+
+const SA_F32 = SA{Float32}
+const SA_F64 = SA{Float64}
 
 @inline similar_type(::Type{SA}, ::Size{S}) where {S} = SArray{Tuple{S...}}
 @inline similar_type(::Type{SA{T}}, ::Size{S}) where {T,S} = SArray{Tuple{S...}, T}

--- a/test/initializers.jl
+++ b/test/initializers.jl
@@ -1,3 +1,5 @@
+@testset "Initialization with SA" begin
+
 SA_test_ref(x)   = SA[1,x,x]
 SA_test_ref(x,T) = SA{T}[1,x,x]
 @test @inferred(SA_test_ref(2))   === SVector{3,Int}((1,2,2))
@@ -31,3 +33,7 @@ SA_test_hvcat(x,T) = SA{T}[1 x x;
                                                                                        4 5]
 @test_throws ArgumentError("SA[...] matrix rows of length (2, 3) are inconsistent") SA[1 2;
                                                                                        3 4 5]
+@test SA_F64[1, 2] === SVector{2,Float64}((1,2))
+@test SA_F32[1, 2] === SVector{2,Float32}((1,2))
+
+end


### PR DESCRIPTION
The discussion at #655 has stimulated what I feel is finally a reasonable solution to constructing small static arrays with precise eltype without too much typing:

```julia
SA_F64 = SA{Float64}
SA_F32 = SA{Float32}

v = SA_F64[1,2,3]  # A Float64 vector

v = SA_F32[1 2; 3 4]  # A 2x2 Float32 SMatrix
```

I don't love the underscore there, but `SAF64` looks very confusing.  Other than that, I think the naming here is consistent with the precedent set by `Base.ComplexF64`.

Better naming options welcome!

I believe this (along with #633) finally fixes #24 to the extent that we can have a solution to that.