### PR TITLE
Correctly find size of non-homogenous tuples in broadcast_size

### DIFF
--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -55,7 +55,7 @@ broadcast_indices(A::StaticArray) = indices(A)
 @inline broadcast_sizes() = ()
 @inline broadcast_size(a) = Size()
 @inline broadcast_size(a::AbstractArray) = Size(a)
-@inline broadcast_size(a::NTuple{N}) where N = Size(N)
+@inline broadcast_size(a::Tuple) = Size(length(a))
 
 function broadcasted_index(oldsize, newindex)
     index = ones(Int, length(oldsize))

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -26,6 +26,9 @@ end
     end
     # test case issue #191
     @test @inferred(broadcast((a, b, c) -> 0, SVector(1, 1), 0, 0)) == SVector(0, 0)
+
+    # test case issue #841
+    @test @inferred(StaticArrays.broadcast_size((1, 2.0))) === Size(2)
 end
 
 @testset "Broadcast" begin


### PR DESCRIPTION
Fixes #841