### PR TITLE
Fix method amguity in Scalar(::StaticArray)

### DIFF
--- a/src/Scalar.jl
+++ b/src/Scalar.jl
@@ -9,7 +9,7 @@ const Scalar{T} = SArray{Tuple{},T,0,1}
 @inline Scalar(x::Tuple{T}) where {T} = Scalar{T}(x[1])
 @inline Scalar(a::AbstractArray) = Scalar{typeof(a)}((a,))
 @inline Scalar(a::AbstractScalar) = Scalar{eltype(a)}((a[],)) # Do we want this to convert or wrap?
-@inline Scalar(a::SA) where {SA<:StaticArrar} = Scalar{SA}(a) # solve ambiguity
+@inline Scalar(a::SA) where {SA<:StaticArray} = Scalar{SA}(a) # solve ambiguity
 @inline function convert(::Type{SA}, a::AbstractArray) where {SA <: Scalar}
     return SA((a[],))
 end

--- a/src/Scalar.jl
+++ b/src/Scalar.jl
@@ -9,6 +9,7 @@ const Scalar{T} = SArray{Tuple{},T,0,1}
 @inline Scalar(x::Tuple{T}) where {T} = Scalar{T}(x[1])
 @inline Scalar(a::AbstractArray) = Scalar{typeof(a)}((a,))
 @inline Scalar(a::AbstractScalar) = Scalar{eltype(a)}((a[],)) # Do we want this to convert or wrap?
+@inline Scalar(a::SA) where {SA<:StaticArrar} = Scalar{SA}(a) # solve ambiguity
 @inline function convert(::Type{SA}, a::AbstractArray) where {SA <: Scalar}
     return SA((a[],))
 end


### PR DESCRIPTION
Before this pr:
```julia
julia> using StaticArrays

julia> Scalar(SA[1,2,3])
ERROR: MethodError: Scalar{T} where T(::SArray{Tuple{3},Int64,1,3}) is ambiguous. Candidates:
  (::Type{Scalar{T} where T})(a::AbstractArray) in StaticArrays at /home/mason/.julia/packages/StaticArrays/1g9bq/src/Scalar.jl:10
  (::Type{SA})(a::StaticArray) where SA<:StaticArray in StaticArrays at /home/mason/.julia/packages/StaticArrays/1g9bq/src/convert.jl:5
Possible fix, define
  Scalar{T} where T(::StaticArray)
Stacktrace:
 [1] top-level scope at REPL[2]:3
 [2] eval(::Module, ::Any) at ./boot.jl:331
 [3] eval_user_input(::Any, ::REPL.REPLBackend) at /home/mason/julia/usr/share/julia/stdlib/v1.4/REPL/src/REPL.jl:86
 [4] run_backend(::REPL.REPLBackend) at /home/mason/.julia/packages/Revise/0meWR/src/Revise.jl:1075
 [5] top-level scope at none:0
```

```julia
julia> StaticArrays.Scalar(sa::SA) where {SA<:StaticArray} = Scalar{SA}(sa) #disambiguate

julia> Scalar(SA[1,2,3])
Scalar{SArray{Tuple{3},Int64,1,3}}(([1, 2, 3],))
```

