### PR TITLE
sort: avoid use of `ReverseOrdering` for `BitonicSort`

### DIFF
--- a/src/sort.jl
+++ b/src/sort.jl
@@ -1,4 +1,4 @@
-import Base.Order: Forward, Ordering, Perm, ReverseOrdering, ord
+import Base.Order: Forward, Ordering, Perm, ord
 import Base.Sort: Algorithm, lt, sort, sortperm
 
 
@@ -51,8 +51,7 @@ _sort(a::NTuple, alg, order) = sort!(Base.copymutable(a); alg=alg, order=order)
     function swap_expr(i, j, rev)
         ai = Symbol('a', i)
         aj = Symbol('a', j)
-        order = rev ? :revorder : :order
-        return :( ($ai, $aj) = @inbounds lt($order, $ai, $aj) ? ($ai, $aj) : ($aj, $ai) )
+        return :( ($ai, $aj) = @inbounds lt(order, $ai, $aj) ⊻ $rev ? ($ai, $aj) : ($aj, $ai) )
     end
 
     function merge_exprs(idx, rev)
@@ -83,7 +82,6 @@ _sort(a::NTuple, alg, order) = sort!(Base.copymutable(a); alg=alg, order=order)
     symlist = (Symbol('a', i) for i in idx)
     return quote
         @_inline_meta
-        revorder = Base.Order.ReverseOrdering(order)
         ($(symlist...),) = a
         ($(sort_exprs(idx)...);)
         return ($(symlist...),)

--- a/test/sort.jl
+++ b/test/sort.jl
@@ -25,6 +25,9 @@ using StaticArrays, Test
             vp = sortperm(v)
             @test v[vp] == sort(v)
         end
+
+        # stability
+        @test sortperm(SA[1, 1, 1, 0]) == SA[4, 1, 2, 3]
     end
 
 end


### PR DESCRIPTION
We reverse the order as part of the bitonic sort algorithm, but
`ReverseOrdering` is not the true reverse order for an order `::Perm`.
This led to non-stable sorting for `sortperm`.

Fixed by hand-wiring the reversal.
Fixes #858.