### PR TITLE
make reshaping SizedArrays not turn them into SArrays

### DIFF
--- a/src/abstractarray.jl
+++ b/src/abstractarray.jl
@@ -86,9 +86,9 @@ similar_type(::Type{SA},::Type{T},s::Size{S}) where {SA<:Union{MVector,MMatrix,M
 
 mutable_similar_type(::Type{T}, s::Size{S}, ::Type{Val{D}}) where {T,S,D} = MArray{Tuple{S...},T,D,prod(s)}
 
-# Should `SizedArray` stay the same, and also take over an `Array`?
-#similar_type{SA<:SizedArray,T,S}(::Type{SA},::Type{T},s::Size{S}) = sizedarray_similar_type(T,s,length_val(s))
-#similar_type{A<:Array,T,S}(::Type{A},::Type{T},s::Size{S}) = sizedarray_similar_type(T,s,length_val(s))
+similar_type(::Type{<:SizedArray},::Type{T},s::Size{S}) where {S,T} = sizedarray_similar_type(T,s,length_val(s))
+# Should SizedArray also be used for normal Array?
+#similar_type(::Type{<:Array},::Type{T},s::Size{S}) where {S,T} = sizedarray_similar_type(T,s,length_val(s))
 
 sizedarray_similar_type(::Type{T},s::Size{S},::Type{Val{D}}) where {T,S,D} = SizedArray{Tuple{S...},T,D,length(s)}
 
@@ -238,4 +238,3 @@ end
         @inbounds return similar_type(a, promote_type(eltype(a), eltype(b)), Size($Snew))(tuple($(exprs...)))
     end
 end
-

--- a/test/SizedArray.jl
+++ b/test/SizedArray.jl
@@ -99,4 +99,12 @@
         @test @inferred(promote_type(SizedVector{2,Int,1}, SizedVector{2,Float64,1})) === SizedVector{2,Float64,1}
         @test @inferred(promote_type(SizedMatrix{2,3,Float32,2}, SizedMatrix{2,3,Complex{Float64},2})) === SizedMatrix{2,3,Complex{Float64},2}
     end
+
+    @testset "reshaping" begin
+        y = rand(4,1,2)
+        sy = SizedArray{Tuple{size(y)...}}(y)
+
+        @test vec(sy) isa SizedArray{Tuple{8}, Float64}
+        @test reshape(sy, Size(2,4)) isa SizedArray{Tuple{2, 4}, Float64}
+    end
 end


### PR DESCRIPTION
I had an array, and I wanted to carry size information about it around in its type..
At first I thought, I can use a `SArray`, but then I remember my matrix might endup being something like 10^3 x 10^6 elements; and  creating a `SArray` would be really slow.

I looked in the docs and I spotted `SizedArray` and I am likle _Pefect_.
So I am happily using that.
Then at some point I needed to call `vec` on my `SizedArray`,
and after I did that, it had turned into a `SArray`.
Which I really did not want, reasons outlined above.

This fixed that.
The code was basically already there, I just uncommented and updated it.