### PR TITLE
Fix accidential API breakage in one()

### DIFF
--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -2,6 +2,14 @@ using StaticArrays, Test, LinearAlgebra
 
 using LinearAlgebra: checksquare
 
+# For one() test
+struct RotMat2 <: StaticMatrix{2,2,Float64}
+    elements::NTuple{4,Float64}
+end
+Base.getindex(m::RotMat2, i::Int) = getindex(m.elements, i)
+# Rotation matrices must be unitary so `similar_type` has to return an SMatrix.
+StaticArrays.similar_type(::Union{RotMat2,Type{RotMat2}}) = SMatrix{2,2,Float64,4}
+
 @testset "Linear algebra" begin
 
     @testset "SArray as a (mathematical) vector space" begin
@@ -103,6 +111,11 @@ using LinearAlgebra: checksquare
         @test @inferred(one(MMatrix{2}))::MMatrix == @MMatrix [1.0 0.0; 0.0 1.0]
 
         @test_throws DimensionMismatch one(MMatrix{2,4})
+
+        @test one(RotMat2) isa RotMat2
+        @test one(RotMat2) == SA[1 0; 0 1]
+        # TODO: See comment in _one.
+        @test_broken one(RotMat2) isa SMatrix{2,2,Float64}
     end
 
     @testset "cross()" begin


### PR DESCRIPTION
Fix release-blocking bug #700 .

It turns out that Rotations.jl relies on `one(M)` calling the constructor of `M`, so transitioning to use of `simliar_type` in #690 broke `Rotations`. 

It's arguably a bug to call the constructor rather than calling `similar_type`, but let's avoid breaking compatibility for now.

I say it's arguably a bug because some sets of matrices defined by a type cannot represent the multiplicative identity, for example the set of skew-symmetric matrices. StaticArrays should likely assume that generic operations like `one()` must devolve to a matrix type which can represent
anything in GL(n,R).