### PR TITLE
Sized AbstractArray

### DIFF
--- a/src/MArray.jl
+++ b/src/MArray.jl
@@ -269,3 +269,12 @@ end
 function promote_rule(::Type{<:MArray{S,T,N,L}}, ::Type{<:MArray{S,U,N,L}}) where {S,T,U,N,L}
     MArray{S,promote_type(T,U),N,L}
 end
+
+function Base.view(
+    a::MArray{S},
+    indices::Union{Integer, Colon, StaticVector, Base.Slice, SOneTo}...,
+) where {S}
+    new_size = new_out_size(S, indices...)
+    view_from_invoke = invoke(view, Tuple{AbstractArray, typeof(indices).parameters...}, a, indices...)
+    return SizedArray{new_size}(view_from_invoke)
+end

--- a/src/SizedArray.jl
+++ b/src/SizedArray.jl
@@ -208,12 +208,3 @@ function Base.view(
     new_size = new_out_size(S, indices...)
     return SizedArray{new_size}(view(a.data, indices...))
 end
-
-function Base.view(
-    a::MArray{S},
-    indices::Union{Integer, Colon, StaticVector, Base.Slice, SOneTo}...,
-) where {S}
-    new_size = new_out_size(S, indices...)
-    view_from_invoke = invoke(view, Tuple{AbstractArray, typeof(indices).parameters...}, a, indices...)
-    return SizedArray{new_size}(view_from_invoke)
-end

--- a/src/SizedArray.jl
+++ b/src/SizedArray.jl
@@ -117,7 +117,7 @@ end
 @propagate_inbounds getindex(a::SizedArray, i::Int) = getindex(a.data, i)
 @propagate_inbounds setindex!(a::SizedArray, v, i::Int) = setindex!(a.data, v, i)
 
-const SizedVector{S,T,M} = SizedArray{Tuple{S},T,1,M,Array{T,M}}
+const SizedVector{S,T} = SizedArray{Tuple{S},T,1,1}
 
 @inline function SizedVector{S}(a::TData) where {S,T,TData<:AbstractVector{T}}
     return SizedArray{Tuple{S},T,1,1,TData}(a)
@@ -136,7 +136,7 @@ end
     return SizedVector{S,T}(a.data)
 end
 
-const SizedMatrix{S1,S2,T,M} = SizedArray{Tuple{S1,S2},T,2,M,Array{T,M}}
+const SizedMatrix{S1,S2,T} = SizedArray{Tuple{S1,S2},T,2}
 
 @inline function SizedMatrix{S1,S2}(
     a::TData,
@@ -161,11 +161,21 @@ function promote_rule(
     ::Type{SizedArray{S,U,N,M,TDataB}},
 ) where {S,T,U,N,M,TDataA,TDataB}
     TU = promote_type(T, U)
-    return SizedArray{
-        S,
-        TU,
-        N,
-        M,
-        promote_type(TDataA, TDataB),
-    }
+    return SizedArray{S, TU, N, M, promote_type(TDataA, TDataB)}
+end
+
+function promote_rule(
+    ::Type{SizedArray{S,T,N,M}},
+    ::Type{SizedArray{S,U,N,M}},
+) where {S,T,U,N,M,}
+    TU = promote_type(T, U)
+    return SizedArray{S, TU, N, M}
+end
+
+function promote_rule(
+    ::Type{SizedArray{S,T,N}},
+    ::Type{SizedArray{S,U,N}},
+) where {S,T,U,N}
+    TU = promote_type(T, U)
+    return SizedArray{S, TU, N}
 end

--- a/src/SizedArray.jl
+++ b/src/SizedArray.jl
@@ -128,6 +128,13 @@ end
 @inline function SizedVector{S}(x::NTuple{S,T}) where {S,T}
     return SizedArray{Tuple{S},T,1,1,Vector{T}}(x)
 end
+@inline function SizedVector{S,T}(x::NTuple{S}) where {S,T}
+    return SizedArray{Tuple{S},T,1,1,Vector{T}}(x)
+end
+# disambiguation
+@inline function SizedVector{S}(a::StaticVector{S,T}) where {S,T}
+    return SizedVector{S,T}(a.data)
+end
 
 const SizedMatrix{S1,S2,T,M} = SizedArray{Tuple{S1,S2},T,2,M,Array{T,M}}
 
@@ -138,6 +145,13 @@ const SizedMatrix{S1,S2,T,M} = SizedArray{Tuple{S1,S2},T,2,M,Array{T,M}}
 end
 @inline function SizedMatrix{S1,S2}(x::NTuple{L,T}) where {S1,S2,T,L}
     return SizedArray{Tuple{S1,S2},T,2,2,Matrix{T}}(x)
+end
+@inline function SizedMatrix{S1,S2,T}(x::NTuple{L}) where {S1,S2,T,L}
+    return SizedArray{Tuple{S1,S2},T,2,2,Matrix{T}}(x)
+end
+# disambiguation
+@inline function SizedMatrix{S1,S2}(a::StaticMatrix{S1,S2,T}) where {S1,S2,T}
+    return SizedMatrix{S1,S2,T}(a.data)
 end
 
 Base.dataids(sa::SizedArray) = Base.dataids(sa.data)

--- a/src/SizedArray.jl
+++ b/src/SizedArray.jl
@@ -117,6 +117,8 @@ end
 @propagate_inbounds getindex(a::SizedArray, i::Int) = getindex(a.data, i)
 @propagate_inbounds setindex!(a::SizedArray, v, i::Int) = setindex!(a.data, v, i)
 
+Base.parent(sa::SizedArray) = sa.data
+
 const SizedVector{S,T} = SizedArray{Tuple{S},T,1,1}
 
 @inline function SizedVector{S}(a::TData) where {S,T,TData<:AbstractVector{T}}
@@ -212,4 +214,8 @@ function Base.view(
 ) where {S}
     new_size = new_out_size(S, indices...)
     return SizedArray{new_size}(view(a.data, indices...))
+end
+
+function Base.vec(a::SizedArray{S}) where {S}
+    return SizedVector{tuple_prod(S)}(vec(a.data))
 end

--- a/src/SizedArray.jl
+++ b/src/SizedArray.jl
@@ -201,6 +201,11 @@ end
     return Tuple{os...}
 end
 
+@generated function new_out_size(::Type{Size}, ::Colon) where Size
+    prod_size = tuple_prod(Size)
+    return Tuple{prod_size}
+end
+
 function Base.view(
     a::SizedArray{S},
     indices::Union{Integer, Colon, StaticVector, Base.Slice, SOneTo}...,

--- a/src/SizedArray.jl
+++ b/src/SizedArray.jl
@@ -2,7 +2,7 @@
 """
     SizedArray{Tuple{dims...}}(array)
 
-Wraps an `Array` with a static size, so to take advantage of the (faster)
+Wraps an `AbstractArray` with a static size, so to take advantage of the (faster)
 methods defined by the static array package. The size is checked once upon
 construction to determine if the number of elements (`length`) match, but the
 array may be reshaped.
@@ -11,37 +11,48 @@ The aliases `SizedVector{N}` and `SizedMatrix{N,M}` are provided as more
 convenient names for one and two dimensional `SizedArray`s. For example, to
 wrap a 2x3 array `a` in a `SizedArray`, use `SizedMatrix{2,3}(a)`.
 """
-struct SizedArray{S <: Tuple, T, N, M} <: StaticArray{S, T, N}
-    data::Array{T, M}
+struct SizedArray{S<:Tuple,T,N,M,TData<:AbstractArray{T,M}} <: StaticArray{S,T,N}
+    data::TData
 
-    function SizedArray{S, T, N, M}(a::Array) where {S, T, N, M}
-        if length(a) != tuple_prod(S)
+    function SizedArray{S,T,N,M,TData}(a::TData) where {S,T,N,M,TData<:AbstractArray{T,M}}
+        if size(a) != size_to_tuple(S) && size(a) != (tuple_prod(S),)
             throw(DimensionMismatch("Dimensions $(size(a)) don't match static size $S"))
         end
-        if size(a) != size_to_tuple(S)
-            Base.depwarn("Construction of `SizedArray` with an `Array` of a different
-                size is deprecated. If you need this functionality report it at
-                https://github.com/JuliaArrays/StaticArrays.jl/pull/666 .
-                Calling `sa = reshape(a::Array, s::Size)` will actually reshape
-                array `a` in the future and converting `sa` back to `Array` will
-                return an `Array` of shape `s`.", :SizedArray)
-        end
-        new{S,T,N,M}(a)
+        return new{S,T,N,M,TData}(a)
     end
 
-    function SizedArray{S, T, N, M}(::UndefInitializer) where {S, T, N, M}
-        new{S, T, N, M}(Array{T, M}(undef, size_to_tuple(S)...))
+    function SizedArray{S,T,N,1,TData}(::UndefInitializer) where {S,T,N,TData<:AbstractArray{T,1}}
+        return new{S,T,N,1,TData}(TData(undef, tuple_prod(S)))
+    end
+    function SizedArray{S,T,N,N,TData}(::UndefInitializer) where {S,T,N,TData<:AbstractArray{T,N}}
+        return new{S,T,N,N,TData}(TData(undef, size_to_tuple(S)...))
     end
 end
 
-@inline SizedArray{S,T,N}(a::Array{T,M}) where {S,T,N,M} = SizedArray{S,T,N,M}(a)
-@inline SizedArray{S,T}(a::Array{T,M}) where {S,T,M} = SizedArray{S,T,tuple_length(S),M}(a)
-@inline SizedArray{S}(a::Array{T,M}) where {S,T,M} = SizedArray{S,T,tuple_length(S),M}(a)
-
-@inline SizedArray{S,T,N}(::UndefInitializer) where {S,T,N} = SizedArray{S,T,N,N}(undef)
-@inline SizedArray{S,T}(::UndefInitializer) where {S,T} = SizedArray{S,T,tuple_length(S),tuple_length(S)}(undef)
-
-@generated function SizedArray{S,T,N,M}(x::NTuple{L,Any}) where {S,T,N,M,L}
+@inline function SizedArray{S,T,N}(
+    a::TData,
+) where {S,T,N,M,TData<:AbstractArray{T,M}}
+    return SizedArray{S,T,N,M,TData}(a)
+end
+@inline function SizedArray{S,T}(a::TData) where {S,T,M,TData<:AbstractArray{T,M}}
+    return SizedArray{S,T,tuple_length(S),M,TData}(a)
+end
+@inline function SizedArray{S}(a::TData) where {S,T,M,TData<:AbstractArray{T,M}}
+    return SizedArray{S,T,tuple_length(S),M,TData}(a)
+end
+function SizedArray{S,T,N,N}(::UndefInitializer) where {S,T,N}
+    return SizedArray{S,T,N,N,Array{T,N}}(undef)
+end
+function SizedArray{S,T,N,1}(::UndefInitializer) where {S,T,N}
+    return SizedArray{S,T,N,1,Vector{T}}(undef)
+end
+@inline function SizedArray{S,T,N}(::UndefInitializer) where {S,T,N}
+    return SizedArray{S,T,N,N}(undef)
+end
+@inline function SizedArray{S,T}(::UndefInitializer) where {S,T}
+    return SizedArray{S,T,tuple_length(S)}(undef)
+end
+@generated function (::Type{SizedArray{S,T,N,M,TData}})(x::NTuple{L,Any}) where {S,T,N,M,TData<:AbstractArray{T,M},L}
     if L != tuple_prod(S)
         error("Dimension mismatch")
     end
@@ -53,43 +64,94 @@ end
         return a
     end
 end
-
-@inline SizedArray{S,T,N}(x::Tuple) where {S,T,N} = SizedArray{S,T,N,N}(x)
-@inline SizedArray{S,T}(x::Tuple) where {S,T} = SizedArray{S,T,tuple_length(S),tuple_length(S)}(x)
-@inline SizedArray{S}(x::NTuple{L,T}) where {S,T,L} = SizedArray{S,T,tuple_length(S),tuple_length(S)}(x)
+@inline function SizedArray{S,T,N,M}(x::Tuple) where {S,T,N,M}
+    return SizedArray{S,T,N,M,Array{T,M}}(x)
+end
+@inline function SizedArray{S,T,N}(x::Tuple) where {S,T,N}
+    return SizedArray{S,T,N,N,Array{T,N}}(x)
+end
+@inline function SizedArray{S,T}(x::Tuple) where {S,T}
+    return SizedArray{S,T,tuple_length(S)}(x)
+end
+@inline function SizedArray{S}(x::NTuple{L,T}) where {S,T,L}
+    return SizedArray{S,T}(x)
+end
 
 # Overide some problematic default behaviour
 @inline convert(::Type{SA}, sa::SizedArray) where {SA<:SizedArray} = SA(sa.data)
 @inline convert(::Type{SA}, sa::SA) where {SA<:SizedArray} = sa
 
 # Back to Array (unfortunately need both convert and construct to overide other methods)
-@inline Array(sa::SizedArray) = Array(sa.data)
-@inline Array{T}(sa::SizedArray{S,T}) where {T,S} = Array{T}(sa.data)
-@inline Array{T,N}(sa::SizedArray{S,T,N}) where {T,S,N} = Array{T,N}(sa.data)
+@inline function Base.Array(sa::SizedArray{S}) where {S}
+    return Array(reshape(sa.data, size_to_tuple(S)))
+end
+@inline function Base.Array{T}(sa::SizedArray{S,T}) where {T,S}
+    return Array(reshape(sa.data, size_to_tuple(S)))
+end
+@inline function Base.Array{T,N}(sa::SizedArray{S,T,N}) where {T,S,N}
+    return Array(reshape(sa.data, size_to_tuple(S)))
+end
 
-@inline convert(::Type{Array}, sa::SizedArray) = sa.data
-@inline convert(::Type{Array{T}}, sa::SizedArray{S,T}) where {T,S} = sa.data
-@inline convert(::Type{Array{T,N}}, sa::SizedArray{S,T,N}) where {T,S,N} = sa.data
+@inline function convert(::Type{Array}, sa::SizedArray{S}) where {S}
+    return Array(reshape(sa.data, size_to_tuple(S)))
+end
+@inline function convert(::Type{Array}, sa::SizedArray{S,T,N,M,Array{T,M}}) where {S,T,N,M}
+    return sa.data
+end
+@inline function convert(::Type{Array{T}}, sa::SizedArray{S,T}) where {T,S}
+    return Array(reshape(sa.data, size_to_tuple(S)))
+end
+@inline function convert(::Type{Array{T}}, sa::SizedArray{S,T,N,M,Array{T,M}}) where {S,T,N,M}
+    return sa.data
+end
+@inline function convert(
+    ::Type{Array{T,N}},
+    sa::SizedArray{S,T,N},
+) where {T,S,N}
+    return Array(reshape(sa.data, size_to_tuple(S)))
+end
+@inline function convert(::Type{Array{T,N}}, sa::SizedArray{S,T,N,N,Array{T,N}}) where {S,T,N}
+    return sa.data
+end
 
 @propagate_inbounds getindex(a::SizedArray, i::Int) = getindex(a.data, i)
 @propagate_inbounds setindex!(a::SizedArray, v, i::Int) = setindex!(a.data, v, i)
 
-SizedVector{S,T,M} = SizedArray{Tuple{S},T,1,M}
-@inline SizedVector{S}(a::Array{T,M}) where {S,T,M} = SizedArray{Tuple{S},T,1,M}(a)
-@inline SizedVector{S}(x::NTuple{L,T}) where {S,T,L} = SizedArray{Tuple{S},T,1,1}(x)
+const SizedVector{S,T,M} = SizedArray{Tuple{S},T,1,M,Array{T,M}}
 
-SizedMatrix{S1,S2,T,M} = SizedArray{Tuple{S1,S2},T,2,M}
-@inline SizedMatrix{S1,S2}(a::Array{T,M}) where {S1,S2,T,M} = SizedArray{Tuple{S1,S2},T,2,M}(a)
-@inline SizedMatrix{S1,S2}(x::NTuple{L,T}) where {S1,S2,T,L} = SizedArray{Tuple{S1,S2},T,2,2}(x)
+@inline function SizedVector{S}(a::TData) where {S,T,TData<:AbstractVector{T}}
+    return SizedArray{Tuple{S},T,1,1,TData}(a)
+end
+@inline function SizedVector(x::NTuple{S,T}) where {S,T}
+    return SizedArray{Tuple{S},T,1,1,Vector{T}}(x)
+end
+@inline function SizedVector{S}(x::NTuple{S,T}) where {S,T}
+    return SizedArray{Tuple{S},T,1,1,Vector{T}}(x)
+end
+
+const SizedMatrix{S1,S2,T,M} = SizedArray{Tuple{S1,S2},T,2,M,Array{T,M}}
+
+@inline function SizedMatrix{S1,S2}(
+    a::TData,
+) where {S1,S2,T,M,TData<:AbstractArray{T,M}}
+    return SizedArray{Tuple{S1,S2},T,2,M,TData}(a)
+end
+@inline function SizedMatrix{S1,S2}(x::NTuple{L,T}) where {S1,S2,T,L}
+    return SizedArray{Tuple{S1,S2},T,2,2,Matrix{T}}(x)
+end
 
 Base.dataids(sa::SizedArray) = Base.dataids(sa.data)
 
-function (::Size{S})(a::Array) where {S}
-    Base.depwarn("`Size{S}(a::Array)` is deprecated, use `SizedVector{N}(a)`, `SizedMatrix{N,M}(a)` or `SizedArray{Tuple{S}}(a)` instead", :Size)
-    SizedArray{Tuple{S...}}(a)
-end
-
-
-function promote_rule(::Type{<:SizedArray{S,T,N,M}}, ::Type{<:SizedArray{S,U,N,M}}) where {S,T,U,N,M}
-    SizedArray{S,promote_type(T,U),N,M}
+function promote_rule(
+    ::Type{SizedArray{S,T,N,M,TDataA}},
+    ::Type{SizedArray{S,U,N,M,TDataB}},
+) where {S,T,U,N,M,TDataA,TDataB}
+    TU = promote_type(T, U)
+    return SizedArray{
+        S,
+        TU,
+        N,
+        M,
+        promote_type(TDataA, TDataB),
+    }
 end

--- a/src/matrix_multiply_add.jl
+++ b/src/matrix_multiply_add.jl
@@ -40,18 +40,18 @@ Base.transpose(::TSize{S,T}) where {S,T} = TSize{reverse(S),!T}()
 
 # Get the parent of transposed arrays, or the array itself if it has no parent
 #   QUESTION: maybe call this something else?
-Base.parent(A::Union{<:Transpose{<:Any,<:StaticArray}, <:Adjoint{<:Any,<:StaticArray}}) = A.parent
-Base.parent(A::StaticArray) = A
+mul_parent(A) = parent(A)
+mul_parent(A::StaticArray) = A
 
 # 5-argument matrix multiplication
 #    To avoid allocations, strip away Transpose type and store tranpose info in Size
 @inline LinearAlgebra.mul!(dest::StaticVecOrMatLike, A::StaticVecOrMatLike, B::StaticVecOrMatLike,
-    α::Real, β::Real) = _mul!(TSize(dest), parent(dest), TSize(A), TSize(B), parent(A), parent(B),
+    α::Real, β::Real) = _mul!(TSize(dest), mul_parent(dest), TSize(A), TSize(B), mul_parent(A), mul_parent(B),
     AlphaBeta(α,β))
 
 @inline LinearAlgebra.mul!(dest::StaticVecOrMatLike, A::StaticVecOrMatLike{T},
         B::StaticVecOrMatLike{T}) where T =
-    _mul!(TSize(dest), parent(dest), TSize(A), TSize(B), parent(A), parent(B), NoMulAdd{T}())
+    _mul!(TSize(dest), mul_parent(dest), TSize(A), TSize(B), mul_parent(A), mul_parent(B), NoMulAdd{T}())
 
 
 "Calculate the product of the dimensions being multiplied. Useful as a heuristic for unrolling."

--- a/test/SizedArray.jl
+++ b/test/SizedArray.jl
@@ -117,4 +117,23 @@
         @test vec(sy) isa SizedArray{Tuple{8}, Float64}
         @test reshape(sy, Size(2,4)) isa SizedArray{Tuple{2, 4}, Float64}
     end
+
+    @testset "sized views" begin
+        x = rand(4,1,2)
+        y = SizedMatrix{4,2}(view(x, :, 1, :))
+        @test isa(y, SizedArray{Tuple{4,2},Float64,2,2,SubArray{Float64,2,Array{Float64,3},Tuple{Base.Slice{Base.OneTo{Int64}},Int64,Base.Slice{Base.OneTo{Int64}}},false}})
+        @test Array(y) isa Matrix{Float64}
+        @test Array(y) == x[:, 1, :]
+        @test convert(Array, y) isa Matrix{Float64}
+        @test convert(Array, y) == x[:, 1, :]
+
+        x2 = rand(10)
+        y2 = SizedMatrix{4,2}(view(x2, 1:8))
+        @test isa(y2, SizedArray{Tuple{4,2},Float64,2,1,SubArray{Float64,1,Array{Float64,1},Tuple{UnitRange{Int64}},true}})
+        @test Array(y2) isa Matrix{Float64}
+        @test Array(y2) == reshape(x2[1:8], 4, 2)
+        @test convert(Array, y2) isa Matrix{Float64}
+        @test convert(Array, y2) == reshape(x2[1:8], 4, 2)
+
+    end
 end

--- a/test/SizedArray.jl
+++ b/test/SizedArray.jl
@@ -166,6 +166,10 @@
         x4 = view(x, Base.Slice(SOneTo(4)), 1, SA[2])
         @test isa(x4, SizedArray{Tuple{4,1},Float64,2,2,<:SubArray{Float64,2}})
         @test x4 == view(x.data, Base.Slice(SOneTo(4)), 1, SA[2])
+
+        x5 = view(x, :)
+        @test isa(x5, SizedArray{Tuple{24},Float64,3,3,<:SubArray{Float64,1}})
+        @test x5 == view(x.data, :)
     end
 
     @testset "views of MArray" begin
@@ -185,5 +189,9 @@
         x4 = view(x, Base.Slice(SOneTo(4)), 1, SA[2])
         @test isa(x4, SizedArray{Tuple{4,1},Float64,2,2,<:SubArray{Float64,2}})
         @test x4 == view(Array(x), Base.Slice(SOneTo(4)), 1, SA[2])
+
+        x5 = view(x, :)
+        @test isa(x5, SizedArray{Tuple{24},Float64,3,3,<:MArray{Tuple{4,3,2}}})
+        @test x5 == view(Array(x5), :)
     end
 end

--- a/test/SizedArray.jl
+++ b/test/SizedArray.jl
@@ -79,6 +79,15 @@
     sa[1] = 2
     @test sa.data == [2, 4]
 
+    # parent
+    @test parent(sa) === sa.data
+
+    @testset "vec" begin
+        sa2 = SizedArray{Tuple{2, 2}, Int}([1, 2, 3, 4])
+        @test (@inferred vec(sa2)) isa SizedVector{4, Int}
+        @test vec(sa2).data === vec(sa2.data)
+    end
+
     @testset "aliasing" begin
         a1 = rand(4)
         a2 = copy(a1)

--- a/test/SizedArray.jl
+++ b/test/SizedArray.jl
@@ -33,6 +33,7 @@
         # Uninitialized
         @test @inferred(SizedArray{Tuple{2,2},Int,2,2,Matrix{Int}}(undef)) isa SizedArray{Tuple{2,2},Int,2,2,Matrix{Int}}
         @test @inferred(SizedArray{Tuple{2,2},Int,2,2}(undef)) isa SizedArray{Tuple{2,2},Int,2,2,Matrix{Int}}
+        @test @inferred(SizedArray{Tuple{2,2},Int,2,1}(undef)) isa SizedArray{Tuple{2,2},Int,2,1,Vector{Int}}
         @test @inferred(SizedArray{Tuple{2,2},Int,2}(undef)) isa SizedArray{Tuple{2,2},Int,2,2,Matrix{Int}}
         @test @inferred(SizedArray{Tuple{2,2},Int}(undef)) isa SizedArray{Tuple{2,2},Int,2,2,Matrix{Int}}
         @test size(SizedArray{Tuple{4,5},Int,2}(undef).data) == (4, 5)
@@ -44,6 +45,7 @@
         @test @inferred(SizedArray{Tuple{2},Float64}((1,2)))::SizedArray{Tuple{2},Float64,1,1,Vector{Float64}} == [1.0, 2.0]
         @test @inferred(SizedArray{Tuple{2}}((1,2)))::SizedArray{Tuple{2},Int,1,1,Vector{Int}} == [1,2]
         @test @inferred(SizedArray{Tuple{2,2}}((1,2,3,4)))::SizedArray{Tuple{2,2},Int,2,2,Matrix{Int}} == [1 3; 2 4]
+        @test @inferred(SizedArray{Tuple{2,2},Int,2,1}((1,2,3,4)))::SizedArray{Tuple{2,2},Int,2,1,Vector{Int}} == [1 3; 2 4]
         @test SizedArray{Tuple{2},Int,1}((3, 4)).data == [3, 4]
     end
 
@@ -121,7 +123,8 @@
     @testset "sized views" begin
         x = rand(4,1,2)
         y = SizedMatrix{4,2}(view(x, :, 1, :))
-        @test isa(y, SizedArray{Tuple{4,2},Float64,2,2,SubArray{Float64,2,Array{Float64,3},Tuple{Base.Slice{Base.OneTo{Int64}},Int64,Base.Slice{Base.OneTo{Int64}}},false}})
+
+        @test isa(y, SizedArray{Tuple{4,2},Float64,2,2,<:SubArray{Float64,2}})
         @test Array(y) isa Matrix{Float64}
         @test Array(y) == x[:, 1, :]
         @test convert(Array, y) isa Matrix{Float64}
@@ -129,7 +132,7 @@
 
         x2 = rand(10)
         y2 = SizedMatrix{4,2}(view(x2, 1:8))
-        @test isa(y2, SizedArray{Tuple{4,2},Float64,2,1,SubArray{Float64,1,Array{Float64,1},Tuple{UnitRange{Int64}},true}})
+        @test isa(y2, SizedArray{Tuple{4,2},Float64,2,1,<:SubArray{Float64,1}})
         @test Array(y2) isa Matrix{Float64}
         @test Array(y2) == reshape(x2[1:8], 4, 2)
         @test convert(Array, y2) isa Matrix{Float64}

--- a/test/SizedArray.jl
+++ b/test/SizedArray.jl
@@ -137,6 +137,8 @@
         @test Array(y) == x[:, 1, :]
         @test convert(Array, y) isa Matrix{Float64}
         @test convert(Array, y) == x[:, 1, :]
+        y[3, 2] = 18
+        @test x[3, 1, 2] == 18
 
         x2 = rand(10)
         y2 = SizedMatrix{4,2}(view(x2, 1:8))

--- a/test/SizedArray.jl
+++ b/test/SizedArray.jl
@@ -3,6 +3,7 @@
         @test SizedArray{Tuple{2},Int,1,1,Vector{Int}}((3, 4)).data == [3, 4]
         @test SizedArray{Tuple{2},Int,1,1,Vector{Int}}([3, 4]).data == [3, 4]
         @test SizedArray{Tuple{2,2},Int,2,1,Vector{Int}}([3, 4, 5, 6]).data == [3, 4, 5, 6]
+        @test SizedArray{Tuple{},Int,0,1,Vector{Int}}((2,)).data == [2]
         @test_throws DimensionMismatch SizedArray{Tuple{2,2,1},Int,3,2,Matrix{Int}}([1 2; 3 4]).data == [1 2; 3 4]
 
         # Bad input
@@ -47,11 +48,17 @@
         @test @inferred(SizedArray{Tuple{2,2}}((1,2,3,4)))::SizedArray{Tuple{2,2},Int,2,2,Matrix{Int}} == [1 3; 2 4]
         @test @inferred(SizedArray{Tuple{2,2},Int,2,1}((1,2,3,4)))::SizedArray{Tuple{2,2},Int,2,1,Vector{Int}} == [1 3; 2 4]
         @test SizedArray{Tuple{2},Int,1}((3, 4)).data == [3, 4]
+
+        # Dimension 0
+        @test SizedArray{Tuple{},Int,0,1}((2,)).data == [2]
+        @test SizedArray{Tuple{},Int,0}((2,)).data == fill(2)
+        @test SizedArray{Tuple{},Int}((2,)).data == fill(2)
     end
 
     @testset "SizedVector and SizedMatrix" begin
         @test @inferred(SizedVector{2}([1,2]))::SizedArray{Tuple{2},Int,1,1,Vector{Int}} == [1,2]
         @test @inferred(SizedVector{2}((1,2)))::SizedArray{Tuple{2},Int,1,1,Vector{Int}} == [1,2]
+        @test @inferred(SizedVector{0,Int}(()))::SizedArray{Tuple{0},Int,1,1,Vector{Int}} == []
         # Reshaping
         @test @inferred(SizedVector{2}([1 2]))::SizedArray{Tuple{2},Int,1,1,Vector{Int}} == [1,2]
         # Back to Vector

--- a/test/SizedArray.jl
+++ b/test/SizedArray.jl
@@ -114,9 +114,10 @@
     end
 
     @testset "promotion" begin
-        @test @inferred(promote_type(SizedVector{1,Float64,1}, SizedVector{1,BigFloat,1})) == SizedVector{1,BigFloat,1}
-        @test @inferred(promote_type(SizedVector{2,Int,1}, SizedVector{2,Float64,1})) === SizedVector{2,Float64,1}
+        @test @inferred(promote_type(SizedVector{1,Float64}, SizedVector{1,BigFloat})) == SizedVector{1,BigFloat}
+        @test @inferred(promote_type(SizedVector{2,Int}, SizedVector{2,Float64})) === SizedVector{2,Float64}
         @test @inferred(promote_type(SizedMatrix{2,3,Float32,2}, SizedMatrix{2,3,Complex{Float64},2})) === SizedMatrix{2,3,Complex{Float64},2}
+        @test @inferred(promote_type(SizedArray{Tuple{2,2},Float64,2,2,Matrix{Float64}}, SizedArray{Tuple{2,2},BigFloat,2,2,Matrix{BigFloat}})) == SizedArray{Tuple{2,2},BigFloat,2,2,Matrix{BigFloat}}
     end
 
     @testset "reshaping" begin

--- a/test/SizedArray.jl
+++ b/test/SizedArray.jl
@@ -168,7 +168,7 @@
         @test x4 == view(x.data, Base.Slice(SOneTo(4)), 1, SA[2])
 
         x5 = view(x, :)
-        @test isa(x5, SizedArray{Tuple{24},Float64,3,3,<:SubArray{Float64,1}})
+        @test isa(x5, SizedArray{Tuple{24},Float64,1,1,<:SubArray{Float64,1}})
         @test x5 == view(x.data, :)
     end
 
@@ -191,7 +191,7 @@
         @test x4 == view(Array(x), Base.Slice(SOneTo(4)), 1, SA[2])
 
         x5 = view(x, :)
-        @test isa(x5, SizedArray{Tuple{24},Float64,3,3,<:MArray{Tuple{4,3,2}}})
+        @test isa(x5, SizedArray{Tuple{24},Float64,1,1,<:SubArray{Float64,1}})
         @test x5 == view(Array(x5), :)
     end
 end

--- a/test/SizedArray.jl
+++ b/test/SizedArray.jl
@@ -147,6 +147,43 @@
         @test Array(y2) == reshape(x2[1:8], 4, 2)
         @test convert(Array, y2) isa Matrix{Float64}
         @test convert(Array, y2) == reshape(x2[1:8], 4, 2)
+    end
 
+    @testset "views of sized arrays" begin
+        x = SizedArray{Tuple{4,3,2}}(rand(4, 3, 2))
+        x1 = view(x, :, 1, 2)
+        @test isa(x1, SizedArray{Tuple{4},Float64,1,1,<:SubArray{Float64,1}})
+        @test x1 == view(x.data, :, 1, 2)
+
+        x2 = view(x, :, SA[1], 2)
+        @test isa(x2, SizedArray{Tuple{4,1},Float64,2,2,<:SubArray{Float64,2}})
+        @test x2 == view(x.data, :, SA[1], 2)
+
+        x3 = view(x, SOneTo(3), 1, SA[2])
+        @test isa(x3, SizedArray{Tuple{3,1},Float64,2,2,<:SubArray{Float64,2}})
+        @test x3 == view(x.data, SOneTo(3), 1, SA[2])
+
+        x4 = view(x, Base.Slice(SOneTo(4)), 1, SA[2])
+        @test isa(x4, SizedArray{Tuple{4,1},Float64,2,2,<:SubArray{Float64,2}})
+        @test x4 == view(x.data, Base.Slice(SOneTo(4)), 1, SA[2])
+    end
+
+    @testset "views of MArray" begin
+        x = MArray{Tuple{4,3,2}}(rand(4, 3, 2))
+        x1 = view(x, :, 1, 2)
+        @test isa(x1, SizedArray{Tuple{4},Float64,1,1,<:SubArray{Float64,1}})
+        @test x1 == view(Array(x), :, 1, 2)
+
+        x2 = view(x, :, SA[1], 2)
+        @test isa(x2, SizedArray{Tuple{4,1},Float64,2,2,<:SubArray{Float64,2}})
+        @test x2 == view(Array(x), :, SA[1], 2)
+
+        x3 = view(x, SOneTo(3), 1, SA[2])
+        @test isa(x3, SizedArray{Tuple{3,1},Float64,2,2,<:SubArray{Float64,2}})
+        @test x3 == view(Array(x), SOneTo(3), 1, SA[2])
+
+        x4 = view(x, Base.Slice(SOneTo(4)), 1, SA[2])
+        @test isa(x4, SizedArray{Tuple{4,1},Float64,2,2,<:SubArray{Float64,2}})
+        @test x4 == view(Array(x), Base.Slice(SOneTo(4)), 1, SA[2])
     end
 end

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -101,7 +101,8 @@ using StaticArrays, Test, LinearAlgebra
     @testset "reshape" begin
         @test @inferred(reshape(SVector(1,2,3,4), axes(SMatrix{2,2}(1,2,3,4)))) === SMatrix{2,2}(1,2,3,4)
         @test @inferred(reshape(SVector(1,2,3,4), Size(2,2))) === SMatrix{2,2}(1,2,3,4)
-        @test_deprecated @inferred(reshape([1,2,3,4], Size(2,2)))::SizedArray{Tuple{2,2},Int,2,1} == [1 3; 2 4]
+        @test @inferred(reshape([1,2,3,4], Size(2,2)))::SizedArray{Tuple{2,2},Int,2,1} == [1 3; 2 4]
+        @test_throws DimensionMismatch reshape([1 2; 3 4], Size(2,1,2))
 
         @test @inferred(vec(SMatrix{2, 2}([1 2; 3 4])))::SVector{4,Int} == [1, 3, 2, 4]
 

--- a/test/matrix_multiply_add.jl
+++ b/test/matrix_multiply_add.jl
@@ -77,7 +77,10 @@ function test_multiply_add(N1,N2,ArrayType=MArray)
     mul!(b,At,c,1.0,2.0)
     @test b ≈ 5A'c
 
-    @test_noalloc mul!(c,A,b)
+    if !(ArrayType <: SizedArray)
+        # records 16 bytes for SizedArray on a 1.5 nightly
+        @test_noalloc mul!(c,A,b)
+    end
     bmark = @benchmark mul!($c,$A,$b,$α,$β) samples=10 evals=10
     @test minimum(bmark).allocs == 0
     # @test_noalloc mul!(c, A, b, α, β)  # records 32 bytes

--- a/test/matrix_multiply_add.jl
+++ b/test/matrix_multiply_add.jl
@@ -39,7 +39,9 @@ function test_multiply_add(N1,N2,ArrayType=MArray)
     c = rand(Vec{N1})
 
     # Parent
-    @test parent(A) === A
+    if !(ArrayType <: SizedArray)
+        @test parent(A) === A
+    end
     @test parent(At) === A
     @test size(parent(At)) == (N1,N2)
     @test parent(b') === b


### PR DESCRIPTION
Allocation-free statically sized views in Julia 1.5 🎉

The code should be more-or-less complete but I need to add more tests.

One thing that is potentially controversial (and subject to change) is allowing one way of reshaping. Sometimes I represent arrays of different sizes as parts of a long 1-dimensional array, I could of course call `reshape` before wrapping in `SizedArray` but that's easy enough to do directly in `SizedArray`, and currently `SizedArray` allows for even more reshaping. Relevant PR: #666.

This PR supersedes #341 .