### PR TITLE
Test run CI without coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,8 @@ jobs:
           arch: ${{ matrix.arch }}
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest
+        with:
+          coverage: false
       - uses: julia-actions/julia-uploadcodecov@latest
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Just testing this out, it should be significantly faster (see e.g. https://github.com/julia-actions/julia-runtest/pull/19#issuecomment-708345663). I think it should be sufficient to produce and submit coverage from one or two workers, I don't think there is any OS specific code-paths in StaticArrays for example.