### PR TITLE
Fix eltype for recurisve adjoint/transpose

### DIFF
--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -62,7 +62,8 @@ end
 
     return quote
         $(Expr(:meta, :inline))
-        @inbounds return similar_type($m, Size($Snew))(tuple($(exprs...)))
+        elements = tuple($(exprs...))
+        @inbounds return similar_type($m, eltype(elements), Size($Snew))(elements)
     end
 end
 
@@ -78,7 +79,8 @@ end
 
     return quote
         $(Expr(:meta, :inline))
-        @inbounds return similar_type($m, Size($Snew))(tuple($(exprs...)))
+        elements = tuple($(exprs...))
+        @inbounds return similar_type($m, eltype(elements), Size($Snew))(elements)
     end
 end
 

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -147,6 +147,9 @@ using LinearAlgebra: checksquare
         @test @inferred(adjoint(@SMatrix [m m; m m])) == adjoint([[m] [m]; [m] [m]])
         @test @inferred(transpose(@SMatrix [m m; m m])) == transpose([[m] [m]; [m] [m]])
 
+        # Recursive adjoint/transpose correctly handles eltype (#708)
+        @test (@inferred(adjoint(SMatrix{2,2}(fill([1,2], 2,2)))))::SMatrix == SMatrix{2,2}(fill(adjoint([1,2]), 2,2))
+        @test (@inferred(transpose(SMatrix{2,2}(fill([1,2], 2,2)))))::SMatrix == SMatrix{2,2}(fill(transpose([1,2]), 2,2))
     end
 
     @testset "normalization" begin


### PR DESCRIPTION
The eltype may change due to the recursive nature of adjoint and
transpose.

Fixes #708