### PR TITLE
Port perf/benchmark_matrix_ops.jl to benchmark/*.jl

### DIFF
--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -2,3 +2,4 @@
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 PkgBenchmark = "32113eaa-f34f-5b0d-bd6c-c81e245fc73d"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/benchmark/bench_matrix_ops.jl
+++ b/benchmark/bench_matrix_ops.jl
@@ -21,7 +21,7 @@ for f in [det, inv, exp]
     for N in matrix_sizes
         SA = @SMatrix rand(N, N)
         A = Array(SA)
-        s2 = s1["$N"] = BenchmarkGroup()
+        s2 = s1[string(N, pad=2)] = BenchmarkGroup()
         s2["SMatrix"] = @benchmarkable $f($SA)
         s2["Matrix"] = @benchmarkable $f($A)
     end
@@ -35,7 +35,7 @@ for f in [*, \]
         SB = @SMatrix rand(N, N)
         A = Array(SA)
         B = Array(SB)
-        s2 = s1["$N"] = BenchmarkGroup()
+        s2 = s1[string(N, pad=2)] = BenchmarkGroup()
         s2["SMatrix"] = @benchmarkable $f($SA, $SB)
         s2["Matrix"] = @benchmarkable $f($A, $B)
     end

--- a/benchmark/bench_matrix_ops.jl
+++ b/benchmark/bench_matrix_ops.jl
@@ -1,21 +1,21 @@
 module BenchMatrixOps
 
+import Random
 using BenchmarkTools
 using LinearAlgebra
-using Random
 using StaticArrays
 
 const suite = BenchmarkGroup()
 const Nmax = 20
 
 # Use same arrays across processes (at least with the same Julia version):
-const RNG = MersenneTwister(1234)
+Random.seed!(1234)
 
 # Unary operators
 for f in [det, inv, exp]
     s1 = suite["$f"] = BenchmarkGroup()
     for N in 1:Nmax
-        SA = @SMatrix rand(RNG, N, N)
+        SA = @SMatrix rand(N, N)
         A = Array(SA)
         s2 = s1["$N"] = BenchmarkGroup()
         s2["SMatrix"] = @benchmarkable $f($SA)
@@ -27,8 +27,8 @@ end
 for f in [*, \]
     s1 = suite["$f"] = BenchmarkGroup()
     for N in 1:Nmax
-        SA = @SMatrix rand(RNG, N, N)
-        SB = @SMatrix rand(RNG, N, N)
+        SA = @SMatrix rand(N, N)
+        SB = @SMatrix rand(N, N)
         A = Array(SA)
         B = Array(SB)
         s2 = s1["$N"] = BenchmarkGroup()

--- a/benchmark/bench_matrix_ops.jl
+++ b/benchmark/bench_matrix_ops.jl
@@ -1,0 +1,41 @@
+module BenchMatrixOps
+
+using BenchmarkTools
+using LinearAlgebra
+using Random
+using StaticArrays
+
+const suite = BenchmarkGroup()
+const Nmax = 20
+
+# Use same arrays across processes (at least with the same Julia version):
+const RNG = MersenneTwister(1234)
+
+# Unary operators
+for f in [det, inv, exp]
+    s1 = suite["$f"] = BenchmarkGroup()
+    for N in 1:Nmax
+        SA = @SMatrix rand(RNG, N, N)
+        A = Array(SA)
+        s2 = s1["$N"] = BenchmarkGroup()
+        s2["SMatrix"] = @benchmarkable $f($SA)
+        s2["Matrix"] = @benchmarkable $f($A)
+    end
+end
+
+# Binary operators
+for f in [*, \]
+    s1 = suite["$f"] = BenchmarkGroup()
+    for N in 1:Nmax
+        SA = @SMatrix rand(RNG, N, N)
+        SB = @SMatrix rand(RNG, N, N)
+        A = Array(SA)
+        B = Array(SB)
+        s2 = s1["$N"] = BenchmarkGroup()
+        s2["SMatrix"] = @benchmarkable $f($SA, $SB)
+        s2["Matrix"] = @benchmarkable $f($A, $B)
+    end
+end
+
+end  # module
+BenchMatrixOps.suite

--- a/benchmark/bench_matrix_ops.jl
+++ b/benchmark/bench_matrix_ops.jl
@@ -6,7 +6,11 @@ using LinearAlgebra
 using StaticArrays
 
 const suite = BenchmarkGroup()
-const Nmax = 20
+const matrix_sizes = if haskey(ENV, "GITHUB_EVENT_PATH")
+    (1, 2, 3, 4, 10, 20)
+else
+    1:20
+end
 
 # Use same arrays across processes (at least with the same Julia version):
 Random.seed!(1234)
@@ -14,7 +18,7 @@ Random.seed!(1234)
 # Unary operators
 for f in [det, inv, exp]
     s1 = suite["$f"] = BenchmarkGroup()
-    for N in 1:Nmax
+    for N in matrix_sizes
         SA = @SMatrix rand(N, N)
         A = Array(SA)
         s2 = s1["$N"] = BenchmarkGroup()
@@ -26,7 +30,7 @@ end
 # Binary operators
 for f in [*, \]
     s1 = suite["$f"] = BenchmarkGroup()
-    for N in 1:Nmax
+    for N in matrix_sizes
         SA = @SMatrix rand(N, N)
         SB = @SMatrix rand(N, N)
         A = Array(SA)


### PR DESCRIPTION
This PR adds `benchmark/bench_matrix_ops.jl` which is a straight-forward port of `perf/benchmark_matrix_ops.jl`.