### PR TITLE
Ensure `full` is constant propagated in `svd(A,full=false)`

### DIFF
--- a/src/svd.jl
+++ b/src/svd.jl
@@ -37,7 +37,9 @@ function svd(A::StaticMatrix; full=Val(false))
 end
 
 # Allow plain Bool in addition to Val
-_svd(A, full) = _svd(A, Val(convert(Bool, full)))
+# Required inline as of version 1.5 to ensure Bool usage like svd(A,
+# full=false) is constant-propagated
+@inline _svd(A, full) = _svd(A, Val(convert(Bool, full)))
 
 function _svd(A, full::Val{false})
     f = svd(Matrix(A), full=false)

--- a/test/svd.jl
+++ b/test/svd.jl
@@ -71,6 +71,14 @@ using StaticArrays, Test, LinearAlgebra
         @testinf svd(m_sing2'; full=Val(true)) \ v2 ≈ svd(Matrix(m_sing2'); full=true) \ Vector(v2)
         @testinf svd(m_sing2; full=Val(true)) \ m23' ≈ svd(Matrix(m_sing2); full=true) \ Matrix(m23')
         @testinf svd(m_sing2'; full=Val(true)) \ m23 ≈ svd(Matrix(m_sing2'); full=true) \ Matrix(m23)
+        if VERSION >= v"1.5-DEV"
+            # Test that svd of rectangular matrix is inferred.
+            # Note the placement of @inferred brackets is important.
+            #
+            # This only seems to work on >= v"1.5" due to unknown compiler improvements.
+            svd_full_false(A) = svd(m_sing2, full=false)
+            @test @inferred(svd_full_false(m_sing2)).S ≈ svd(Matrix(m_sing2)).S
+        end
 
         @testinf svd(mc_sing) \ v ≈ svd(Matrix(mc_sing)) \ Vector(v)
         @testinf svd(mc_sing) \ vc ≈ svd(Matrix(mc_sing)) \ Vector(vc)


### PR DESCRIPTION
This workaround allows the LinearAlgebra implementation of `pinv` to be
inferred on julia 1.5-rc1 and 1.6-DEV. Unfortunately the extra inline
annotation doesn't seem to work on lower Julia versions.

Fixes #803 on newer Julia versions