### PR TITLE
use `SOneTo` for `eachindex()`

### DIFF
--- a/src/abstractarray.jl
+++ b/src/abstractarray.jl
@@ -15,6 +15,8 @@ end
 Base.axes(rv::Adjoint{<:Any,<:StaticVector})   = (SOneTo(1), axes(rv.parent)...)
 Base.axes(rv::Transpose{<:Any,<:StaticVector}) = (SOneTo(1), axes(rv.parent)...)
 
+Base.eachindex(::IndexLinear, a::StaticArray) = SOneTo(length(a))
+
 # Base.strides is intentionally not defined for SArray, see PR #658 for discussion
 Base.strides(a::MArray) = Base.size_to_strides(1, size(a)...)
 Base.strides(a::SizedArray) = strides(a.data)

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -7,6 +7,7 @@ using StaticArrays, Test, LinearAlgebra
         @test length(m) == 12
         @test IndexStyle(m) == IndexLinear()
         @test Base.isassigned(m, 2, 2) == true
+        @test eachindex(m) isa SOneTo
     end
 
     @testset "strides" begin


### PR DESCRIPTION
Currently we already have `eachindex(SA[1, 2, 3, 4]) isa SOneTo` for
vectors but not for matrices. This changes makes `eachindex` consistent.