### PR TITLE
fix broadcasts with only adjoint/transpose SVectors

### DIFF
--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -97,7 +97,7 @@ scalar_getindex(x) = x
 scalar_getindex(x::Ref) = x[]
 
 @generated function _broadcast(f, ::Size{newsize}, s::Tuple{Vararg{Size}}, a...) where newsize
-    first_staticarray = a[findfirst(ai -> ai <: StaticArray, a)]
+    first_staticarray = a[findfirst(ai -> ai <: Union{StaticArray, Transpose{<:Any, <:StaticArray}, Adjoint{<:Any, <:StaticArray}}, a)]
 
     if prod(newsize) == 0
         # Use inference to get eltype in empty case (see also comments in _map)

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -115,6 +115,8 @@ end
         # Issue 382: infinite recursion in Base.Broadcast.broadcast_indices with Adjoint
         @test @inferred(SVector(1,1)' .+ [1, 1]) == [2 2; 2 2]
         @test @inferred(transpose(SVector(1,1)) .+ [1, 1]) == [2 2; 2 2]
+        
+        @test @inferred(v1' + v2') === SVector(2,6)'
     end
 
     @testset "StaticVector with Scalar" begin

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -116,7 +116,8 @@ end
         @test @inferred(SVector(1,1)' .+ [1, 1]) == [2 2; 2 2]
         @test @inferred(transpose(SVector(1,1)) .+ [1, 1]) == [2 2; 2 2]
         
-        @test @inferred(v1' + v2') === SVector(2,6)'
+        # Issue 704: broadcast with adjoint wrapped static arrays
+        @test @inferred(v1' .+ v2') === SA[2 6]
     end
 
     @testset "StaticVector with Scalar" begin


### PR DESCRIPTION
A minor thing I ran into / fixed. 