### PR TITLE
Remove allocations with `norm(x, p)`

### DIFF
--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -267,13 +267,13 @@ _norm_p0(x) = x == 0 ? zero(x) : one(x)
     return quote
         $(Expr(:meta, :inline))
         if p == Inf
-            return mapreduce(abs, max, a; init=$(zero(real(eltype(a)))))
+            return mapreduce(abs, max, a)
         elseif p == 1
             @inbounds return $expr_p1
         elseif p == 2
             return norm(a)
         elseif p == 0
-            return mapreduce(_norm_p0, +, a; init=$(zero(real(eltype(a)))))
+            return mapreduce(_norm_p0, +, a)
         else
             @inbounds return ($expr)^(inv(p))
         end


### PR DESCRIPTION
The allcations were probably due to lack of proper inlining of the
`init=...` keyword, but we're not reducing empty vectors here (there's a
special case for that) so we shouldn't need `init` at all.

Should fix #678