### PR TITLE
Move concatenation into abstractarray.jl

### DIFF
--- a/src/abstractarray.jl
+++ b/src/abstractarray.jl
@@ -169,3 +169,53 @@ reshape(a::Array, ::Size{S}) where {S} = SizedArray{Tuple{S...}}(a)
 
 # TODO permutedims?
 
+#--------------------------------------------------
+# Concatenation
+@inline vcat(a::StaticVecOrMatLike) = a
+@inline vcat(a::StaticVecOrMatLike, b::StaticVecOrMatLike) = _vcat(Size(a), Size(b), a, b)
+@inline vcat(a::StaticVecOrMatLike, b::StaticVecOrMatLike, c::StaticVecOrMatLike...) = vcat(vcat(a,b), vcat(c...))
+
+@generated function _vcat(::Size{Sa}, ::Size{Sb}, a::StaticVecOrMatLike, b::StaticVecOrMatLike) where {Sa, Sb}
+    if Size(Sa)[2] != Size(Sb)[2]
+        return :(throw(DimensionMismatch("Tried to vcat arrays of size $Sa and $Sb")))
+    end
+
+    # TODO cleanup?
+    if a <: StaticVector && b <: StaticVector
+        Snew = (Sa[1] + Sb[1],)
+        exprs = vcat([:(a[$i]) for i = 1:Sa[1]],
+                     [:(b[$i]) for i = 1:Sb[1]])
+    else
+        Snew = (Sa[1] + Sb[1], Size(Sa)[2])
+        exprs = [((i <= size(a,1)) ? ((a <: StaticVector) ? :(a[$i]) : :(a[$i,$j]))
+                                   : ((b <: StaticVector) ? :(b[$(i-size(a,1))]) : :(b[$(i-size(a,1)),$j])))
+                                   for i = 1:(Sa[1]+Sb[1]), j = 1:Size(Sa)[2]]
+    end
+
+    return quote
+        @_inline_meta
+        @inbounds return similar_type(a, promote_type(eltype(a), eltype(b)), Size($Snew))(tuple($(exprs...)))
+    end
+end
+
+@inline hcat(a::StaticVector) = similar_type(a, Size(Size(a)[1],1))(a)
+@inline hcat(a::StaticMatrixLike) = a
+@inline hcat(a::StaticVecOrMatLike, b::StaticVecOrMatLike) = _hcat(Size(a), Size(b), a, b)
+@inline hcat(a::StaticVecOrMatLike, b::StaticVecOrMatLike, c::StaticVecOrMatLike...) = hcat(hcat(a,b), hcat(c...))
+
+@generated function _hcat(::Size{Sa}, ::Size{Sb}, a::StaticVecOrMatLike, b::StaticVecOrMatLike) where {Sa, Sb}
+    if Sa[1] != Sb[1]
+        return :(throw(DimensionMismatch("Tried to hcat arrays of size $Sa and $Sb")))
+    end
+
+    exprs = vcat([:(a[$i]) for i = 1:prod(Sa)],
+                 [:(b[$i]) for i = 1:prod(Sb)])
+
+    Snew = (Sa[1], Size(Sa)[2] + Size(Sb)[2])
+
+    return quote
+        @_inline_meta
+        @inbounds return similar_type(a, promote_type(eltype(a), eltype(b)), Size($Snew))(tuple($(exprs...)))
+    end
+end
+

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -130,3 +130,65 @@ using StaticArrays, Test, LinearAlgebra
         @test @inferred(reverse(m))::typeof(m) == MVector(3, 2, 1)
     end
 end
+
+@testset "vcat() and hcat()" begin
+    @test @inferred(vcat(SVector(1,2,3))) === SVector(1,2,3)
+    @test @inferred(hcat(SVector(1,2,3))) === SMatrix{3,1}(1,2,3)
+    @test @inferred(hcat(SMatrix{3,1}(1,2,3))) === SMatrix{3,1}(1,2,3)
+
+    @test @inferred(vcat(SVector(1,2,3), SVector(4,5,6))) === SVector(1,2,3,4,5,6)
+    @test @inferred(hcat(SVector(1,2,3), SVector(4,5,6))) === @SMatrix [1 4; 2 5; 3 6]
+    @test_throws DimensionMismatch vcat(SVector(1,2,3), @SMatrix [1 4; 2 5])
+    @test_throws DimensionMismatch hcat(SVector(1,2,3), SVector(4,5))
+
+    @test @inferred(vcat(@SMatrix([1;2;3]), SVector(4,5,6))) === @SMatrix([1;2;3;4;5;6])
+    @test @inferred(vcat(SVector(1,2,3), @SMatrix([4;5;6]))) === @SMatrix([1;2;3;4;5;6])
+    @test @inferred(hcat(@SMatrix([1;2;3]), SVector(4,5,6))) === @SMatrix [1 4; 2 5; 3 6]
+    @test @inferred(hcat(SVector(1,2,3), @SMatrix([4;5;6]))) === @SMatrix [1 4; 2 5; 3 6]
+
+    @test @inferred(vcat(@SMatrix([1;2;3]), @SMatrix([4;5;6]))) === @SMatrix([1;2;3;4;5;6])
+    @test @inferred(hcat(@SMatrix([1;2;3]), @SMatrix([4;5;6]))) === @SMatrix [1 4; 2 5; 3 6]
+
+    @test @inferred(vcat(SVector(1),SVector(2),SVector(3),SVector(4))) === SVector(1,2,3,4)
+    @test @inferred(hcat(SVector(1),SVector(2),SVector(3),SVector(4))) === SMatrix{1,4}(1,2,3,4)
+
+    vcat(SVector(1.0f0), SVector(1.0)) === SVector(1.0, 1.0)
+    hcat(SVector(1.0f0), SVector(1.0)) === SMatrix{1,2}(1.0, 1.0)
+
+    # issue #388
+    let x = SVector(1, 2, 3)
+        # current limit: 34 arguments
+        hcat(
+            x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x,
+            x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x)
+        allocs = @allocated hcat(
+            x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x,
+            x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x)
+        @test allocs == 0
+        vcat(
+            x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x,
+            x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x)
+        allocs = @allocated vcat(
+            x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x,
+            x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x)
+        @test allocs == 0
+    end
+
+    # issue #561
+    let A = Diagonal(SVector(1, 2)), B = @SMatrix [3 4; 5 6]
+        @test @inferred(hcat(A, B)) === SMatrix{2, 4}([Matrix(A) Matrix(B)])
+    end
+
+    let A = Transpose(@SMatrix [1 2; 3 4]), B = Adjoint(@SMatrix [5 6; 7 8])
+        @test @inferred(hcat(A, B)) === SMatrix{2, 4}([Matrix(A) Matrix(B)])
+    end
+
+    let A = Diagonal(SVector(1, 2)), B = @SMatrix [3 4; 5 6]
+        @test @inferred(vcat(A, B)) === SMatrix{4, 2}([Matrix(A); Matrix(B)])
+    end
+
+    let A = Transpose(@SMatrix [1 2; 3 4]), B = Adjoint(@SMatrix [5 6; 7 8])
+        @test @inferred(vcat(A, B)) === SMatrix{4, 2}([Matrix(A); Matrix(B)])
+    end
+end
+

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -147,67 +147,6 @@ using StaticArrays, Test, LinearAlgebra
 
     end
 
-    @testset "vcat() and hcat()" begin
-        @test @inferred(vcat(SVector(1,2,3))) === SVector(1,2,3)
-        @test @inferred(hcat(SVector(1,2,3))) === SMatrix{3,1}(1,2,3)
-        @test @inferred(hcat(SMatrix{3,1}(1,2,3))) === SMatrix{3,1}(1,2,3)
-
-        @test @inferred(vcat(SVector(1,2,3), SVector(4,5,6))) === SVector(1,2,3,4,5,6)
-        @test @inferred(hcat(SVector(1,2,3), SVector(4,5,6))) === @SMatrix [1 4; 2 5; 3 6]
-        @test_throws DimensionMismatch vcat(SVector(1,2,3), @SMatrix [1 4; 2 5])
-        @test_throws DimensionMismatch hcat(SVector(1,2,3), SVector(4,5))
-
-        @test @inferred(vcat(@SMatrix([1;2;3]), SVector(4,5,6))) === @SMatrix([1;2;3;4;5;6])
-        @test @inferred(vcat(SVector(1,2,3), @SMatrix([4;5;6]))) === @SMatrix([1;2;3;4;5;6])
-        @test @inferred(hcat(@SMatrix([1;2;3]), SVector(4,5,6))) === @SMatrix [1 4; 2 5; 3 6]
-        @test @inferred(hcat(SVector(1,2,3), @SMatrix([4;5;6]))) === @SMatrix [1 4; 2 5; 3 6]
-
-        @test @inferred(vcat(@SMatrix([1;2;3]), @SMatrix([4;5;6]))) === @SMatrix([1;2;3;4;5;6])
-        @test @inferred(hcat(@SMatrix([1;2;3]), @SMatrix([4;5;6]))) === @SMatrix [1 4; 2 5; 3 6]
-
-        @test @inferred(vcat(SVector(1),SVector(2),SVector(3),SVector(4))) === SVector(1,2,3,4)
-        @test @inferred(hcat(SVector(1),SVector(2),SVector(3),SVector(4))) === SMatrix{1,4}(1,2,3,4)
-
-        vcat(SVector(1.0f0), SVector(1.0)) === SVector(1.0, 1.0)
-        hcat(SVector(1.0f0), SVector(1.0)) === SMatrix{1,2}(1.0, 1.0)
-
-        # issue #388
-        let x = SVector(1, 2, 3)
-            # current limit: 34 arguments
-            hcat(
-                x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x,
-                x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x)
-            allocs = @allocated hcat(
-                x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x,
-                x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x)
-            @test allocs == 0
-            vcat(
-                x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x,
-                x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x)
-            allocs = @allocated vcat(
-                x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x,
-                x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x)
-            @test allocs == 0
-        end
-
-        # issue #561
-        let A = Diagonal(SVector(1, 2)), B = @SMatrix [3 4; 5 6]
-            @test @inferred(hcat(A, B)) === SMatrix{2, 4}([Matrix(A) Matrix(B)])
-        end
-
-        let A = Transpose(@SMatrix [1 2; 3 4]), B = Adjoint(@SMatrix [5 6; 7 8])
-            @test @inferred(hcat(A, B)) === SMatrix{2, 4}([Matrix(A) Matrix(B)])
-        end
-
-        let A = Diagonal(SVector(1, 2)), B = @SMatrix [3 4; 5 6]
-            @test @inferred(vcat(A, B)) === SMatrix{4, 2}([Matrix(A); Matrix(B)])
-        end
-
-        let A = Transpose(@SMatrix [1 2; 3 4]), B = Adjoint(@SMatrix [5 6; 7 8])
-            @test @inferred(vcat(A, B)) === SMatrix{4, 2}([Matrix(A); Matrix(B)])
-        end
-    end
-
     @testset "normalization" begin
         @test norm(SVector(1.0,2.0,2.0)) ≈ 3.0
         @test norm(SVector(1.0,2.0,2.0),2) ≈ 3.0


### PR DESCRIPTION
This is where it belongs; it's array functionality rather than linear algebra.

Also return a throw expression for size mismatches rather than throwing
from function generators.