### PR TITLE
Default implementation of similar_type for FieldArray

### DIFF
--- a/test/FieldMatrix.jl
+++ b/test/FieldMatrix.jl
@@ -13,7 +13,7 @@
                 zz::Float64
             end
 
-            StaticArrays.similar_type(::Type{Tensor3x3}, ::Type{Float64}, s::Size{(3,3)}) = Tensor3x3
+            # No need to define similar_type for non-parametric FieldMatrix (#792)
         end)
 
         p = Tensor3x3(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0)


### PR DESCRIPTION
This should free users from defining similar_type in many cases, though
they'll still need to do so when their type is parametric on the eltype.
(There's no general way for us to know how to reparameterize such
user-defined types.)

Fixes #729