### PR TITLE
Adjust to upcoming Base Vararg change

### DIFF
--- a/src/traits.jl
+++ b/src/traits.jl
@@ -153,9 +153,9 @@ number of dimensions, and their dimensions match as determined by [`dimmatch`](@
 """
 @pure sizematch(::Size{S1}, ::Size{S2}) where {S1, S2} = sizematch(S1, S2)
 @inline sizematch(::Tuple{}, ::Tuple{}) = true
-@inline sizematch(S1::Tuple{Vararg{<:StaticDimension, N}}, S2::Tuple{Vararg{<:StaticDimension, N}}) where {N} =
+@inline sizematch(S1::Tuple{Vararg{StaticDimension, N}}, S2::Tuple{Vararg{StaticDimension, N}}) where {N} =
     dimmatch(S1[1], S2[1]) && sizematch(Base.tail(S1), Base.tail(S2))
-@inline sizematch(::Tuple{Vararg{<:StaticDimension}}, ::Tuple{Vararg{<:StaticDimension}}) = false # mismatch in number of dimensions
+@inline sizematch(::Tuple{Vararg{StaticDimension}}, ::Tuple{Vararg{StaticDimension}}) = false # mismatch in number of dimensions
 
 """
     sizematch(::Size, A::AbstractArray)

--- a/src/util.jl
+++ b/src/util.jl
@@ -16,10 +16,7 @@ end
 @generated function promote_tuple_eltype(::Union{T,Type{T}}) where T <: Tuple
     t = Union{}
     for i = 1:length(T.parameters)
-        tmp = T.parameters[i]
-        if tmp <: Vararg
-            tmp = tmp.parameters[1]
-        end
+        tmp = Base.unwrapva(T.parameters[i])
         t = :(promote_type($t, $tmp))
     end
     return quote


### PR DESCRIPTION
There's two changes here:
1. Drop unnecessary `<:` in Vararg. Tuples are already covariant and this form will be deprecated.
2. Use Base.unwrapva, rather than open coding the equivalent, since the implementation will change.

With this change, everything should work with or without https://github.com/JuliaLang/julia/pull/38136.