### PR TITLE
Fix nightly CI tests

### DIFF
--- a/test/ambiguities.jl
+++ b/test/ambiguities.jl
@@ -10,8 +10,11 @@ const allowable_ambiguities =
         1
     end
 
-@static if VERSION < v"1.6-"
-   @test length(detect_ambiguities(Base, LinearAlgebra, StaticArrays)) <= allowable_ambiguities
+if v"1.6.0-DEV.816" <= VERSION < v"1.6.0-rc"
+    # Revisit in 1.6.0-rc1 or before. See
+    #   https://github.com/JuliaLang/julia/pull/36962
+    #   https://github.com/JuliaLang/julia/issues/36951
+    @test_broken length(detect_ambiguities(#=LinearAlgebra, =#StaticArrays)) <= allowable_ambiguities
 else
-   @test_broken length(detect_ambiguities(#=LinearAlgebra, =#StaticArrays)) <= allowable_ambiguities
+    @test length(detect_ambiguities(Base, LinearAlgebra, StaticArrays)) <= allowable_ambiguities
 end

--- a/test/ambiguities.jl
+++ b/test/ambiguities.jl
@@ -10,4 +10,8 @@ const allowable_ambiguities =
         1
     end
 
-@test length(detect_ambiguities(Base, LinearAlgebra, StaticArrays)) <= allowable_ambiguities
+@static if VERSION < v"1.6-"
+   @test length(detect_ambiguities(Base, LinearAlgebra, StaticArrays)) <= allowable_ambiguities
+else
+   @test_broken length(detect_ambiguities(#=LinearAlgebra, =#StaticArrays)) <= allowable_ambiguities
+end

--- a/test/core.jl
+++ b/test/core.jl
@@ -19,7 +19,11 @@
     @testset "Type parameter errors" begin
         # (not sure what type of exception these should be?)
         @test_throws Exception SVector{1.0,Int}((1,))
-        @test_throws DimensionMismatch("No precise constructor for SArray{Tuple{2},$Int,1,2} found. Length of input was 1.") SVector{2,Int}((1,))
+        @static if VERSION < v"1.6-"
+            @test_throws DimensionMismatch("No precise constructor for SArray{Tuple{2},$Int,1,2} found. Length of input was 1.") SVector{2,Int}((1,))
+        else
+            @test_throws DimensionMismatch("No precise constructor for SVector{2,$Int} found. Length of input was 1.") SVector{2,Int}((1,))
+        end
         @test_throws Exception SVector{1,3}((1,))
 
         @test_throws Exception SMatrix{1.0,1,Int,1}((1,))

--- a/test/core.jl
+++ b/test/core.jl
@@ -22,7 +22,7 @@
         @static if VERSION < v"1.6-"
             @test_throws DimensionMismatch("No precise constructor for SArray{Tuple{2},$Int,1,2} found. Length of input was 1.") SVector{2,Int}((1,))
         else
-            @test_throws DimensionMismatch("No precise constructor for SVector{2,$Int} found. Length of input was 1.") SVector{2,Int}((1,))
+            @test_throws DimensionMismatch("No precise constructor for SVector{2, $Int} found. Length of input was 1.") SVector{2,Int}((1,))
         end
         @test_throws Exception SVector{1,3}((1,))
 

--- a/test/matrix_multiply_add.jl
+++ b/test/matrix_multiply_add.jl
@@ -77,7 +77,16 @@ function test_multiply_add(N1,N2,ArrayType=MArray)
     mul!(b,At,c,1.0,2.0)
     @test b ≈ 5A'c
 
-    @test_noalloc mul!(c,A,b)
+    @static if VERSION < v"1.5-"
+        @test_noalloc mul!(c,A,b)
+    else
+        if !(ArrayType <: SizedArray)
+            @test_noalloc mul!(c,A,b)
+        else
+            mul!(c,A,b)
+            @test_broken(@allocated(mul!(c,A,b)) == 0)
+        end
+    end
     bmark = @benchmark mul!($c,$A,$b,$α,$β) samples=10 evals=10
     @test minimum(bmark).allocs == 0
     # @test_noalloc mul!(c, A, b, α, β)  # records 32 bytes


### PR DESCRIPTION
This (hopefully) turns the angry red cross into a nice green tick.

There are two separate commits, with two distinct goals:
- the first commit is a genuine test fix for julia versions >= v1.6, which reflects https://github.com/JuliaLang/julia/pull/36107
- the second commit is not a fix, it just marks as `@test_broken` what has been broken for a few months now on julia versions >= v1.5. I tried to correctly fix this issue but `@code_typed mul!(c,A,b)` yields the same thing on v1.4 and v1.5 while `@code_llvm mul!(c,A,b)` is different, so I have no idea how to fix it, sorry.

(The second commit is in direct conflict with https://github.com/JuliaArrays/StaticArrays.jl/pull/783/commits/6e0936f0f0361e5330a0fe780ea687eff48fce1d so https://github.com/JuliaArrays/StaticArrays.jl/pull/783 will have to remove that commit if this PR gets merged.)

EDIT: added a third commit, see https://github.com/JuliaArrays/StaticArrays.jl/pull/810#issuecomment-685759708