### PR TITLE
remove unnecessary definition of `!=`

### DIFF
--- a/src/traits.jl
+++ b/src/traits.jl
@@ -129,9 +129,6 @@ Length(::Size{S}) where {S} = _Length(S...)
 @pure Base.:(==)(::Size{S}, s::Tuple{Vararg{Int}}) where {S} = S === s
 @pure Base.:(==)(s::Tuple{Vararg{Int}}, ::Size{S}) where {S} = s === S
 
-@pure Base.:(!=)(::Size{S}, s::Tuple{Vararg{Int}}) where {S} = S !== s
-@pure Base.:(!=)(s::Tuple{Vararg{Int}}, ::Size{S}) where {S} = s !== S
-
 @pure Base.prod(::Size{S}) where {S} = prod(S)
 
 Base.LinearIndices(::Size{S}) where {S} = LinearIndices(S)
@@ -143,9 +140,6 @@ Base.LinearIndices(::Size{S}) where {S} = LinearIndices(S)
 
 @pure Base.:(==)(::Length{L}, l::Int) where {L} = L == l
 @pure Base.:(==)(l::Int, ::Length{L}) where {L} = l == L
-
-@pure Base.:(!=)(::Length{L}, l::Int) where {L} = L != l
-@pure Base.:(!=)(l::Int, ::Length{L}) where {L} = l != L
 
 # unroll_tuple also works with `Length`
 @propagate_inbounds unroll_tuple(f, ::Length{L}) where {L} = unroll_tuple(f, Val{L})


### PR DESCRIPTION
`!=` should inline to `!(a == b)` anyways, but by defining those, there is a massive amount of method invalidation going on.
Compile times on master:
```
julia> @time using StaticArrays
[ Info: Precompiling StaticArrays [90137ffa-7385-5640-81b9-e52037218182]
  5.000174 seconds (3.63 M allocations: 227.198 MiB, 0.06% gc time)
```
Compile times on this branch:
```
julia> @time using StaticArrays
[ Info: Precompiling StaticArrays [90137ffa-7385-5640-81b9-e52037218182]
  4.748623 seconds (3.63 M allocations: 227.200 MiB, 0.05% gc time)
```