### PR TITLE
add and benchmark typed_hvcat(SA, ::Val, ...)

### DIFF
--- a/perf/hvcat_val.jl
+++ b/perf/hvcat_val.jl
@@ -1,0 +1,27 @@
+using StaticArray, BenchmarkTools
+
+let
+rows, cols = 4, 4
+_dims = Expr(:tuple, [cols for _ in 1:rows]...)
+
+for (f, wrap_val) in [(:f1, false), (:f2, true)]
+    dims = wrap_val ? :(Val{$_dims}()) : _dims
+    zeros_sa = :(Base.typed_hvcat(SA, $dims, $([0 for _ in 1:rows*cols]...)))
+    xs = [Symbol(:x, i) for i in 1:rows*cols]
+    is = [Symbol(:i, i) for i in 1:rows*cols]
+    is_sa = :(Base.typed_hvcat(SA, $dims, $(is...)))
+    @eval begin
+        function $f($(xs...))
+            r = $zeros_sa
+            for ($(is...),) in Iterators.product($(xs...))
+                r += $is_sa
+            end
+            r
+        end
+    end
+end
+
+xs = [:(1:2) for _ in 1:rows*cols]
+display(@eval @benchmark f1($(xs...)))
+display(@eval @benchmark f2($(xs...)))
+end


### PR DESCRIPTION
to explore the benefits of JuliaLang/julia#36719.

For constructing a 4x4 SMatrix in a loop, as shown here in `perf/hvcat_val.jl`, I get the following timings on my machine:
```
julia> include("perf/hvcat_val.jl")
BenchmarkTools.Trial: 
  memory estimate:  69.00 MiB
  allocs estimate:  524288
  --------------
  minimum time:     324.084 ms (0.40% GC)
  median time:      325.538 ms (0.68% GC)
  mean time:        327.568 ms (0.62% GC)
  maximum time:     351.516 ms (0.41% GC)
  --------------
  samples:          16
  evals/sample:     1
BenchmarkTools.Trial: 
  memory estimate:  49.00 MiB
  allocs estimate:  327680
  --------------
  minimum time:     87.512 ms (0.98% GC)
  median time:      88.072 ms (1.22% GC)
  mean time:        89.065 ms (1.31% GC)
  maximum time:     113.838 ms (0.91% GC)
  --------------
  samples:          57
  evals/sample:     1
```