### PR TITLE
Remove show(::IO, ::Type{StaticArrays.Blah}) overloads

### DIFF
--- a/src/MMatrix.jl
+++ b/src/MMatrix.jl
@@ -54,9 +54,6 @@ end
 @inline convert(::Type{MMatrix{S1,S2}}, a::StaticArray{<:Tuple, T}) where {S1,S2,T} = MMatrix{S1,S2,T}(Tuple(a))
 @inline MMatrix(a::StaticMatrix) = MMatrix{size(typeof(a),1),size(typeof(a),2)}(Tuple(a))
 
-# Simplified show for the type
-#show(io::IO, ::Type{MMatrix{N, M, T}}) where {N, M, T} = print(io, "MMatrix{$N,$M,$T}")
-
 # Some more advanced constructor-like functions
 @inline one(::Type{MMatrix{N}}) where {N} = one(MMatrix{N,N})
 

--- a/src/MVector.jl
+++ b/src/MVector.jl
@@ -20,9 +20,6 @@ const MVector{S, T} = MArray{Tuple{S}, T, 1, S}
 @inline MVector{S}(x::NTuple{S,T}) where {S, T} = MVector{S, T}(x)
 @inline MVector{S}(x::NTuple{S,Any}) where {S} = MVector{S, promote_tuple_eltype(typeof(x))}(x)
 
-# Simplified show for the type
-#show(io::IO, ::Type{MVector{N, T}}) where {N, T} = print(io, "MVector{$N,$T}")
-
 # Some more advanced constructor-like functions
 @inline zeros(::Type{MVector{N}}) where {N} = zeros(MVector{N,Float64})
 @inline ones(::Type{MVector{N}}) where {N} = ones(MVector{N,Float64})

--- a/src/SMatrix.jl
+++ b/src/SMatrix.jl
@@ -55,9 +55,6 @@ end
 @inline convert(::Type{SMatrix{S1,S2}}, a::StaticArray{<:Tuple, T}) where {S1,S2,T} = SMatrix{S1,S2,T}(Tuple(a))
 @inline SMatrix(a::StaticMatrix{S1, S2}) where {S1, S2} = SMatrix{S1, S2}(Tuple(a))
 
-# Simplified show for the type
-# show(io::IO, ::Type{SMatrix{N, M, T}}) where {N, M, T} = print(io, "SMatrix{$N,$M,$T}") # TODO reinstate
-
 # Some more advanced constructor-like functions
 @inline one(::Type{SMatrix{N}}) where {N} = one(SMatrix{N,N})
 

--- a/src/SUnitRange.jl
+++ b/src/SUnitRange.jl
@@ -26,7 +26,6 @@ end
 end
 
 # Shorten show for REPL use.
-show(io::IO, ::Type{SUnitRange}) = print(io, "SUnitRange")
 function show(io::IO, ::MIME"text/plain", ::SUnitRange{Start, L}) where {Start, L}
     print(io, "SUnitRange($Start,$(Start + L - 1))")
 end

--- a/src/SVector.jl
+++ b/src/SVector.jl
@@ -22,9 +22,6 @@ const SVector{S, T} = SArray{Tuple{S}, T, 1, S}
 # conversion from AbstractVector / AbstractArray (better inference than default)
 #@inline convert{S,T}(::Type{SVector{S}}, a::AbstractArray{T}) = SVector{S,T}((a...))
 
-# Simplified show for the type
-# show(io::IO, ::Type{SVector{N, T}}) where {N, T} = print(io, "SVector{$N,$T}") # TODO reinstate
-
 # Some more advanced constructor-like functions
 @inline zeros(::Type{SVector{N}}) where {N} = zeros(SVector{N,Float64})
 @inline ones(::Type{SVector{N}}) where {N} = ones(SVector{N,Float64})

--- a/src/Scalar.jl
+++ b/src/Scalar.jl
@@ -24,5 +24,3 @@ end
 # A lot more compact than the default array show
 Base.show(io::IO, ::MIME"text/plain", x::Scalar{T}) where {T} = print(io, "Scalar{$T}(", x.data, ")")
 
-# Simplified show for the type
-show(io::IO, ::Type{Scalar{T}}) where {T} = print(io, "Scalar{T}")

--- a/test/SUnitRange.jl
+++ b/test/SUnitRange.jl
@@ -10,7 +10,4 @@
 
     @test_throws Exception StaticArrays.SUnitRange{1, -1}()
     @test_throws TypeError StaticArrays.SUnitRange{1, 1.5}()
-
-    ur_str = sprint(show, StaticArrays.SUnitRange)
-    @test ur_str == "SUnitRange"
 end


### PR DESCRIPTION
Apparently these can be problematic for compiler-internal reasons, and I
think the printing has been improved such that the remaining cases of
these may not do anything useful. So let's just remove them.