### PR TITLE
RFC: Deprecate calling of Size to get SizedArray

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ similar_type(m3) == SArray{Tuple{3,3},Int64,2,9}
 Size(m3) === Size(3,3)
 
 # A standard Array can be wrapped into a SizedArray
-m4 = Size(3,3)(rand(3,3))
+m4 = SizedMatrix{3,3}(rand(3,3))
 inv(m4) # Take advantage of specialized fast methods
 
 # reshape() uses Size() or types to specify size:

--- a/docs/src/pages/api.md
+++ b/docs/src/pages/api.md
@@ -82,7 +82,7 @@ _det(::Size{(2,2)}, x::StaticMatrix) = x[1,1]*x[2,2] - x[1,2]*x[2,1]
 Examples of using `Size` as a compile-time constant include
 ```julia
 reshape(svector, Size(2,2))  # Convert SVector{4} to SMatrix{2,2}
-Size(3,3)(rand(3,3))         # Construct a random 3×3 SizedArray (see below)
+SizedMatrix{3,3}(rand(3,3))  # Construct a random 3×3 SizedArray (see below)
 ```
 
 ### Indexing
@@ -152,8 +152,9 @@ Another convenient mutable type is the `SizedArray`, which is just a wrapper-typ
 about a standard Julia `Array` which declares its knwon size. For example, if
 we knew that `a` was a 2×2 `Matrix`, then we can type `sa = SizedArray{Tuple{2,2}}(a)`
 to construct a new object which knows the type (the size will be verified
-automatically). A more convenient syntax for obtaining a `SizedArray` is by calling
-a `Size` object, e.g. `sa = Size(2,2)(a)`.
+automatically). For one and two dimensions, a more convenient syntax for
+obtaining a `SizedArray` is by using the `SizedMatrix` and `SizedVector`
+aliases, e.g. `sa = SizedMatrix{2,2}(a)`.
 
 Then, methods on `sa` will use the specialized code provided by the *StaticArrays*
 pacakge, which in many cases will be much, much faster. For example, calling
@@ -219,17 +220,15 @@ m = [1 2;
 
 sv = SVector{2}(v)
 sm = SMatrix{2,2}(m)
-sa = SArray{(2,2)}(m)
+sa = SArray{Tuple{2,2}}(m)
 
-sized_v = Size(2)(v)     # SizedArray{(2,)}(v)
-sized_m = Size(2,2)(m)   # SizedArray{(2,2)}(m)
+sized_v = SizedVector{2}(v)
+sized_m = SizedMatrix{2,2}(m)
 ```
 
 We have avoided adding `SVector(v::AbstractVector)` as a valid constructor to
 help users avoid the type instability (and potential performance disaster, if
-used without care) of this innocuous looking expression. However, the simplest
-way to deal with an `Array` is to create a `SizedArray` by calling a `Size`
-instance, e.g. `Size(2)(v)`.
+used without care) of this innocuous looking expression.
 
 ### Arrays of static arrays
 

--- a/docs/src/pages/quickstart.md
+++ b/docs/src/pages/quickstart.md
@@ -57,7 +57,7 @@ similar_type(m3) == SArray{Tuple{3,3},Int64,2,9}
 Size(m3) === Size(3,3)
 
 # A standard Array can be wrapped into a SizedArray
-m4 = Size(3,3)(rand(3,3))
+m4 = SizedMatrix{3,3}(rand(3,3))
 inv(m4) # Take advantage of specialized fast methods
 
 # reshape() uses Size() or types to specify size:

--- a/perf/benchmark2.jl
+++ b/perf/benchmark2.jl
@@ -19,7 +19,7 @@ A = rand(Float64,N,N)
 A = A*A'
 As = SMatrix{N,N}(A)
 Am = MMatrix{N,N}(A)
-Az = Size(N,N)(copy(A))
+Az = SizedMatrix{N,N}(copy(A))
 @static if fsa
     Af = Mat(ntuple(j -> ntuple(i->A[i,j], N), N)) # there is a bug in FixedSizeArrays Mat constructor (13 July 2016)
 end

--- a/perf/benchmark3.jl
+++ b/perf/benchmark3.jl
@@ -16,7 +16,7 @@ for T ∈ [Int64, Float64]
         println(" Vectors of length ", N, " and eltype ", T)
         println("=====================================================================")
         immutables = [rand(SVector{N,T})]
-        mutables = [rand(T,N), rand(MVector{N,T}), Size(N)(rand(T,N))]
+        mutables = [rand(T,N), rand(MVector{N,T}), SizedVector{N}(rand(T,N))]
         instances = vcat(immutables, mutables)
 
         namelengths = [length(string(typeof(v).name.name)) for v ∈ instances]
@@ -45,7 +45,7 @@ for T ∈ [Int64, Float64]
         println(" Matrices of size ", N, "×", N, " and eltype ", T)
         println("=====================================================================")
         immutables = [rand(SMatrix{N,N,T})]
-        mutables = [rand(T,N,N), rand(MMatrix{N,N,T}), Size(N,N)(rand(T,N,N))]
+        mutables = [rand(T,N,N), rand(MMatrix{N,N,T}), SizedMatrix{N,N}(rand(T,N,N))]
         instances = vcat(immutables, mutables)
 
         namelengths = [length(string(typeof(v).name.name)) for v ∈ instances]

--- a/src/SizedArray.jl
+++ b/src/SizedArray.jl
@@ -7,7 +7,9 @@ methods defined by the static array package. The size is checked once upon
 construction to determine if the number of elements (`length`) match, but the
 array may be reshaped.
 
-(Also, `Size(dims...)(array)` acheives the same thing)
+The aliases `SizedVector{N}` and `SizedMatrix{N,M}` are provided as more
+convenient names for one and two dimensional `SizedArray`s. For example, to
+wrap a 2x3 array `a` in a `SizedArray`, use `SizedMatrix{2,3}(a)`.
 """
 struct SizedArray{S <: Tuple, T, N, M} <: StaticArray{S, T, N}
     data::Array{T, M}
@@ -74,14 +76,10 @@ SizedMatrix{S1,S2,T,M} = SizedArray{Tuple{S1,S2},T,2,M}
 
 Base.dataids(sa::SizedArray) = Base.dataids(sa.data)
 
-"""
-    Size(dims)(array)
-
-Creates a `SizedArray` wrapping `array` with the specified statically-known
-`dims`, so to take advantage of the (faster) methods defined by the static array
-package.
-"""
-(::Size{S})(a::Array) where {S} = SizedArray{Tuple{S...}}(a)
+function (::Size{S})(a::Array) where {S}
+    Base.depwarn("`Size{S}(a::Array)` is deprecated, use `SizedVector{N}(a)`, `SizedMatrix{N,M}(a)` or `SizedArray{Tuple{S}}(a)` instead", :Size)
+    SizedArray{Tuple{S...}}(a)
+end
 
 
 function promote_rule(::Type{<:SizedArray{S,T,N,M}}, ::Type{<:SizedArray{S,U,N,M}}) where {S,T,U,N,M}

--- a/src/abstractarray.jl
+++ b/src/abstractarray.jl
@@ -158,7 +158,7 @@ homogenize_shape(shape::Tuple{Vararg{HeterogeneousShape}}) = map(last, shape)
     end
 end
 
-reshape(a::Array, s::Size{S}) where {S} = s(a)
+reshape(a::Array, ::Size{S}) where {S} = SizedArray{Tuple{S...}}(a)
 
 @inline vec(a::StaticArray) = reshape(a, Size(prod(Size(typeof(a)))))
 

--- a/src/cholesky.jl
+++ b/src/cholesky.jl
@@ -53,5 +53,7 @@ end
 end
 
 # Otherwise default algorithm returning wrapped SizedArray
-@inline _cholesky(s::Size, A::StaticArray) = s(Matrix(cholesky(Hermitian(Matrix(A))).U))
+@inline _cholesky(::Size{S}, A::StaticArray) where {S} =
+    SizedArray{Tuple{S...}}(Matrix(cholesky(Hermitian(Matrix(A))).U))
+
 LinearAlgebra.hermitian_type(::Type{SA}) where {T, S, SA<:SArray{S,T}} = Hermitian{T,SA}

--- a/src/lyap.jl
+++ b/src/lyap.jl
@@ -8,4 +8,5 @@ _lyap(::Size{(1,1)}, ::Size{(1,1)}, a::StaticMatrix,  c::StaticMatrix) = -c/(2a[
      -(d*c  + (a - t*I)*c*(a-t*I)')/(2*d*t) # http://www.nber.org/papers/w8956.pdf
 end
 
-@inline _lyap(sa::Size, sc::Size, a::StaticMatrix, c::StaticMatrix) = sc(lyap(Array(a),Array(c)))
+@inline _lyap(::Size, ::Size{SC}, a::StaticMatrix, c::StaticMatrix) where {SC} =
+    SizedArray{Tuple{SC...}}(lyap(Array(a),Array(c)))

--- a/src/sqrtm.jl
+++ b/src/sqrtm.jl
@@ -17,4 +17,4 @@ end
     end
 end
 
-@inline _sqrt(s::Size, A::StaticArray) = s(sqrt(Array(A)))
+@inline _sqrt(::Size{S}, A::StaticArray) where {S} = SizedArray{Tuple{S...}}(sqrt(Array(A)))

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -11,7 +11,7 @@ using StaticArrays, Test, LinearAlgebra
 
     @testset "strides" begin
         m1 = MArray{Tuple{3, 4, 5}}(rand(Int, 3, 4, 5))
-        m2 = Size(3,4,5)(rand(Int, 3, 4, 5))
+        m2 = SizedArray{Tuple{3,4,5}}(rand(Int, 3, 4, 5))
         @test strides(m1) === (1, 3, 12)
         @test strides(m2) === (1, 3, 12)
     end
@@ -117,7 +117,7 @@ using StaticArrays, Test, LinearAlgebra
         M = [1 2; 3 4]
         SM = SMatrix{2, 2}(M)
         MM = MMatrix{2, 2}(M)
-        SizeM = Size(2,2)(M)
+        SizeM = SizedMatrix{2,2}(M)
         @test @inferred(copy(SM)) === @SMatrix [1 2; 3 4]
         @test @inferred(copy(MM))::MMatrix == M
         @test copy(SM).data !== M

--- a/test/convert.jl
+++ b/test/convert.jl
@@ -2,7 +2,7 @@ using StaticArrays, Test
 
 @testset "Copy constructors" begin
     M = [1 2; 3 4]
-    SizeM = Size(2,2)(M)
+    SizeM = SizedMatrix{2,2}(M)
     @test typeof(SizeM)(SizeM).data === M
 end # testset
 

--- a/test/flatten.jl
+++ b/test/flatten.jl
@@ -3,7 +3,7 @@ using StaticArrays, Test
 @testset "Iterators.flatten" begin
     for x in [SVector(1.0, 2.0), MVector(1.0, 2.0),
             @SMatrix([1.0 2.0; 3.0 4.0]), @MMatrix([1.0 2.0]),
-            Size(1,2)([1.0 2.0])
+            SizedMatrix{1,2}([1.0 2.0])
             ]
         X = [x,x,x]
         @test length(Iterators.flatten(X)) == length(X)*length(x)


### PR DESCRIPTION
This feature makes it hard to find code which actually uses SizedArray (eg see https://github.com/JuliaArrays/StaticArrays.jl/pull/666#pullrequestreview-295372179), and it blesses `SizedArray` in an odd fashion by providing a special syntax for constructing it using the trait, which is completely different from the way that other `StaticArray` subtypes are constructed.

So I feel like it's an oddity which we should deprecate, perhaps.

If we do this, it's definitely breaking! But I also kind of suspect that a relatively small number of users actually use `SizedArray`. That's quite hard to assess though with a code search for the reasons mentioned...

One thing I'm not so sure about here is "what if you have `s::Size`, and you want to make a `SizedArray` which is that size"?  The natural thing to do would be to use `similar_type(a, s)`, but that currently produces an `SArray`.  For example, consider `reshape`:

```
# The following is the new version in this PR
reshape(a::Array, ::Size{S}) where {S} = SizedArray{Tuple{S...}}(a)
# vs the arguably-more-natural
reshape(a::Array, s::Size) = similar_type(SizedArray, s)(a)
```

Unfortunately I don't think we can really change `similar_type` to return a `SizedArray` for efficiency reasons. So maybe the current solution is ok.