### PR TITLE
remove ambiguity in unsafe_convert with RefValue

### DIFF
--- a/src/SArray.jl
+++ b/src/SArray.jl
@@ -66,7 +66,7 @@ Base.dataids(::SArray) = ()
 
 # See #53
 Base.cconvert(::Type{Ptr{T}}, a::SArray) where {T} = Base.RefValue(a)
-Base.unsafe_convert(::Type{Ptr{T}}, a::Base.RefValue{SArray{S,T,D,L}}) where {S,T,D,L} =
+Base.unsafe_convert(::Type{Ptr{T}}, a::Base.RefValue{SA}) where {S,T,D,L,SA<:SArray{S,T,D,L}} =
     Ptr{T}(Base.unsafe_convert(Ptr{SArray{S,T,D,L}}, a))
 
 macro SArray(ex)


### PR DESCRIPTION
Before:
```
julia> detect_ambiguities(Base, LinearAlgebra, StaticArrays)
2-element Array{Tuple{Method,Method},1}:
 (unsafe_convert(::Type{Ptr{T}}, a::Base.RefValue{SArray{S,T,D,L}}) where {S, T, D, L} in StaticArrays at /home/steve/.julia/dev/StaticArrays/src/SArray.jl:69, unsafe_convert(::Type{Ptr{Nothing}}, b::Base.RefValue{T}) where T in Base at refvalue.jl:30)
 (convert(::Type{SA}, a::AbstractArray) where SA<:(SArray{Tuple{},T,0,1} where T) in StaticArrays at /home/steve/.julia/dev/StaticArrays/src/Scalar.jl:13, convert(::Type{SA}, sa::StaticArray) where SA<:StaticArray in StaticArrays at /home/steve/.julia/dev/StaticArrays/src/convert.jl:10)

```

After:
```
julia> detect_ambiguities(Base, LinearAlgebra, StaticArrays)
1-element Array{Tuple{Method,Method},1}:
 (convert(::Type{SA}, a::AbstractArray) where SA<:(SArray{Tuple{},T,0,1} where T) in StaticArrays at /home/steve/.julia/dev/StaticArrays/src/Scalar.jl:13, convert(::Type{SA}, sa::StaticArray) where SA<:StaticArray in StaticArrays at /home/steve/.julia/dev/StaticArrays/src/convert.jl:10
```

The remaining ambiguity is covered by #774
