### PR TITLE
overload Base.rest

### DIFF
--- a/src/abstractarray.jl
+++ b/src/abstractarray.jl
@@ -288,6 +288,10 @@ end
 end
 
 if VERSION >= v"1.6.0-DEV.1334"
-    Base.rest(a::SArray, st=(nothing, 0)) = SVector(Base.rest(Tuple(a), st[2] + 1))
-    Base.rest(a::MArray, st=(nothing, 0)) = MVector(Base.rest(Tuple(a), st[2] + 1))
+    # FIXME: This always assumes one-based linear indexing and that subtypes of StaticArray
+    # don't overload iterate
+    @inline function Base.rest(a::StaticArray, (_, i) = (nothing, 0))
+        newlen = StaticArrays.tuple_prod(Size(a)) - i
+        return similar_type(typeof(a), Size(newlen))(Base.rest(Tuple(a), i + 1))
+    end
 end

--- a/src/abstractarray.jl
+++ b/src/abstractarray.jl
@@ -290,8 +290,8 @@ end
 if VERSION >= v"1.6.0-DEV.1334"
     # FIXME: This always assumes one-based linear indexing and that subtypes of StaticArray
     # don't overload iterate
-    @inline function Base.rest(a::StaticArray, (_, i) = (nothing, 0))
-        newlen = StaticArrays.tuple_prod(Size(a)) - i
+    @inline function Base.rest(a::StaticArray{S}, (_, i) = (nothing, 0)) where {S}
+        newlen = tuple_prod(S) - i
         return similar_type(typeof(a), Size(newlen))(Base.rest(Tuple(a), i + 1))
     end
 end

--- a/src/abstractarray.jl
+++ b/src/abstractarray.jl
@@ -286,3 +286,8 @@ end
         @inbounds return similar_type(a, promote_type(eltype(a), eltype(b)), Size($Snew))(tuple($(exprs...)))
     end
 end
+
+if VERSION >= v"1.6.0-DEV.1334"
+    Base.rest(a::SArray, st=(nothing, 0)) = SVector(Base.rest(Tuple(a), st[2] + 1))
+    Base.rest(a::MArray, st=(nothing, 0)) = MVector(Base.rest(Tuple(a), st[2] + 1))
+end

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -274,7 +274,7 @@ end
     @test @inferred(hcat(SA[1 2 3])) === SA[1 2 3]
 end
 
-if VERSION >= v"1.6.0-DEV.1334"
+@static if VERSION >= v"1.6.0-DEV.1334"
     @testset "Base.rest" begin
         x = @SVector[1, 2, 3]
         @test Base.rest(x) == x

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -276,26 +276,36 @@ end
 
 @static if VERSION >= v"1.6.0-DEV.1334"
     @testset "Base.rest" begin
-        x = @SVector[1, 2, 3]
+        x = SA[1, 2, 3]
         @test Base.rest(x) == x
         a, b... = x
-        @test b == @SVector[2, 3]
+        @test b == SA[2, 3]
     
-        x = @SMatrix[1 2; 3 4]
+        x = SA[1 2; 3 4]
         @test Base.rest(x) == vec(x)
         a, b... = x
-        @test b == @SVector[3, 2, 4]
+        @test b == SA[3, 2, 4]
+
+        a, b... = SA[1]
+        @test b == []
+        @test b isa SVector{0}
     
-        x = @MVector[1, 2, 3]
-        @test Base.rest(x) == x
-        @test pointer(Base.rest(x)) != pointer(x)
-        a, b... = x
-        @test b == @MVector[2, 3]
-    
-        x = @MMatrix[1 2; 3 4]
-        @test Base.rest(x) == vec(x)
-        @test pointer(Base.rest(x)) != pointer(x)
-        a, b... = x
-        @test b == @MVector[3, 2, 4]
+        for (Vec, Mat) in [(MVector, MMatrix), (SizedVector, SizedMatrix)]
+            x = Vec(1, 2, 3)
+            @test Base.rest(x) == x
+            @test pointer(Base.rest(x)) != pointer(x)
+            a, b... = x
+            @test b == Vec(2, 3)
+        
+            x = Mat{2,2}(1, 2, 3, 4)
+            @test Base.rest(x) == vec(x)
+            @test pointer(Base.rest(x)) != pointer(x)
+            a, b... = x
+            @test b == Vec(2, 3, 4)
+
+            a, b... = Vec(1)
+            @test b == []
+            @test b isa Vec{0}
+        end
     end
 end

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -273,3 +273,29 @@ end
     @test @inferred(hcat(SA[1,2,3])) === SMatrix{3,1}(1,2,3)
     @test @inferred(hcat(SA[1 2 3])) === SA[1 2 3]
 end
+
+if VERSION >= v"1.6.0-DEV.1334"
+    @testset "Base.rest" begin
+        x = @SVector[1, 2, 3]
+        @test Base.rest(x) == x
+        a, b... = x
+        @test b == @SVector[2, 3]
+    
+        x = @SMatrix[1 2; 3 4]
+        @test Base.rest(x) == vec(x)
+        a, b... = x
+        @test b == @SVector[3, 2, 4]
+    
+        x = @MVector[1, 2, 3]
+        @test Base.rest(x) == x
+        @test pointer(Base.rest(x)) != pointer(x)
+        a, b... = x
+        @test b == @MVector[2, 3]
+    
+        x = @MMatrix[1 2; 3 4]
+        @test Base.rest(x) == vec(x)
+        @test pointer(Base.rest(x)) != pointer(x)
+        a, b... = x
+        @test b == @MVector[3, 2, 4]
+    end
+end


### PR DESCRIPTION
This makes the new lhs slurping syntax return an `S/MVector` if the rhs is an `S/MArray`. See JuliaLang/julia#37410