### PR TITLE
Unpirate Union{}[]

### DIFF
--- a/src/initializers.jl
+++ b/src/initializers.jl
@@ -26,6 +26,7 @@ const SA_F64 = SA{Float64}
 @inline similar_type(::Type{SA}, ::Size{S}) where {S} = SArray{Tuple{S...}}
 @inline similar_type(::Type{SA{T}}, ::Size{S}) where {T,S} = SArray{Tuple{S...}, T}
 
+# Lower bound `SA{E}<:T` prevents `T == Union{}` from accidentally matching this signature.
 @inline Base.getindex(sa::Type{T}, xs...) where {E, SA{E}<:T<:SA} = similar_type(sa, Size(length(xs)))(xs)
 @inline Base.typed_vcat(sa::Type{T}, xs::Number...) where {E, SA{E}<:T<:SA} = similar_type(sa, Size(length(xs)))(xs)
 @inline Base.typed_hcat(sa::Type{T}, xs::Number...) where {E, SA{E}<:T<:SA} = similar_type(sa, Size(1,length(xs)))(xs)

--- a/src/initializers.jl
+++ b/src/initializers.jl
@@ -27,8 +27,8 @@ const SA_F64 = SA{Float64}
 @inline similar_type(::Type{SA{T}}, ::Size{S}) where {T,S} = SArray{Tuple{S...}, T}
 
 @inline Base.getindex(sa::Type{T}, xs...) where {E, SA{E}<:T<:SA} = similar_type(sa, Size(length(xs)))(xs)
-@inline Base.typed_vcat(sa::Type{T}, xs::Number...) where {E, SA{E}<:T<:SA} = similar_type(sa, Size(length(xs)))(xs)
-@inline Base.typed_hcat(sa::Type{T}, xs::Number...) where {E, SA{E}<:T<:SA} = similar_type(sa, Size(1,length(xs)))(xs)
+@inline Base.typed_vcat(sa::Type{<:SA}, xs::Number...) = similar_type(sa, Size(length(xs)))(xs)
+@inline Base.typed_hcat(sa::Type{<:SA}, xs::Number...) = similar_type(sa, Size(1,length(xs)))(xs)
 
 Base.@pure function _SA_hvcat_transposed_size(rows)
     M = rows[1]
@@ -40,7 +40,7 @@ Base.@pure function _SA_hvcat_transposed_size(rows)
     Size(M, length(rows))
 end
 
-@inline function Base.typed_hvcat(sa::Type{T}, rows::Dims, xs::Number...) where {E, SA{E}<:T<:SA}
+@inline function Base.typed_hvcat(sa::Type{<:SA}, rows::Dims, xs::Number...)
     msize = _SA_hvcat_transposed_size(rows)
     if msize === nothing
         throw(ArgumentError("SA[...] matrix rows of length $rows are inconsistent"))

--- a/src/initializers.jl
+++ b/src/initializers.jl
@@ -26,7 +26,6 @@ const SA_F64 = SA{Float64}
 @inline similar_type(::Type{SA}, ::Size{S}) where {S} = SArray{Tuple{S...}}
 @inline similar_type(::Type{SA{T}}, ::Size{S}) where {T,S} = SArray{Tuple{S...}, T}
 
-# Lower bound `SA{E}<:T` prevents `T == Union{}` from accidentally matching this signature.
 @inline Base.getindex(sa::Type{T}, xs...) where {E, SA{E}<:T<:SA} = similar_type(sa, Size(length(xs)))(xs)
 @inline Base.typed_vcat(sa::Type{T}, xs::Number...) where {E, SA{E}<:T<:SA} = similar_type(sa, Size(length(xs)))(xs)
 @inline Base.typed_hcat(sa::Type{T}, xs::Number...) where {E, SA{E}<:T<:SA} = similar_type(sa, Size(1,length(xs)))(xs)

--- a/src/initializers.jl
+++ b/src/initializers.jl
@@ -27,6 +27,8 @@ const SA_F64 = SA{Float64}
 @inline similar_type(::Type{SA{T}}, ::Size{S}) where {T,S} = SArray{Tuple{S...}, T}
 
 @inline Base.getindex(::Type{Union{}}) = invoke(getindex, Tuple{Type}, Union{})
+@inline Base.getindex(::Type{Union{}}, xs::Vararg{T,N}) where {T,N} =
+    invoke(getindex, Tuple{Type,Vararg{T,N}}, Union{}, xs...)
 @inline Base.getindex(sa::Type{<:SA}, xs...) = similar_type(sa, Size(length(xs)))(xs)
 @inline Base.typed_vcat(sa::Type{<:SA}, xs::Number...) = similar_type(sa, Size(length(xs)))(xs)
 @inline Base.typed_hcat(sa::Type{<:SA}, xs::Number...) = similar_type(sa, Size(1,length(xs)))(xs)

--- a/src/initializers.jl
+++ b/src/initializers.jl
@@ -26,10 +26,7 @@ const SA_F64 = SA{Float64}
 @inline similar_type(::Type{SA}, ::Size{S}) where {S} = SArray{Tuple{S...}}
 @inline similar_type(::Type{SA{T}}, ::Size{S}) where {T,S} = SArray{Tuple{S...}, T}
 
-@inline Base.getindex(::Type{Union{}}) = invoke(getindex, Tuple{Type}, Union{})
-@inline Base.getindex(::Type{Union{}}, xs::Vararg{T,N}) where {T,N} =
-    invoke(getindex, Tuple{Type,Vararg{T,N}}, Union{}, xs...)
-@inline Base.getindex(sa::Type{<:SA}, xs...) = similar_type(sa, Size(length(xs)))(xs)
+@inline Base.getindex(sa::Type{T}, xs...) where {E, SA{E}<:T<:SA} = similar_type(sa, Size(length(xs)))(xs)
 @inline Base.typed_vcat(sa::Type{<:SA}, xs::Number...) = similar_type(sa, Size(length(xs)))(xs)
 @inline Base.typed_hcat(sa::Type{<:SA}, xs::Number...) = similar_type(sa, Size(1,length(xs)))(xs)
 

--- a/src/initializers.jl
+++ b/src/initializers.jl
@@ -26,7 +26,10 @@ const SA_F64 = SA{Float64}
 @inline similar_type(::Type{SA}, ::Size{S}) where {S} = SArray{Tuple{S...}}
 @inline similar_type(::Type{SA{T}}, ::Size{S}) where {T,S} = SArray{Tuple{S...}, T}
 
-@inline Base.getindex(sa::Type{T}, xs...) where {E, SA{E}<:T<:SA} = similar_type(sa, Size(length(xs)))(xs)
+@inline Base.getindex(::Type{Union{}}) = invoke(getindex, Tuple{Type}, Union{})
+@inline Base.getindex(::Type{Union{}}, xs::Vararg{T,N}) where {T,N} =
+    invoke(getindex, Tuple{Type,Vararg{T,N}}, Union{}, xs...)
+@inline Base.getindex(sa::Type{<:SA}, xs...) = similar_type(sa, Size(length(xs)))(xs)
 @inline Base.typed_vcat(sa::Type{<:SA}, xs::Number...) = similar_type(sa, Size(length(xs)))(xs)
 @inline Base.typed_hcat(sa::Type{<:SA}, xs::Number...) = similar_type(sa, Size(1,length(xs)))(xs)
 

--- a/src/initializers.jl
+++ b/src/initializers.jl
@@ -25,10 +25,6 @@ const SA_F64 = SA{Float64}
 
 @inline similar_type(::Type{SA}, ::Size{S}) where {S} = SArray{Tuple{S...}}
 @inline similar_type(::Type{SA{T}}, ::Size{S}) where {T,S} = SArray{Tuple{S...}, T}
-
-@inline Base.getindex(::Type{Union{}}) = invoke(getindex, Tuple{Type}, Union{})
-@inline Base.getindex(::Type{Union{}}, xs::Vararg{T,N}) where {T,N} =
-    invoke(getindex, Tuple{Type,Vararg{T,N}}, Union{}, xs...)
 @inline Base.getindex(sa::Type{<:SA}, xs...) = similar_type(sa, Size(length(xs)))(xs)
 @inline Base.typed_vcat(sa::Type{<:SA}, xs::Number...) = similar_type(sa, Size(length(xs)))(xs)
 @inline Base.typed_hcat(sa::Type{<:SA}, xs::Number...) = similar_type(sa, Size(1,length(xs)))(xs)
@@ -52,3 +48,20 @@ end
     transpose(similar_type(sa, msize)(xs))
 end
 
+# Unpirate `Union{}[]`.  We tried another solution that dispatches on
+# `Type{T}` with `SA{E}<:T<:SA` However, it did not work well with the
+# compiler.
+# https://github.com/JuliaArrays/StaticArrays.jl/pull/685#issuecomment-550497302
+@inline Base.getindex(::Type{Union{}}) = invoke(getindex, Tuple{Type}, Union{})
+@inline Base.getindex(::Type{Union{}}, xs::Vararg{T,N}) where {T,N} =
+    invoke(getindex, Tuple{Type,Vararg{T,N}}, Union{}, xs...)
+@inline Base.typed_vcat(::Type{Union{}}) = invoke(Base.typed_vcat, Tuple{Type}, Union{})
+@inline Base.typed_vcat(::Type{Union{}}, xs::Vararg{T,N}) where {T,N} =
+    invoke(Base.typed_vcat, Tuple{Type,Vararg{T,N}}, Union{}, xs...)
+@inline Base.typed_hcat(::Type{Union{}}) = invoke(Base.typed_hcat, Tuple{Type}, Union{})
+@inline Base.typed_hcat(::Type{Union{}}, xs::Vararg{T,N}) where {T,N} =
+    invoke(Base.typed_hcat, Tuple{Type,Vararg{T,N}}, Union{}, xs...)
+@inline Base.typed_hvcat(::Type{Union{}}, rows::Dims) where {T,N} =
+    invoke(Base.typed_hvcat, Tuple{Type,Dims}, Union{}, rows)
+@inline Base.typed_hvcat(::Type{Union{}}, rows::Dims, xs::Vararg{T,N}) where {T,N} =
+    invoke(Base.typed_hvcat, Tuple{Type,Dims,Vararg{T,N}}, Union{}, rows, xs...)

--- a/src/initializers.jl
+++ b/src/initializers.jl
@@ -27,8 +27,8 @@ const SA_F64 = SA{Float64}
 @inline similar_type(::Type{SA{T}}, ::Size{S}) where {T,S} = SArray{Tuple{S...}, T}
 
 @inline Base.getindex(sa::Type{T}, xs...) where {E, SA{E}<:T<:SA} = similar_type(sa, Size(length(xs)))(xs)
-@inline Base.typed_vcat(sa::Type{<:SA}, xs::Number...) = similar_type(sa, Size(length(xs)))(xs)
-@inline Base.typed_hcat(sa::Type{<:SA}, xs::Number...) = similar_type(sa, Size(1,length(xs)))(xs)
+@inline Base.typed_vcat(sa::Type{T}, xs::Number...) where {E, SA{E}<:T<:SA} = similar_type(sa, Size(length(xs)))(xs)
+@inline Base.typed_hcat(sa::Type{T}, xs::Number...) where {E, SA{E}<:T<:SA} = similar_type(sa, Size(1,length(xs)))(xs)
 
 Base.@pure function _SA_hvcat_transposed_size(rows)
     M = rows[1]
@@ -40,7 +40,7 @@ Base.@pure function _SA_hvcat_transposed_size(rows)
     Size(M, length(rows))
 end
 
-@inline function Base.typed_hvcat(sa::Type{<:SA}, rows::Dims, xs::Number...)
+@inline function Base.typed_hvcat(sa::Type{T}, rows::Dims, xs::Number...) where {E, SA{E}<:T<:SA}
     msize = _SA_hvcat_transposed_size(rows)
     if msize === nothing
         throw(ArgumentError("SA[...] matrix rows of length $rows are inconsistent"))

--- a/src/initializers.jl
+++ b/src/initializers.jl
@@ -26,6 +26,7 @@ const SA_F64 = SA{Float64}
 @inline similar_type(::Type{SA}, ::Size{S}) where {S} = SArray{Tuple{S...}}
 @inline similar_type(::Type{SA{T}}, ::Size{S}) where {T,S} = SArray{Tuple{S...}, T}
 
+@inline Base.getindex(::Type{Union{}}) = invoke(getindex, Tuple{Type}, Union{})
 @inline Base.getindex(sa::Type{<:SA}, xs...) = similar_type(sa, Size(length(xs)))(xs)
 @inline Base.typed_vcat(sa::Type{<:SA}, xs::Number...) = similar_type(sa, Size(length(xs)))(xs)
 @inline Base.typed_hcat(sa::Type{<:SA}, xs::Number...) = similar_type(sa, Size(1,length(xs)))(xs)

--- a/test/initializers.jl
+++ b/test/initializers.jl
@@ -38,6 +38,9 @@ SA_test_hvcat(x,T) = SA{T}[1 x x;
 
 # https://github.com/JuliaArrays/StaticArrays.jl/pull/685
 @test Union{}[] isa Vector{Union{}}
+@test Base.typed_vcat(Union{}) isa Vector{Union{}}
+@test Base.typed_hcat(Union{}) isa Vector{Union{}}
+@test Base.typed_hvcat(Union{}, ()) isa Vector{Union{}}
 @test_throws MethodError Union{}[1]
 @test_throws MethodError Union{}[1 2]
 @test_throws MethodError Union{}[1; 2]

--- a/test/initializers.jl
+++ b/test/initializers.jl
@@ -38,5 +38,6 @@ SA_test_hvcat(x,T) = SA{T}[1 x x;
 
 # https://github.com/JuliaArrays/StaticArrays.jl/pull/685
 @test Union{}[] isa Vector{Union{}}
+@test_throws MethodError Union{}[1]
 
 end

--- a/test/initializers.jl
+++ b/test/initializers.jl
@@ -39,5 +39,8 @@ SA_test_hvcat(x,T) = SA{T}[1 x x;
 # https://github.com/JuliaArrays/StaticArrays.jl/pull/685
 @test Union{}[] isa Vector{Union{}}
 @test_throws MethodError Union{}[1]
+@test_throws MethodError Union{}[1 2]
+@test_throws MethodError Union{}[1; 2]
+@test_throws MethodError Union{}[1 2; 3 4]
 
 end

--- a/test/initializers.jl
+++ b/test/initializers.jl
@@ -36,4 +36,7 @@ SA_test_hvcat(x,T) = SA{T}[1 x x;
 @test SA_F64[1, 2] === SVector{2,Float64}((1,2))
 @test SA_F32[1, 2] === SVector{2,Float32}((1,2))
 
+# https://github.com/JuliaArrays/StaticArrays.jl/pull/685
+@test Union{}[] isa Vector{Union{}}
+
 end


### PR DESCRIPTION
`Union{}[]` does not work after I import `StaticArrays` (cb46c2dfb6e53b398a156ba7f6522f727ef26795) due to the new `SA[...]` constructor:

```julia
julia> Union{}[]
0-element Array{Union{},1}

julia> using StaticArrays

julia> Union{}[]
ERROR: ArgumentError: Union{} does not have elements
Stacktrace:
 [1] eltype(::Type{Union{}}) at ./array.jl:124
 [2] similar_type(::Type{Union{}}, ::Size{(0,)}) at /home/takafumi/.julia/dev/StaticArrays/src/abstractarray.jl:66
 [3] getindex(::Core.TypeofBottom) at /home/takafumi/.julia/dev/StaticArrays/src/initializers.jl:29
 [4] top-level scope at REPL[3]:1
```

This PR fixes it by overloading type piracy by yet another type piracy.

(Though I'm not sure if this is technically a type piracy. If you can't overload anything that can accept `Type{Union{}}`, you can't write `Type{<:MyType}`. But then `getindex(::Type{Union{}}) = ...` just totally looks like a type piracy...)
