### PR TITLE
Tidy one() implementation and UniformScaling constructors

### DIFF
--- a/src/MArray.jl
+++ b/src/MArray.jl
@@ -73,16 +73,6 @@ end
 
 @inline MArray(a::StaticArray) = MArray{size_tuple(Size(a))}(Tuple(a))
 
-# Simplified show for the type
-#show(io::IO, ::Type{MArray{S, T, N}}) where {S, T, N} = print(io, "MArray{$S,$T,$N}")
-
-# Some more advanced constructor-like functions
-@inline one(::Type{MArray{S}}) where {S} = one(MArray{S,Float64,tuple_length(S)})
-@inline one(::Type{MArray{S,T}}) where {S,T} = one(MArray{S,T,tuple_length(S)})
-
-# MArray(I::UniformScaling) methods to replace eye
-(::Type{MA})(I::UniformScaling) where {MA<:MArray} = _eye(Size(MA), MA, I)
-
 ####################
 ## MArray methods ##
 ####################

--- a/src/MVector.jl
+++ b/src/MVector.jl
@@ -95,7 +95,7 @@ macro MVector(ex)
                 error("@MVector expected a 1-dimensional array expression")
             end
         else
-            error("@MVector only supports the zeros(), ones(), rand(), randn(), randexp(), and eye() functions.")
+            error("@MVector only supports the zeros(), ones(), rand(), randn(), and randexp() functions.")
         end
     else
         error("Use @MVector [a,b,c] or @MVector([a,b,c])")

--- a/src/SArray.jl
+++ b/src/SArray.jl
@@ -52,16 +52,6 @@ end
 
 @inline SArray(a::StaticArray) = SArray{size_tuple(Size(a))}(Tuple(a))
 
-# Simplified show for the type
-# show(io::IO, ::Type{SArray{S, T, N}}) where {S, T, N} = print(io, "SArray{$S,$T,$N}") # TODO reinstate
-
-# Some more advanced constructor-like functions
-@inline one(::Type{SArray{S}}) where {S} = one(SArray{S, Float64, tuple_length(S)})
-@inline one(::Type{SArray{S, T}}) where {S, T} = one(SArray{S, T, tuple_length(S)})
-
-# SArray(I::UniformScaling) methods to replace eye
-(::Type{SA})(I::UniformScaling) where {SA<:SArray} = _eye(Size(SA), SA, I)
-
 ####################
 ## SArray methods ##
 ####################

--- a/src/SDiagonal.jl
+++ b/src/SDiagonal.jl
@@ -33,7 +33,7 @@ size(::Type{<:SDiagonal{N}}, d::Int) where {N} = d > 2 ? 1 : N
 # override to avoid copying
 diag(D::SDiagonal) = D.diag
 
-# SDiagonal(I::UniformScaling) methods to replace eye
+# SDiagonal(I::UniformScaling) methods
 (::Type{SDiagonal{N}})(I::UniformScaling) where {N} = SDiagonal{N}(ntuple(x->I.λ, Val(N)))
 (::Type{SDiagonal{N,T}})(I::UniformScaling) where {N,T} = SDiagonal{N,T}(ntuple(x->I.λ, Val(N)))
 

--- a/src/SHermitianCompact.jl
+++ b/src/SHermitianCompact.jl
@@ -230,7 +230,7 @@ end
     end
 end
 
-@inline _eye(s::Size{S}, t::Type{SSC}) where {S, SSC <: SHermitianCompact} = _one(s, t)
+@inline _scalar_matrix(s::Size{S}, t::Type{SSC}) where {S, SSC <: SHermitianCompact} = _one(s, t)
 
 # _fill covers fill, zeros, and ones:
 @generated function _fill(val, ::Size{s}, ::Type{SSC}) where {s, SSC <: SHermitianCompact}

--- a/src/SVector.jl
+++ b/src/SVector.jl
@@ -108,9 +108,9 @@ macro SVector(ex)
                 error("@SVector expected a 1-dimensional array expression")
             end
         else
-            error("@SVector only supports the zeros(), ones(), rand(), randn(), randexp(), and eye() functions.")
+            error("@SVector only supports the zeros(), ones(), rand(), randn() and randexp() functions.")
         end
-    else # TODO Expr(:call, :zeros), Expr(:call, :ones), Expr(:call, :eye) ?
+    else
         error("Use @SVector [a,b,c], @SVector Type[a,b,c] or a comprehension like [f(i) for i = i_min:i_max]")
     end
 end

--- a/src/StaticArrays.jl
+++ b/src/StaticArrays.jl
@@ -19,11 +19,7 @@ import LinearAlgebra: transpose, adjoint, dot, eigvals, eigen, lyap, tr,
                       kron, diag, norm, dot, diagm, lu, svd, svdvals,
                       factorize, ishermitian, issymmetric, isposdef, normalize,
                       normalize!, Eigen, det, logdet, cross, diff, qr, \
-
-# import eye for deprecation warnings
-@static if isdefined(LinearAlgebra, :eye)
-    import LinearAlgebra: eye
-end
+using LinearAlgebra: checksquare
 
 export SOneTo
 export StaticScalar, StaticArray, StaticVector, StaticMatrix
@@ -88,8 +84,8 @@ const StaticMatrixLike{T} = Union{
     StaticMatrix{<:Any, <:Any, T},
     Transpose{T, <:StaticVecOrMat{T}},
     Adjoint{T, <:StaticVecOrMat{T}},
-    Symmetric{T, <:StaticMatrix{T}},
-    Hermitian{T, <:StaticMatrix{T}},
+    Symmetric{T, <:StaticMatrix{<:Any, <:Any, T}},
+    Hermitian{T, <:StaticMatrix{<:Any, <:Any, T}},
     Diagonal{T, <:StaticVector{<:Any, T}}
 }
 const StaticVecOrMatLike{T} = Union{StaticVector{<:Any, T}, StaticMatrixLike{T}}

--- a/src/abstractarray.jl
+++ b/src/abstractarray.jl
@@ -93,6 +93,27 @@ mutable_similar_type(::Type{T}, s::Size{S}, ::Type{Val{D}}) where {T,S,D} = MArr
 
 sizedarray_similar_type(::Type{T},s::Size{S},::Type{Val{D}}) where {T,S,D} = SizedArray{Tuple{S...},T,D,length(s)}
 
+# Utility for computing the eltype of an array instance, type, or type
+# constructor.  For type constructors without a definite eltype, the default
+# value is returned.
+Base.@pure _eltype_or(a::AbstractArray, default) = eltype(a)
+Base.@pure _eltype_or(::Type{<:AbstractArray{T}}, default) where {T} = T
+Base.@pure _eltype_or(::Type{<:AbstractArray}, default) = default # eltype not available
+
+"""
+    _construct_similar(a, ::Size, elements::NTuple)
+
+Construct a static array of similar type to `a` with the given `elements`.
+
+When `a` is an instance or a concrete type the element type `eltype(a)` is
+used. However, when `a` is a `UnionAll` type such as `SMatrix{2,2}`, the
+promoted type of `elements` is used instead.
+"""
+@inline function _construct_similar(a, s::Size, elements::NTuple{L,ET}) where {L,ET}
+    similar_type(a, _eltype_or(a, ET), s)(elements)
+end
+
+
 # Field vectors are user controlled, and currently default to SVector, etc
 
 """

--- a/src/det.jl
+++ b/src/det.jl
@@ -43,7 +43,7 @@ end
 end
 
 @generated function _det(::Size{S}, A::StaticMatrix) where S
-    LinearAlgebra.checksquare(A)
+    checksquare(A)
     if prod(S) ≤ 14*14
         quote
             @_inline_meta
@@ -58,7 +58,7 @@ end
 @inline logdet(A::StaticMatrix) = _logdet(Size(A), A)
 @inline _logdet(::Union{Size{(1,1)}, Size{(2,2)}, Size{(3,3)}, Size{(4,4)}}, A::StaticMatrix) = log(det(A))
 @generated function _logdet(::Size{S}, A::StaticMatrix) where S
-    LinearAlgebra.checksquare(A)
+    checksquare(A)
     if prod(S) ≤ 14*14
         quote
             @_inline_meta

--- a/src/qr.jl
+++ b/src/qr.jl
@@ -98,7 +98,7 @@ end
     Q = [Symbol("Q_$(i)_$(j)") for i = 1:m, j = 1:m]
     R = [Symbol("R_$(i)_$(j)") for i = 1:m, j = 1:n]
 
-    initQ = [:($(Q[i, j]) = $(i == j ? one : zero)(T)) for i = 1:m, j = 1:m]  # Q .= eye(A)
+    initQ = [:($(Q[i, j]) = $(i == j ? one : zero)(T)) for i = 1:m, j = 1:m]  # Q .= I
     initR = [:($(R[i, j]) = T(A[$i, $j])) for i = 1:m, j = 1:n]               # R .= A
 
     code = quote end

--- a/src/util.jl
+++ b/src/util.jl
@@ -108,3 +108,4 @@ Base.@propagate_inbounds function invperm(p::StaticVector)
      ip[p] = 1:length(p)
      similar_type(p)(ip)
 end
+

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -1,5 +1,7 @@
 using StaticArrays, Test, LinearAlgebra
 
+using LinearAlgebra: checksquare
+
 @testset "Linear algebra" begin
 
     @testset "SArray as a (mathematical) vector space" begin
@@ -100,7 +102,7 @@ using StaticArrays, Test, LinearAlgebra
         @test @inferred(one(MMatrix{2,2}))::MMatrix == @MMatrix [1.0 0.0; 0.0 1.0]
         @test @inferred(one(MMatrix{2}))::MMatrix == @MMatrix [1.0 0.0; 0.0 1.0]
 
-        @test_throws ErrorException one(MMatrix{2,4})
+        @test_throws DimensionMismatch one(MMatrix{2,4})
     end
 
     @testset "cross()" begin
@@ -325,5 +327,13 @@ using StaticArrays, Test, LinearAlgebra
         @test @inferred(kron(transpose(b),A))::SizedMatrix{10,210} == kron(transpose(q),P)
         @test @inferred(kron(A,transpose(b)))::SizedMatrix{10,210} == kron(P,transpose(q))
 
+    end
+
+    @testset "checksquare" begin
+        m22 = SA[1 2; 3 4]
+        @test @inferred(checksquare(m22)) === 2
+        @test_inlined checksquare(m22)
+        m23 = SA[1 2 3; 4 5 6]
+        @test_inlined checksquare(m23) false
     end
 end


### PR DESCRIPTION
* Remove all reference to the deprecated name `eye` (replace internal
  _eye with _scaler_matrix)
* Remove all the more-or-less duplicate definitions of one() and use
  _scalar_matrix as the implementation.
* Fix StaticMatrixLike definition to properly include Hermitian and
  Symmetric wrappers of static matrices.
* Import LinearAlgebra.checksquare() and use it directly.

Introduce `_construct_similar` to alleviate the difficulty of computing
eltype purely in the type domain with non-concrete UnionAlls.