### PR TITLE
require one-based indexing for SizedArray

### DIFF
--- a/src/SizedArray.jl
+++ b/src/SizedArray.jl
@@ -1,3 +1,5 @@
+require_one_based_indexing(A...) = !Base.has_offset_axes(A...) ||
+    throw(ArgumentError("offset arrays are not supported but got an array with index other than 1"))
 
 """
     SizedArray{Tuple{dims...}}(array)
@@ -15,6 +17,7 @@ struct SizedArray{S<:Tuple,T,N,M,TData<:AbstractArray{T,M}} <: StaticArray{S,T,N
     data::TData
 
     function SizedArray{S,T,N,M,TData}(a::TData) where {S,T,N,M,TData<:AbstractArray{T,M}}
+        require_one_based_indexing(a)
         if size(a) != size_to_tuple(S) && size(a) != (tuple_prod(S),)
             throw(DimensionMismatch("Dimensions $(size(a)) don't match static size $S"))
         end

--- a/test/SizedArray.jl
+++ b/test/SizedArray.jl
@@ -220,3 +220,8 @@
         @test x5 == view(Array(x5), :)
     end
 end
+
+struct OVector <: AbstractVector{Int} end
+Base.length(::OVector) = 10
+Base.axes(::OVector) = (0:9,)
+@test_throws ArgumentError SizedVector{10}(OVector())


### PR DESCRIPTION
Things like iteration currently fail for SizedArrays with offset axes, so I think it's better to error right array. See https://github.com/JuliaArrays/StaticArrays.jl/pull/844#issuecomment-717598756