### PR TITLE
Updated _cholesky function.

### DIFF
--- a/src/cholesky.jl
+++ b/src/cholesky.jl
@@ -14,7 +14,7 @@ end
 
 @generated function _cholesky(::Size{S}, A::StaticMatrix{M,M}) where {S,M}
     @assert (M,M) == S
-    M > 24 && return :(_cholesky_large(Size{$S}(), :A))
+    M > 24 && return :(_cholesky_large(Size{$S}(), A))
     q = Expr(:block)
     for n ∈ 1:M
         for m ∈ n:M
@@ -52,6 +52,6 @@ end
 
 # Otherwise default algorithm returning wrapped SizedArray
 @inline _cholesky_large(::Size{S}, A::StaticArray) where {S} =
-    SizedArray{Tuple{S...}}(Matrix(cholesky(Hermitian(Matrix(A))).U))
+    similar_type(A)(cholesky(Hermitian(Matrix(A))).U)
 
 LinearAlgebra.hermitian_type(::Type{SA}) where {T, S, SA<:SArray{S,T}} = Hermitian{T,SA}

--- a/src/cholesky.jl
+++ b/src/cholesky.jl
@@ -1,5 +1,5 @@
 # Generic Cholesky decomposition for fixed-size matrices, mostly unrolled
-non_hermitian_error() = throw(L∈earAlgebra.PosDefException(-1))
+non_hermitian_error() = throw(LinearAlgebra.PosDefException(-1))
 @inline function LinearAlgebra.cholesky(A::StaticMatrix)
     ishermitian(A) || non_hermitian_error()
     C = _cholesky(Size(A), A)

--- a/src/cholesky.jl
+++ b/src/cholesky.jl
@@ -28,7 +28,7 @@ end
             push!(q.args, Expr(:(=), L_m_n, Expr(:call, :muladd, Expr(:call, :(-), Symbol(:L_,m,:_,k)), Symbol(:L_,n,:_,k), L_m_n)))
         end
         L_n_n = Symbol(:L_,n,:_,n)
-        push!(q.args, Expr(:(=), L_n_n, Expr(:call, Expr(:(.), :Base, QuoteNode(:sqrt_llvm)), L_n_n)))
+        push!(q.args, Expr(:(=), L_n_n, Expr(:call, :sqrt, L_n_n)))
         Linv_n_n = Symbol(:Linv_,n,:_,n)
         push!(q.args, Expr(:(=), Linv_n_n, Expr(:call, :inv, L_n_n)))
         for m ∈ n+1:M

--- a/src/cholesky.jl
+++ b/src/cholesky.jl
@@ -25,7 +25,7 @@ end
             L_m_n = Symbol(:L_,m,:_,n)
             L_m_k = Symbol(:L_,m,:_,k)
             L_n_k = Symbol(:L_,n,:_,k)
-            push!(q.args, :($L_m_n = muladd(-$L_m_k, $L_n_k, $L_m_n)))
+            push!(q.args, :($L_m_n = muladd(-$L_m_k, $L_n_k', $L_m_n)))
         end
         L_n_n = Symbol(:L_,n,:_,n)
         push!(q.args, :($L_n_n = sqrt($L_n_n)))

--- a/src/cholesky.jl
+++ b/src/cholesky.jl
@@ -1,5 +1,5 @@
 # Generic Cholesky decomposition for fixed-size matrices, mostly unrolled
-non_hermitian_error() = throw(LinearAlgebra.PosDefException(-1))
+non_hermitian_error() = throw(L∈earAlgebra.PosDefException(-1))
 @inline function LinearAlgebra.cholesky(A::StaticMatrix)
     ishermitian(A) || non_hermitian_error()
     C = _cholesky(Size(A), A)
@@ -16,12 +16,12 @@ end
     @assert (M,M) == S
     M > 24 && return :(_cholesky_large(Size{$S}(), :A))
     q = Expr(:block)
-    for n in 1:M
+    for n ∈ 1:M
         for m ∈ n:M
             L_m_n = Symbol(:L_,m,:_,n)
             push!(q.args, :($L_m_n = @inbounds A[$n, $m]))
         end
-        for k ∈ 1:n-1, m in n:M
+        for k ∈ 1:n-1, m ∈ n:M
             L_m_n = Symbol(:L_,m,:_,n)
             L_m_k = Symbol(:L_,m,:_,k)
             L_n_k = Symbol(:L_,n,:_,k)

--- a/src/cholesky.jl
+++ b/src/cholesky.jl
@@ -12,48 +12,46 @@ end
 end
 @inline LinearAlgebra._chol!(A::StaticMatrix, ::Type{UpperTriangular}) = (cholesky(A).U, 0)
 
-
-@generated function _cholesky(::Size{(1,1)}, A::StaticMatrix)
-    @assert size(A) == (1,1)
-
-    quote
-        $(Expr(:meta, :inline))
-        T = promote_type(typeof(sqrt(one(eltype(A)))), Float32)
-        similar_type(A,T)((sqrt(A[1]), ))
+@generated function _cholesky(::Size{S}, A::StaticMatrix{M,M}) where {S,M}
+    @assert (M,M) == S
+    M > 24 && return :(_cholesky_large(Size{$S}(), :A))
+    q = Expr(:block)
+    for n in 1:M
+        for m ∈ n:M
+	    r = Expr(:ref, :A, n, m)
+	    ln = LineNumberNode(@__LINE__,Symbol(@__FILE__))
+	    r = Expr(:macrocall, Symbol("@inbounds"), ln, r)
+            push!(q.args, Expr(:(=), Symbol(:L_,m,:_,n), r))
+        end
+        for k ∈ 1:n-1, m in n:M
+            L_m_n = Symbol(:L_,m,:_,n)
+            push!(q.args, Expr(:(=), L_m_n, Expr(:call, :muladd, Expr(:call, :(-), Symbol(:L_,m,:_,k)), Symbol(:L_,n,:_,k), L_m_n)))
+        end
+        L_n_n = Symbol(:L_,n,:_,n)
+        push!(q.args, Expr(:(=), L_n_n, Expr(:call, Expr(:(.), :Base, QuoteNode(:sqrt_llvm)), L_n_n)))
+        Linv_n_n = Symbol(:Linv_,n,:_,n)
+        push!(q.args, Expr(:(=), Linv_n_n, Expr(:call, :inv, L_n_n)))
+        for m ∈ n+1:M
+            push!(q.args, Expr(:(*=), Symbol(:L_,m,:_,n), Linv_n_n))
+        end
     end
+    push!(q.args, :(T = promote_type(typeof(sqrt(one(eltype(A)))), Float32)))
+    ret = Expr(:tuple)
+    for n ∈ 1:M
+        for m ∈ 1:n
+            push!(ret.args, Symbol(:L_,n,:_,m))
+        end
+        for m ∈ n+1:M
+            push!(ret.args, Expr(:call, :zero, :T))
+        end
+    end
+    push!(q.args, Expr(:call, Expr(:call, :similar_type, :A, :T), ret))
+    Expr(:block, Expr(:meta, :inline), q)
 end
 
-@generated function _cholesky(::Size{(2,2)}, A::StaticMatrix)
-    @assert size(A) == (2,2)
-
-    quote
-        $(Expr(:meta, :inline))
-        @inbounds a = sqrt(A[1])
-        @inbounds b = A[3] / a
-        @inbounds c = sqrt(A[4] - b'*b)
-        T = promote_type(typeof(sqrt(one(eltype(A)))), Float32)
-        similar_type(A,T)((a, zero(T), b, c))
-    end
-end
-
-@generated function _cholesky(::Size{(3,3)}, A::StaticMatrix)
-    @assert size(A) == (3,3)
-
-    quote
-        $(Expr(:meta, :inline))
-        @inbounds a11 = sqrt(A[1])
-        @inbounds a12 = A[4] / a11
-        @inbounds a22 = sqrt(A[5] - a12'*a12)
-        @inbounds a13 = A[7] / a11
-        @inbounds a23 = (A[8] - a12'*a13) / a22
-        @inbounds a33 = sqrt(A[9] - a13'*a13 - a23'*a23)
-        T = promote_type(typeof(sqrt(one(eltype(A)))), Float32)
-        similar_type(A,T)((a11, zero(T), zero(T), a12, a22, zero(T), a13, a23, a33))
-    end
-end
 
 # Otherwise default algorithm returning wrapped SizedArray
-@inline _cholesky(::Size{S}, A::StaticArray) where {S} =
+@inline _cholesky_large(::Size{S}, A::StaticArray) where {S} =
     SizedArray{Tuple{S...}}(Matrix(cholesky(Hermitian(Matrix(A))).U))
 
 LinearAlgebra.hermitian_type(::Type{SA}) where {T, S, SA<:SArray{S,T}} = Hermitian{T,SA}

--- a/test/chol.jl
+++ b/test/chol.jl
@@ -2,44 +2,54 @@ using StaticArrays, Test, LinearAlgebra
 using LinearAlgebra: PosDefException
 
 @testset "Cholesky decomposition" begin
-    @testset "1×1" begin
-        m = @SMatrix [4.0]
-        (c,) = cholesky(m).U
-        @test c === 2.0
+    for elty in [Float32, Float64, ComplexF64]
+        @testset "1×1" begin
+            m = @SMatrix [4.0]
+            (c,) = cholesky(m).U
+            @test c === 2.0
+        end
+
+        @testset "2×2" for i = 1:100
+            m_a = randn(elty, 2,2)
+            #non hermitian
+            @test_throws PosDefException cholesky(SMatrix{2,2}(m_a))
+            m_a = m_a*m_a'
+            m = SMatrix{2,2}(m_a)
+            @test cholesky(Hermitian(m)).U ≈ cholesky(m_a).U
+            @test cholesky(Hermitian(m)).L ≈ cholesky(m_a).L
+        end
+
+        @testset "3×3" for i = 1:100
+            m_a = randn(elty, 3,3)
+            #non hermitian
+            @test_throws PosDefException cholesky(SMatrix{3,3}(m_a))
+            m_a = m_a*m_a'
+            m = SMatrix{3,3}(m_a)
+            @test cholesky(m).U ≈ cholesky(m_a).U
+            @test cholesky(m).L ≈ cholesky(m_a).L
+            @test cholesky(Hermitian(m)).U ≈ cholesky(m_a).U
+            @test cholesky(Hermitian(m)).L ≈ cholesky(m_a).L
+        end
+        @testset "4×4" for i = 1:100
+            m_a = randn(elty, 4,4)
+            #non hermitian
+            @test_throws PosDefException cholesky(SMatrix{4,4}(m_a))
+            m_a = m_a*m_a'
+            m = SMatrix{4,4}(m_a)
+            @test cholesky(m).L ≈ cholesky(m_a).L
+            @test cholesky(m).U ≈ cholesky(m_a).U
+            @test cholesky(Hermitian(m)).L ≈ cholesky(m_a).L
+            @test cholesky(Hermitian(m)).U ≈ cholesky(m_a).U
+        end
+
+        @testset "large (25x25)" begin
+            m_a = randn(elty, 25, 25)
+            m_a = m_a*m_a'
+            m = SMatrix{25,25}(m_a)
+            @test cholesky(m).L ≈ cholesky(m_a).L
+        end
     end
 
-    @testset "2×2" for i = 1:100
-        m_a = randn(2,2)
-        #non hermitian
-        @test_throws PosDefException cholesky(SMatrix{2,2}(m_a))
-        m_a = m_a*m_a'
-        m = SMatrix{2,2}(m_a)
-        @test cholesky(Hermitian(m)).U ≈ cholesky(m_a).U
-        @test cholesky(Hermitian(m)).L ≈ cholesky(m_a).L
-    end
-
-    @testset "3×3" for i = 1:100
-        m_a = randn(3,3)
-        #non hermitian
-        @test_throws PosDefException cholesky(SMatrix{3,3}(m_a))
-        m_a = m_a*m_a'
-        m = SMatrix{3,3}(m_a)
-        @test cholesky(m).U ≈ cholesky(m_a).U
-        @test cholesky(m).L ≈ cholesky(m_a).L
-        @test cholesky(Hermitian(m)).U ≈ cholesky(m_a).U
-        @test cholesky(Hermitian(m)).L ≈ cholesky(m_a).L
-    end
-    @testset "4×4" for i = 1:100
-        m_a = randn(4,4)
-        #non hermitian
-        @test_throws PosDefException cholesky(SMatrix{4,4}(m_a))
-        m_a = m_a*m_a'
-        m = SMatrix{4,4}(m_a)
-        @test cholesky(m).L ≈ cholesky(m_a).L
-        @test cholesky(m).U ≈ cholesky(m_a).U
-        @test cholesky(Hermitian(m)).L ≈ cholesky(m_a).L
-        @test cholesky(Hermitian(m)).U ≈ cholesky(m_a).U
-    end
     @testset "static blockmatrix" for i = 1:10
         m_a = randn(3,3)
         m_a = m_a*m_a'


### PR DESCRIPTION
You can benchmark the implementation in this PR versus the current `StaticArray`s by having the current `StaticArray`s installed and running the following script:
```julia
using StaticArrays, LinearAlgebra

@generated function uchol(A::SMatrix{M,M,T}) where {M,T}
    q = Expr(:block)
    for n in 1:M
        for m ∈ n:M
	    r = Expr(:ref, :A, n, m)
	    ln = LineNumberNode(@__LINE__,Symbol(@__FILE__))
	    r = Expr(:macrocall, Symbol("@inbounds"), ln, r)
            push!(q.args, Expr(:(=), Symbol(:L_,m,:_,n), r))
        end
        for k ∈ 1:n-1, m in n:M
            L_m_n = Symbol(:L_,m,:_,n)
            push!(q.args, Expr(:(=), L_m_n, Expr(:call, :muladd, Expr(:call, :(-), Symbol(:L_,m,:_,k)), Symbol(:L_,n,:_,k), L_m_n)))
        end
        L_n_n = Symbol(:L_,n,:_,n)
        push!(q.args, Expr(:(=), L_n_n, :sqrt, L_n_n)))
        Linv_n_n = Symbol(:Linv_,n,:_,n)
        push!(q.args, Expr(:(=), Linv_n_n, Expr(:call, :inv, L_n_n)))
        for m ∈ n+1:M
            push!(q.args, Expr(:(*=), Symbol(:L_,m,:_,n), Linv_n_n))
        end
    end
    ret = Expr(:tuple)
    for n ∈ 1:M
        for m ∈ 1:n
            push!(ret.args, Symbol(:L_,n,:_,m))
        end
        for m ∈ n+1:M
            push!(ret.args, zero(T))
        end
    end
    push!(q.args, Expr(:call, Expr(:curly, :SMatrix, M, M), ret))
    Expr(:block, Expr(:meta, :inline), q)
end

function bench(rg)
    x = Matrix{Float64}(undef, length(rg), 2);
    for (i,r) ∈ enumerate(rg)
        S = @SMatrix(randn(r,3r ÷ 2)) |> x -> x * x';
        x[i,1] = @belapsed cholesky(Symmetric($S)).U
        x[i,2] = @belapsed uchol($S)
    end
    x
end
benches = bench(1:24);
@. benches = (1:24) ^ 3 / 3e9 / benches;

using Plots; plotly();
plot(1:24, benches, labels = ["Current Implementation" "Proposed Implementation"]);
xlabel!("Matrix dimensions.")
ylabel!("GFLOPS.")
```
Results:
![newplot(13)](https://user-images.githubusercontent.com/8043603/91044325-1754ed00-e5e3-11ea-8df1-0ca2c2c4e6a5.png)

If people are willing, we could replace the `sqrt` implementation with
```julia
fast_sqrt(x) = sqrt(x)
sqrt(x::Union{Float32,Float64}) = Base.sqrt_llvm(x)
```
This would not do domain checks on each `sqrt`, meaning it'll return `NaN`s instead of throwing an error if the matrix isn't positive definite.

The primary benefit of this PR is that it generates code for arbitrary square sizes, instead of special cased for a single size. It is by no means optimal, but it seems to be an improvement.

Currently, it switches to the old LAPACK definition above 24x24 instead of above 3x3. But by the looks of it, I should increase this threshold if anything.