### PR TITLE
Remove some spurious `where T` from SA constructors

### DIFF
--- a/src/initializers.jl
+++ b/src/initializers.jl
@@ -29,9 +29,9 @@ const SA_F64 = SA{Float64}
 Base.@pure _SA_type(sa::Type{SA}, len::Int) = SVector{len}
 Base.@pure _SA_type(sa::Type{SA{T}}, len::Int) where {T} = SVector{len,T}
 
-@inline Base.getindex(sa::Type{<:SA}, xs...) where T = similar_type(sa, Size(length(xs)))(xs)
-@inline Base.typed_vcat(sa::Type{<:SA}, xs::Number...) where T = similar_type(sa, Size(length(xs)))(xs)
-@inline Base.typed_hcat(sa::Type{<:SA}, xs::Number...) where T = similar_type(sa, Size(1,length(xs)))(xs)
+@inline Base.getindex(sa::Type{<:SA}, xs...) = similar_type(sa, Size(length(xs)))(xs)
+@inline Base.typed_vcat(sa::Type{<:SA}, xs::Number...) = similar_type(sa, Size(length(xs)))(xs)
+@inline Base.typed_hcat(sa::Type{<:SA}, xs::Number...) = similar_type(sa, Size(1,length(xs)))(xs)
 
 Base.@pure function _SA_hvcat_transposed_size(rows)
     M = rows[1]
@@ -43,7 +43,7 @@ Base.@pure function _SA_hvcat_transposed_size(rows)
     Size(M, length(rows))
 end
 
-@inline function Base.typed_hvcat(sa::Type{<:SA}, rows::Dims, xs::Number...) where T
+@inline function Base.typed_hvcat(sa::Type{<:SA}, rows::Dims, xs::Number...)
     msize = _SA_hvcat_transposed_size(rows)
     if msize === nothing
         throw(ArgumentError("SA[...] matrix rows of length $rows are inconsistent"))


### PR DESCRIPTION
Surprisingly enough these result in methods which can be called but which don't inline, leading to performance problems.

```julia
julia> g(x) = SA[1 2; 3 x]
```

Before:

```
julia> @code_llvm g(1)

;  @ REPL[2]:1 within `g'
define void @julia_g_16110({ [4 x i64] }* noalias nocapture sret, i64) {
top:
  %2 = alloca %jl_value_t addrspace(10)*, i32 7
  %gcframe = alloca %jl_value_t addrspace(10)*, i32 3
  %3 = bitcast %jl_value_t addrspace(10)** %gcframe to i8*
  call void @llvm.memset.p0i8.i32(i8* %3, i8 0, i32 24, i32 0, i1 false)
  %thread_ptr = call i8* asm "movq %fs:0, $0", "=r"()
  %ptls_i8 = getelementptr i8, i8* %thread_ptr, i64 -15560
  %ptls = bitcast i8* %ptls_i8 to %jl_value_t***
  %4 = getelementptr %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)** %gcframe, i32 0
  %5 = bitcast %jl_value_t addrspace(10)** %4 to i64*
  store i64 2, i64* %5
  %6 = getelementptr %jl_value_t**, %jl_value_t*** %ptls, i32 0
  %7 = getelementptr %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)** %gcframe, i32 1
  %8 = bitcast %jl_value_t addrspace(10)** %7 to %jl_value_t***
  %9 = load %jl_value_t**, %jl_value_t*** %6
  store %jl_value_t** %9, %jl_value_t*** %8
  %10 = bitcast %jl_value_t*** %6 to %jl_value_t addrspace(10)***
  store %jl_value_t addrspace(10)** %gcframe, %jl_value_t addrspace(10)*** %10
  %11 = call %jl_value_t addrspace(10)* @jl_box_int64(i64 signext %1)
  %12 = getelementptr %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)** %gcframe, i32 2
  store %jl_value_t addrspace(10)* %11, %jl_value_t addrspace(10)** %12
  %13 = getelementptr %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)** %2, i32 0
  store %jl_value_t addrspace(10)* addrspacecast (%jl_value_t* inttoptr (i64 140508241764800 to %jl_value_t*) to %jl_value_t addrspace(10)*), %jl_value_t addrspace(10)** %13
  %14 = getelementptr %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)** %2, i32 1
  store %jl_value_t addrspace(10)* addrspacecast (%jl_value_t* inttoptr (i64 140508121018480 to %jl_value_t*) to %jl_value_t addrspace(10)*), %jl_value_t addrspace(10)** %14

blah blah blah
```

After:

```
julia> @code_llvm g(1)

;  @ REPL[2]:1 within `g'
define void @julia_g_16075({ [4 x i64] }* noalias nocapture sret, i64) {
top:
  %2 = bitcast { [4 x i64] }* %0 to <2 x i64>*
  store <2 x i64> <i64 1, i64 3>, <2 x i64>* %2, align 8
  %.sroa.0.sroa.3.0..sroa.0.0..sroa_cast1.sroa_idx8 = getelementptr inbounds { [4 x i64] }, { [4 x i64] }* %0, i64 0, i32 0, i64 2
  store i64 2, i64* %.sroa.0.sroa.3.0..sroa.0.0..sroa_cast1.sroa_idx8, align 8
  %.sroa.0.sroa.4.0..sroa.0.0..sroa_cast1.sroa_idx9 = getelementptr inbounds { [4 x i64] }, { [4 x i64] }* %0, i64 0, i32 0, i64 3
  store i64 %1, i64* %.sroa.0.sroa.4.0..sroa.0.0..sroa_cast1.sroa_idx9, align 8
  ret void
}
```