### PR TITLE
Base.strides methods for statically sized arrays

### DIFF
--- a/src/abstractarray.jl
+++ b/src/abstractarray.jl
@@ -16,6 +16,9 @@ end
 Base.axes(rv::Adjoint{<:Any,<:StaticVector})   = (SOneTo(1), axes(rv.parent)...)
 Base.axes(rv::Transpose{<:Any,<:StaticVector}) = (SOneTo(1), axes(rv.parent)...)
 
+Base.strides(a::Union{SArray,MArray}) = Base.size_to_strides(1, size(a)...)
+Base.strides(a::SizedArray) = strides(a.data)
+
 function Base.summary(io::IO, a, inds::Tuple{SOneTo, Vararg{SOneTo}})
     print(io, Base.dims2string(length.(inds)), " ")
     Base.showarg(io, a, true)

--- a/src/abstractarray.jl
+++ b/src/abstractarray.jl
@@ -16,7 +16,8 @@ end
 Base.axes(rv::Adjoint{<:Any,<:StaticVector})   = (SOneTo(1), axes(rv.parent)...)
 Base.axes(rv::Transpose{<:Any,<:StaticVector}) = (SOneTo(1), axes(rv.parent)...)
 
-Base.strides(a::Union{SArray,MArray}) = Base.size_to_strides(1, size(a)...)
+# Base.strides is intentionally not defined for SArray, see PR #658 for discussion
+Base.strides(a::MArray) = Base.size_to_strides(1, size(a)...)
 Base.strides(a::SizedArray) = strides(a.data)
 
 function Base.summary(io::IO, a, inds::Tuple{SOneTo, Vararg{SOneTo}})

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -10,12 +10,10 @@ using StaticArrays, Test, LinearAlgebra
     end
 
     @testset "strides" begin
-        m1 = SArray{Tuple{3, 4, 5}}(rand(Int, 3, 4, 5))
-        m2 = MArray{Tuple{3, 4, 5}}(rand(Int, 3, 4, 5))
-        m3 = Size(3,4,5)(rand(Int, 3, 4, 5))
+        m1 = MArray{Tuple{3, 4, 5}}(rand(Int, 3, 4, 5))
+        m2 = Size(3,4,5)(rand(Int, 3, 4, 5))
         @test strides(m1) === (1, 3, 12)
         @test strides(m2) === (1, 3, 12)
-        @test strides(m3) === (1, 3, 12)
     end
 
     @testset "similar_type" begin

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -9,6 +9,15 @@ using StaticArrays, Test, LinearAlgebra
         @test Base.isassigned(m, 2, 2) == true
     end
 
+    @testset "strides" begin
+        m1 = SArray{Tuple{3, 4, 5}}(rand(Int, 3, 4, 5))
+        m2 = MArray{Tuple{3, 4, 5}}(rand(Int, 3, 4, 5))
+        m3 = Size(3,4,5)(rand(Int, 3, 4, 5))
+        @test strides(m1) === (1, 3, 12)
+        @test strides(m2) === (1, 3, 12)
+        @test strides(m3) === (1, 3, 12)
+    end
+
     @testset "similar_type" begin
         @test @inferred(similar_type(SVector{3,Int})) == SVector{3,Int}
         @test @inferred(similar_type(@SVector [1,2,3])) == SVector{3,Int}


### PR DESCRIPTION
I need these methods for `HybridArrays` (views use them) and I think they belong here.