### PR TITLE
Resolve ambiguity for `convert(::Type{<:Scalar}, ::StaticArray)`

### DIFF
--- a/src/convert.jl
+++ b/src/convert.jl
@@ -8,7 +8,7 @@
 
 # this covers most conversions and "statically-sized reshapes"
 @inline convert(::Type{SA}, sa::StaticArray) where {SA<:StaticArray} = SA(Tuple(sa))
-@inline convert(::Type{SA}, sa::StaticArray) where {SA<:Scalar} = SA((sa[],))
+@inline convert(::Type{SA}, sa::StaticArray) where {SA<:Scalar} = SA((sa[],)) # disambiguation
 @inline convert(::Type{SA}, sa::SA) where {SA<:StaticArray} = sa
 @inline convert(::Type{SA}, x::Tuple) where {SA<:StaticArray} = SA(x) # convert -> constructor. Hopefully no loops...
 

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -8,6 +8,7 @@
 
 # this covers most conversions and "statically-sized reshapes"
 @inline convert(::Type{SA}, sa::StaticArray) where {SA<:StaticArray} = SA(Tuple(sa))
+@inline convert(::Type{SA}, sa::StaticArray) where {SA<:Scalar} = SA((sa[],))
 @inline convert(::Type{SA}, sa::SA) where {SA<:StaticArray} = sa
 @inline convert(::Type{SA}, x::Tuple) where {SA<:StaticArray} = SA(x) # convert -> constructor. Hopefully no loops...
 

--- a/test/ambiguities.jl
+++ b/test/ambiguities.jl
@@ -3,9 +3,9 @@
 
 const allowable_ambiguities =
     if VERSION < v"1.1"
-        4
+        3
     elseif VERSION < v"1.2"
-        2
+        1
     else
         0
     end

--- a/test/ambiguities.jl
+++ b/test/ambiguities.jl
@@ -7,7 +7,7 @@ const allowable_ambiguities =
     elseif VERSION < v"1.2"
         2
     else
-        1
+        0
     end
 
 @test length(detect_ambiguities(Base, LinearAlgebra, StaticArrays)) <= allowable_ambiguities

--- a/test/convert.jl
+++ b/test/convert.jl
@@ -14,4 +14,8 @@ end # testset
     # Issue #651
     @testinf SVector{0,Float64}(Any[]) === SVector{0,Float64}()
     @testinf SVector{0,Float64}(Int8[]) === SVector{0,Float64}()
+
+    # PR #808
+    @test Scalar{Int}[SVector{1,Int}(3), SVector{1,Float64}(2.0)] == [Scalar{Int}(3), Scalar{Int}(2)]
+    @test Scalar[SVector{1,Int}(3), SVector{1,Float64}(2.0)] == [Scalar{Int}(3), Scalar{Float64}(2.0)]
 end


### PR DESCRIPTION
This PR fixes a method ambiguity in StaticArrays.jl. I found it while testing my package (which depends on StaticArrays.jl) with [Aqua.jl](https://github.com/JuliaTesting/Aqua.jl) and it popped up because I was overloading `convert` (for something completely unrelated).

Before this PR:
```julia
julia> using StaticArrays

julia> Scalar{Int}[SVector{1,Int}(3)]
ERROR: MethodError: convert(::Type{Scalar{Int64}}, ::SVector{1,Int64}) is ambiguous. Candidates:
  convert(::Type{SA}, a::AbstractArray) where SA<:(Scalar{T} where T) in StaticArrays at /home/liozou/.julia/dev/StaticArrays/src/Scalar.jl:12
  convert(::Type{SA}, sa::StaticArray) where SA<:StaticArray in StaticArrays at /home/liozou/.julia/dev/StaticArrays/src/convert.jl:10
Possible fix, define
  convert(::Type{SA}, ::StaticArray) where SA<:(Scalar{T} where T)
Stacktrace:
 [1] setindex!(A::Vector{Scalar{Int64}}, x::SVector{1,Int64}, i1::Int64)
   @ Base ./array.jl:849
 [2] getindex(#unused#::Type{Scalar{Int64}}, x::SVector{1,Int64})
   @ Base ./array.jl:416
 [3] top-level scope
   @ none:1

julia> Scalar[SVector{1,Float64}(2.0)]
ERROR: MethodError: convert(::Type{Scalar{T} where T}, ::SVector{1,Float64}) is ambiguous. Candidates:
  convert(::Type{SA}, a::AbstractArray) where SA<:(Scalar{T} where T) in StaticArrays at /home/liozou/.julia/dev/StaticArrays/src/Scalar.jl:12
  convert(::Type{SA}, sa::StaticArray) where SA<:StaticArray in StaticArrays at /home/liozou/.julia/dev/StaticArrays/src/convert.jl:10
Possible fix, define
  convert(::Type{SA}, ::StaticArray) where SA<:(Scalar{T} where T)
Stacktrace:
 [1] setindex!(A::Vector{Scalar{T} where T}, x::SVector{1,Float64}, i1::Int64)
   @ Base ./array.jl:849
 [2] getindex(#unused#::Type{Scalar{T} where T}, x::SVector{1,Float64})
   @ Base ./array.jl:416
 [3] top-level scope
   @ none:1
```

With this PR:
```julia
julia> Scalar{Int}[SVector{1,Int}(3)]
1-element Vector{Scalar{Int64}}:
 Scalar{Int64}((3,))

julia> Scalar[SVector{1,Float64}(2.0)]
1-element Vector{Scalar{T} where T}:
 Scalar{Float64}((2.0,))
```