### PR TITLE
Conversion of SizedArray to Array reshapes

### DIFF
--- a/src/SizedArray.jl
+++ b/src/SizedArray.jl
@@ -16,6 +16,14 @@ struct SizedArray{S <: Tuple, T, N, M} <: StaticArray{S, T, N}
         if length(a) != tuple_prod(S)
             error("Dimensions $(size(a)) don't match static size $S")
         end
+        if size(a) != size_to_tuple(S)
+            Base.depwarn("Construction of `SizedArray` with an `Array` of a different
+                size is deprecated. If you need this functionality report it at
+                https://github.com/JuliaArrays/StaticArrays.jl/pull/666 .
+                Calling `sa = reshape(a::Array, s::Size)` will actually reshape
+                array `a` in the future and converting `sa` back to `Array` will
+                return an `Array` of shape `s`.", :SizedArray)
+        end
         new{S,T,N,M}(a)
     end
 
@@ -53,13 +61,13 @@ end
 @inline convert(::Type{SA}, sa::SA) where {SA<:SizedArray} = sa
 
 # Back to Array (unfortunately need both convert and construct to overide other methods)
-@inline Array(sa::SizedArray{S}) where {S} = Array(reshape(sa.data, size_to_tuple(S)))
-@inline Array{T}(sa::SizedArray{S,T}) where {T,S} = Array(reshape(sa.data, size_to_tuple(S)))
-@inline Array{T,N}(sa::SizedArray{S,T,N}) where {T,S,N} = Array(reshape(sa.data, size_to_tuple(S)))
+@inline Array(sa::SizedArray{S}) where {S} = sa.data
+@inline Array{T}(sa::SizedArray{S,T}) where {T,S} = sa.data
+@inline Array{T,N}(sa::SizedArray{S,T,N}) where {T,S,N} = sa.data
 
-@inline convert(::Type{Array}, sa::SizedArray{S}) where {S} = convert(Array, reshape(sa.data, size_to_tuple(S)))
-@inline convert(::Type{Array{T}}, sa::SizedArray{S,T}) where {T,S} = convert(Array{T}, reshape(sa.data, size_to_tuple(S)))
-@inline convert(::Type{Array{T,N}}, sa::SizedArray{S,T,N}) where {T,S,N} = convert(Array{T,N}, reshape(sa.data, size_to_tuple(S)))
+@inline convert(::Type{Array}, sa::SizedArray{S}) where {S} = sa.data
+@inline convert(::Type{Array{T}}, sa::SizedArray{S,T}) where {T,S} = sa.data
+@inline convert(::Type{Array{T,N}}, sa::SizedArray{S,T,N}) where {T,S,N} = sa.data
 
 @propagate_inbounds getindex(a::SizedArray, i::Int) = getindex(a.data, i)
 @propagate_inbounds setindex!(a::SizedArray, v, i::Int) = setindex!(a.data, v, i)

--- a/src/SizedArray.jl
+++ b/src/SizedArray.jl
@@ -61,9 +61,9 @@ end
 @inline convert(::Type{SA}, sa::SA) where {SA<:SizedArray} = sa
 
 # Back to Array (unfortunately need both convert and construct to overide other methods)
-@inline Array(sa::SizedArray{S}) where {S} = sa.data
-@inline Array{T}(sa::SizedArray{S,T}) where {T,S} = sa.data
-@inline Array{T,N}(sa::SizedArray{S,T,N}) where {T,S,N} = sa.data
+@inline Array(sa::SizedArray) = Array(sa.data)
+@inline Array{T}(sa::SizedArray{S,T}) where {T,S} = Array{T}(sa.data)
+@inline Array{T,N}(sa::SizedArray{S,T,N}) where {T,S,N} = Array{T,N}(sa.data)
 
 @inline convert(::Type{Array}, sa::SizedArray{S}) where {S} = sa.data
 @inline convert(::Type{Array{T}}, sa::SizedArray{S,T}) where {T,S} = sa.data

--- a/src/SizedArray.jl
+++ b/src/SizedArray.jl
@@ -57,9 +57,9 @@ end
 @inline Array{T}(sa::SizedArray{S,T}) where {T,S} = Array(reshape(sa.data, size_to_tuple(S)))
 @inline Array{T,N}(sa::SizedArray{S,T,N}) where {T,S,N} = Array(reshape(sa.data, size_to_tuple(S)))
 
-@inline convert(::Type{Array}, sa::SizedArray{S}) where {S} = Array(reshape(sa.data, size_to_tuple(S)))
-@inline convert(::Type{Array{T}}, sa::SizedArray{S,T}) where {T,S} = Array(reshape(sa.data, size_to_tuple(S)))
-@inline convert(::Type{Array{T,N}}, sa::SizedArray{S,T,N}) where {T,S,N} = Array(reshape(sa.data, size_to_tuple(S)))
+@inline convert(::Type{Array}, sa::SizedArray{S}) where {S} = convert(Array, reshape(sa.data, size_to_tuple(S)))
+@inline convert(::Type{Array{T}}, sa::SizedArray{S,T}) where {T,S} = convert(Array{T}, reshape(sa.data, size_to_tuple(S)))
+@inline convert(::Type{Array{T,N}}, sa::SizedArray{S,T,N}) where {T,S,N} = convert(Array{T,N}, reshape(sa.data, size_to_tuple(S)))
 
 @propagate_inbounds getindex(a::SizedArray, i::Int) = getindex(a.data, i)
 @propagate_inbounds setindex!(a::SizedArray, v, i::Int) = setindex!(a.data, v, i)

--- a/src/SizedArray.jl
+++ b/src/SizedArray.jl
@@ -65,7 +65,7 @@ end
 @inline Array{T}(sa::SizedArray{S,T}) where {T,S} = Array{T}(sa.data)
 @inline Array{T,N}(sa::SizedArray{S,T,N}) where {T,S,N} = Array{T,N}(sa.data)
 
-@inline convert(::Type{Array}, sa::SizedArray{S}) where {S} = sa.data
+@inline convert(::Type{Array}, sa::SizedArray) = sa.data
 @inline convert(::Type{Array{T}}, sa::SizedArray{S,T}) where {T,S} = sa.data
 @inline convert(::Type{Array{T,N}}, sa::SizedArray{S,T,N}) where {T,S,N} = sa.data
 

--- a/src/SizedArray.jl
+++ b/src/SizedArray.jl
@@ -53,13 +53,13 @@ end
 @inline convert(::Type{SA}, sa::SA) where {SA<:SizedArray} = sa
 
 # Back to Array (unfortunately need both convert and construct to overide other methods)
-@inline Array(sa::SizedArray) = sa.data
-@inline Array{T}(sa::SizedArray{S,T}) where {T,S} = sa.data
-@inline Array{T,N}(sa::SizedArray{S,T,N}) where {T,S,N} = sa.data
+@inline Array(sa::SizedArray{S}) where {S} = Array(reshape(sa.data, size_to_tuple(S)))
+@inline Array{T}(sa::SizedArray{S,T}) where {T,S} = Array(reshape(sa.data, size_to_tuple(S)))
+@inline Array{T,N}(sa::SizedArray{S,T,N}) where {T,S,N} = Array(reshape(sa.data, size_to_tuple(S)))
 
-@inline convert(::Type{Array}, sa::SizedArray) = sa.data
-@inline convert(::Type{Array{T}}, sa::SizedArray{S,T}) where {T,S} = sa.data
-@inline convert(::Type{Array{T,N}}, sa::SizedArray{S,T,N}) where {T,S,N} = sa.data
+@inline convert(::Type{Array}, sa::SizedArray{S}) where {S} = Array(reshape(sa.data, size_to_tuple(S)))
+@inline convert(::Type{Array{T}}, sa::SizedArray{S,T}) where {T,S} = Array(reshape(sa.data, size_to_tuple(S)))
+@inline convert(::Type{Array{T,N}}, sa::SizedArray{S,T,N}) where {T,S,N} = Array(reshape(sa.data, size_to_tuple(S)))
 
 @propagate_inbounds getindex(a::SizedArray, i::Int) = getindex(a.data, i)
 @propagate_inbounds setindex!(a::SizedArray, v, i::Int) = setindex!(a.data, v, i)

--- a/test/SizedArray.jl
+++ b/test/SizedArray.jl
@@ -87,7 +87,7 @@
         @test_deprecated Array(SizedMatrix{2,2}([1,2,3,4])) == [1 3; 2 4]
         # Array(a::Array) makes a copy so this should work similarly
         a = [1 2; 3 4]
-        @test_broken Array(SizedMatrix{2,2}(a)) !== a
+        @test Array(SizedMatrix{2,2}(a)) !== a
         @test @inferred(convert(Array, SizedMatrix{2,2}(a))) === a
         @test @inferred(convert(Array{Int}, SizedMatrix{2,2}(a))) === a
         @test @inferred(convert(Matrix{Int}, SizedMatrix{2,2}(a))) === a

--- a/test/SizedArray.jl
+++ b/test/SizedArray.jl
@@ -84,7 +84,7 @@
         @test convert(Matrix, SMatrix{2,2}((1,2,3,4))) == [1 3; 2 4]
         @test convert(Array, SizedArray{Tuple{2,2,2,2}, Int}(ones(2,2,2,2))) == ones(2,2,2,2)
         # Conversion after reshaping
-        @test_broken Array(SizedMatrix{2,2}([1,2,3,4])) == [1 3; 2 4]
+        @test Array(SizedMatrix{2,2}([1,2,3,4])) == [1 3; 2 4]
     end
 
     @testset "promotion" begin

--- a/test/SizedArray.jl
+++ b/test/SizedArray.jl
@@ -85,6 +85,9 @@
         @test convert(Array, SizedArray{Tuple{2,2,2,2}, Int}(ones(2,2,2,2))) == ones(2,2,2,2)
         # Conversion after reshaping
         @test Array(SizedMatrix{2,2}([1,2,3,4])) == [1 3; 2 4]
+        # Array(a::Array) makes a copy so this should work similarly
+        a = [1 2; 3 4]
+        @test Array(SizedMatrix{2,2}(a)) !== a
     end
 
     @testset "promotion" begin

--- a/test/SizedArray.jl
+++ b/test/SizedArray.jl
@@ -2,7 +2,7 @@
     @testset "Inner Constructors" begin
         @test SizedArray{Tuple{2}, Int, 1}((3, 4)).data == [3, 4]
         @test SizedArray{Tuple{2}, Int, 1}([3, 4]).data == [3, 4]
-        @test SizedArray{Tuple{2, 2}, Int, 2}(collect(3:6)).data == collect(3:6)
+        @test_deprecated SizedArray{Tuple{2, 2}, Int, 2}(collect(3:6)).data == collect(3:6)
         @test size(SizedArray{Tuple{4, 5}, Int, 2}(undef).data) == (4, 5)
         @test size(SizedArray{Tuple{4, 5}, Int}(undef).data) == (4, 5)
 
@@ -25,7 +25,7 @@
         @test @inferred(SizedArray{Tuple{2}}([1,2]))::SizedArray{Tuple{2},Int,1,1} == [1,2]
         @test @inferred(SizedArray{Tuple{2,2}}([1 2;3 4]))::SizedArray{Tuple{2,2},Int,2,2} == [1 2; 3 4]
         # From Array, reshaped
-        @test @inferred(SizedArray{Tuple{2,2}}([1,2,3,4]))::SizedArray{Tuple{2,2},Int,2,1} == [1 3; 2 4]
+        @test_deprecated @inferred(SizedArray{Tuple{2,2}}([1,2,3,4]))::SizedArray{Tuple{2,2},Int,2,1} == [1 3; 2 4]
         # Uninitialized
         @test @inferred(SizedArray{Tuple{2,2},Int,2}(undef)) isa SizedArray{Tuple{2,2},Int,2,2}
         @test @inferred(SizedArray{Tuple{2,2},Int}(undef)) isa SizedArray{Tuple{2,2},Int,2,2}
@@ -41,14 +41,14 @@
         @test @inferred(SizedVector{2}([1,2]))::SizedArray{Tuple{2},Int,1,1} == [1,2]
         @test @inferred(SizedVector{2}((1,2)))::SizedArray{Tuple{2},Int,1,1} == [1,2]
         # Reshaping
-        @test @inferred(SizedVector{2}([1 2]))::SizedArray{Tuple{2},Int,1,2} == [1,2]
+        @test_deprecated @inferred(SizedVector{2}([1 2]))::SizedArray{Tuple{2},Int,1,2} == [1,2]
         # Back to Vector
         @test Vector(SizedVector{2}((1,2))) == [1,2]
         @test convert(Vector, SizedVector{2}((1,2))) == [1,2]
 
         @test @inferred(SizedMatrix{2,2}([1 2; 3 4]))::SizedArray{Tuple{2,2},Int,2,2} == [1 2; 3 4]
         # Reshaping
-        @test @inferred(SizedMatrix{2,2}([1,2,3,4]))::SizedArray{Tuple{2,2},Int,2,1} == [1 3; 2 4]
+        @test_deprecated @inferred(SizedMatrix{2,2}([1,2,3,4]))::SizedArray{Tuple{2,2},Int,2,1} == [1 3; 2 4]
         @test @inferred(SizedMatrix{2,2}((1,2,3,4)))::SizedArray{Tuple{2,2},Int,2,2} == [1 3; 2 4]
         # Back to Matrix
         @test Matrix(SizedMatrix{2,2}([1 2;3 4])) == [1 2; 3 4]
@@ -84,10 +84,10 @@
         @test convert(Matrix, SMatrix{2,2}((1,2,3,4))) == [1 3; 2 4]
         @test convert(Array, SizedArray{Tuple{2,2,2,2}, Int}(ones(2,2,2,2))) == ones(2,2,2,2)
         # Conversion after reshaping
-        @test Array(SizedMatrix{2,2}([1,2,3,4])) == [1 3; 2 4]
+        @test_deprecated Array(SizedMatrix{2,2}([1,2,3,4])) == [1 3; 2 4]
         # Array(a::Array) makes a copy so this should work similarly
         a = [1 2; 3 4]
-        @test Array(SizedMatrix{2,2}(a)) !== a
+        @test_broken Array(SizedMatrix{2,2}(a)) !== a
         @test @inferred(convert(Array, SizedMatrix{2,2}(a))) === a
         @test @inferred(convert(Array{Int}, SizedMatrix{2,2}(a))) === a
         @test @inferred(convert(Matrix{Int}, SizedMatrix{2,2}(a))) === a

--- a/test/SizedArray.jl
+++ b/test/SizedArray.jl
@@ -88,6 +88,10 @@
         # Array(a::Array) makes a copy so this should work similarly
         a = [1 2; 3 4]
         @test Array(SizedMatrix{2,2}(a)) !== a
+        @test @inferred(convert(Array, SizedMatrix{2,2}(a))) === a
+        @test @inferred(convert(Array{Int}, SizedMatrix{2,2}(a))) === a
+        @test @inferred(convert(Matrix{Int}, SizedMatrix{2,2}(a))) === a
+        @test @inferred(convert(Matrix{Float64}, SizedMatrix{2,2}(a))) == a
     end
 
     @testset "promotion" begin

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -101,7 +101,7 @@ using StaticArrays, Test, LinearAlgebra
     @testset "reshape" begin
         @test @inferred(reshape(SVector(1,2,3,4), axes(SMatrix{2,2}(1,2,3,4)))) === SMatrix{2,2}(1,2,3,4)
         @test @inferred(reshape(SVector(1,2,3,4), Size(2,2))) === SMatrix{2,2}(1,2,3,4)
-        @test @inferred(reshape([1,2,3,4], Size(2,2)))::SizedArray{Tuple{2,2},Int,2,1} == [1 3; 2 4]
+        @test_deprecated @inferred(reshape([1,2,3,4], Size(2,2)))::SizedArray{Tuple{2,2},Int,2,1} == [1 3; 2 4]
 
         @test @inferred(vec(SMatrix{2, 2}([1 2; 3 4])))::SVector{4,Int} == [1, 3, 2, 4]
 


### PR DESCRIPTION
I'm trying to port some improvements I've made in `HybridArrays` to `SizedArray` here. Full support for wrapping arbitrary `AbstractArray`s is a fairly large project and noticeable increase in complexity of `SizedArray` so I'm not sure if it's actually a good idea.

Anyway, here is a small change that:
1) makes sure that converting back to `Array` retains given static shape,
2) changes `Array(::SizedArray)` so that it makes a copy (since `Array(::Array)` also makes one).