### PR TITLE
Update SArray.jl

### DIFF
--- a/src/SArray.jl
+++ b/src/SArray.jl
@@ -55,6 +55,7 @@ end
 ####################
 ## SArray methods ##
 ####################
+@inline SArray{S, T, N, L}(x::SArray{S, T, N, L} ) where {S, T, N, L} = x
 
 @propagate_inbounds function getindex(v::SArray, i::Int)
     v.data[i]


### PR DESCRIPTION
avoid calling `@inline (::Type{SA})(a::StaticArray) where {SA<:StaticArray} = SA(Tuple(a))` in `convert.jl`.
it allows us to define function that returns a SVector but expects a AbstractVector argument e.g.
```
fun(x::AbstractVector) = 2 * (SVector{length(x)}(x) )
```
with the proposed method, we can skip adding the following:
```
fun(x::SVector) = 2x
```