### PR TITLE
Allow CI failures on Julia nightly builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.version == 'nightly' }}
     strategy:
       matrix:
         version:


### PR DESCRIPTION
Quick fix (hopefully!) for CI failing on nightly.

Not exactly ideal though, see https://github.community/t5/GitHub-Actions/continue-on-error-allow-failure-UI-indication/td-p/37033

For reference, the failing job https://github.com/JuliaArrays/StaticArrays.jl/runs/625450952