### PR TITLE
A tool for testing whether codegen fully inlines a call tree.

### DIFF
--- a/test/initializers.jl
+++ b/test/initializers.jl
@@ -18,6 +18,7 @@ SA_test_hcat(x,T) = SA{T}[1 x x]
 @test @inferred(SA_test_hcat(2.0)) === SMatrix{1,3,Float64}((1,2,2))
 @test @inferred(SA_test_hcat(2,Float32))   === SMatrix{1,3,Float32}((1,2,2))
 
+# hvcat needs to be in a function for the row argument to constant propagate
 SA_test_hvcat(x) = SA[1 x x;
                       x 2 x]
 SA_test_hvcat(x,T) = SA{T}[1 x x;
@@ -35,6 +36,11 @@ SA_test_hvcat(x,T) = SA{T}[1 x x;
                                                                                        3 4 5]
 @test SA_F64[1, 2] === SVector{2,Float64}((1,2))
 @test SA_F32[1, 2] === SVector{2,Float32}((1,2))
+
+@test_inlined SA[1,2]
+@test_inlined SA[1 2]
+@test_inlined SA[1;2]
+@test_inlined SA_test_hvcat(3)
 
 # https://github.com/JuliaArrays/StaticArrays.jl/pull/685
 @test Union{}[] isa Vector{Union{}}

--- a/test/testutil.jl
+++ b/test/testutil.jl
@@ -36,3 +36,57 @@ end
 function test_expand_error(ex)
     @test_throws LoadError macroexpand(@__MODULE__, ex)
 end
+
+mutable struct ErrorCounterTestSet <: Test.AbstractTestSet
+    passcount::Int
+    errorcount::Int
+    failcount::Int
+end
+ErrorCounterTestSet(args...; kws...) = ErrorCounterTestSet(0,0,0)
+Test.finish(ts::ErrorCounterTestSet) = ts
+Test.record(ts::ErrorCounterTestSet, ::Test.Pass)  = (ts.passcount += 1)
+Test.record(ts::ErrorCounterTestSet, ::Test.Error) = (ts.errorcount += 1)
+Test.record(ts::ErrorCounterTestSet, ::Test.Fail)  = (ts.failcount += 1)
+
+"""
+    @test_inlined f(x,y, ...)
+
+Check that the (optimized) llvm code generated for the expression
+`f(x,y,...)` contains no `call` instructions.
+
+Note that LLVM IR can contain `call` instructions to intrinsics which don't
+make it into the native code, so this can be overly eager in declaring a
+a lack of complete inlining.
+"""
+macro test_inlined(ex)
+    ex_orig = ex
+    ex = macroexpand(@__MODULE__, :(@code_llvm $ex))
+    expr = quote
+        code_str = sprint() do io
+            code_llvm(io, $(map(esc, ex.args[2:end])...))
+        end
+        # Crude detection of call instructions remaining within what should be
+        # fully inlined code.
+        #
+        # TODO: Figure out some better pattern matching; LLVM IR can contain
+        # calls to intrinsics, so this will sometimes/often fail even when the
+        # native code has no call instructions.
+        @test !occursin("call", code_str)
+    end
+    @assert expr.args[4].head == :macrocall
+    expr.args[4].args[2] = __source__
+    expr
+end
+
+should_be_inlined(x) = x*x
+@noinline _should_not_be_inlined(x) = x*x
+should_not_be_inlined(x) = _should_not_be_inlined(x)
+
+@testset "@test_inlined" begin
+    @test_inlined should_be_inlined(1)
+    ts = @testset ErrorCounterTestSet "" begin
+        @test_inlined should_not_be_inlined(1)
+    end
+    @test ts.errorcount == 0 && ts.failcount == 1 && ts.passcount == 0
+end
+


### PR DESCRIPTION
Based on #685 (CC @tkf). I'll rebase once some solution to that issue is merged.

The implementation here is certainly hacky as it does a very simple minded inspection of the LLVM code as a string. But it should be much better to have some hacky tests for code quality rather than inspecting the code by eye!