### PR TITLE
Add `rot180` etc. for SMatrix

### DIFF
--- a/src/abstractarray.jl
+++ b/src/abstractarray.jl
@@ -199,6 +199,17 @@ reshape(a::Array, ::Size{S}) where {S} = SizedArray{Tuple{S...}}(a)
     return Expr(:tuple, (:(v[$i]) for i = N:(-1):1)...)
 end
 
+@eval @generated function Base.rot180(A::SMatrix{M,N}) where {M,N}
+    exs = rot180([:(getindex(A,$i,$j)) for i in 1:M, j in 1:N])
+    return :(SMatrix{M,N}($(exs...)))
+end
+for rot in [:rotl90, :rotr90]
+    @eval @generated function Base.$rot(A::SMatrix{M,N}) where {M,N}
+        exs = $rot([:(getindex(A,$i,$j)) for i in 1:M, j in 1:N])
+        return :(SMatrix{N,M}($(exs...)))
+    end
+end
+
 # TODO permutedims?
 
 #--------------------------------------------------

--- a/src/abstractarray.jl
+++ b/src/abstractarray.jl
@@ -199,7 +199,7 @@ reshape(a::Array, ::Size{S}) where {S} = SizedArray{Tuple{S...}}(a)
     return Expr(:tuple, (:(v[$i]) for i = N:(-1):1)...)
 end
 
-@eval @generated function Base.rot180(A::SMatrix{M,N}) where {M,N}
+@generated function Base.rot180(A::SMatrix{M,N}) where {M,N}
     exs = rot180([:(getindex(A,$i,$j)) for i in 1:M, j in 1:N])
     return :(SMatrix{M,N}($(exs...)))
 end

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -132,6 +132,19 @@ using StaticArrays, Test, LinearAlgebra
         @test @inferred(reverse(m))::typeof(m) == MVector(3, 2, 1)
     end
 
+    @testset "rotate" begin
+        M = [1 2; 3 4]
+        SM = SMatrix{2, 2}(M)
+        @test @inferred(rotl90(SM)) === @SMatrix [2 4; 1 3]
+        @test @inferred(rot180(SM)) === @SMatrix [4 3; 2 1]
+        @test @inferred(rotr90(SM)) === @SMatrix [3 1; 4 2]
+        M23 = rand(2, 3)
+        SM23 = SMatrix{2, 3}(M23)
+        @test @inferred(rotl90(SM23)) == rotl90(M23)
+        @test @inferred(rot180(SM23)) == rot180(M23)
+        @test @inferred(rotr90(SM23)) == rotr90(M23)
+    end
+
     @testset "Conversion to AbstractArray" begin
         # Issue #746
         # conversion to AbstractArray changes the eltype from Int to Float64


### PR DESCRIPTION
Before this, it returned an MMatrix:
```
julia> rot180(SA[1 2; 3 4])
2×2 MMatrix{2, 2, Int64, 4} with indices SOneTo(2)×SOneTo(2):
 4  3
 2  1

julia> @btime rot180(m)  setup=(m=@SMatrix rand(5,5));
  12.852 ns (1 allocation: 208 bytes)
```
Afterwards, `4.373 ns (0 allocations: 0 bytes)`. (But no quicker for `rotl90`.)