### PR TITLE
Avoid calling promote_tuple_eltype in generated function to fix issue

### DIFF
--- a/src/SArray.jl
+++ b/src/SArray.jl
@@ -46,7 +46,7 @@ end
 @generated function (::Type{SArray{S}})(x::T) where {S <: Tuple, T <: Tuple}
     return quote
         @_inline_meta
-        SArray{S, $(promote_tuple_eltype(T)), $(tuple_length(S)), $(tuple_prod(S))}(x)
+        SArray{S, promote_tuple_eltype(T), $(tuple_length(S)), $(tuple_prod(S))}(x)
     end
 end
 


### PR DESCRIPTION
with promotion of user defined types. This is a minimal version of #670. I still think it would be beneficial to avoid generated functions when they aren't needed but it it's not urgent. In contrast this current issue is causing issues when using `StaticArrays` with `ForwardDiff` so it would be useful to get fixed immediately. I'd appreciate if you could make a bugfix release after merging this.