### PR TITLE
Define elsize to make `pointer` more reliable.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StaticArrays"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "1.0.1"
+version = "1.0.2"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/MArray.jl
+++ b/src/MArray.jl
@@ -279,4 +279,4 @@ function Base.view(
     return SizedArray{new_size}(view_from_invoke)
 end
 
-Base.elsize(::Type{<:MArray{S,T}}) where {S,T} = sizeof(eltype(T))
+Base.elsize(::Type{<:MArray{S,T}}) where {S,T} = sizeof(T)

--- a/src/MArray.jl
+++ b/src/MArray.jl
@@ -278,3 +278,5 @@ function Base.view(
     view_from_invoke = invoke(view, Tuple{AbstractArray, typeof(indices).parameters...}, a, indices...)
     return SizedArray{new_size}(view_from_invoke)
 end
+
+Base.elsize(::Type{<:MArray{S,T}}) where {S,T} = sizeof(eltype(T))

--- a/src/SizedArray.jl
+++ b/src/SizedArray.jl
@@ -126,7 +126,8 @@ end
 
 Base.parent(sa::SizedArray) = sa.data
 
-Base.pointer(sa::SizedArray) = pointer(sa.data)
+Base.unsafe_convert(::Type{Ptr{T}}, sa::SizedArray) where {T} = Base.unsafe_convert(Ptr{T}, sa.data)
+Base.elsize(::Type{SizedArray{S,T,M,N,A}}) where {S,T,M,N,A} = Base.elsize(A)
 
 const SizedVector{S,T} = SizedArray{Tuple{S},T,1,1}
 

--- a/test/SizedArray.jl
+++ b/test/SizedArray.jl
@@ -96,8 +96,17 @@
     @test parent(sa) === sa.data
 
     # pointer
-    @test pointer(sa) === pointer(sa.data)
-
+    @testset "pointer" begin
+        @test pointer(sa) === pointer(sa.data)
+        A = MMatrix{32,3,Float64}(undef);
+        av1 = view(A, 1, :);
+        av2 = view(A, :, 1);
+        @test pointer(A) == pointer(av1) == pointer(av2)
+        @test pointer(A, LinearIndices(A)[1,2]) == pointer(av1, 2)
+        @test pointer(A, LinearIndices(A)[2,1]) == pointer(av2, 2)
+        @test pointer(A, LinearIndices(A)[4,3]) == pointer(view(A, :, 3), 4) == pointer(view(A, 4, :), 3)
+    end
+    
     @testset "vec" begin
         sa2 = SizedArray{Tuple{2, 2}, Int}([1, 2, 3, 4])
         @test (@inferred vec(sa2)) isa SizedVector{4, Int}

--- a/test/SizedArray.jl
+++ b/test/SizedArray.jl
@@ -98,13 +98,15 @@
     # pointer
     @testset "pointer" begin
         @test pointer(sa) === pointer(sa.data)
-        A = MMatrix{32,3,Float64}(undef);
-        av1 = view(A, 1, :);
-        av2 = view(A, :, 1);
-        @test pointer(A) == pointer(av1) == pointer(av2)
-        @test pointer(A, LinearIndices(A)[1,2]) == pointer(av1, 2)
-        @test pointer(A, LinearIndices(A)[2,1]) == pointer(av2, 2)
-        @test pointer(A, LinearIndices(A)[4,3]) == pointer(view(A, :, 3), 4) == pointer(view(A, 4, :), 3)
+        if VERSION ≥ v"1.5"
+            A = MMatrix{32,3,Float64}(undef);
+            av1 = view(A, 1, :);
+            av2 = view(A, :, 1);
+            @test pointer(A) == pointer(av1) == pointer(av2)
+            @test pointer(A, LinearIndices(A)[1,2]) == pointer(av1, 2)
+            @test pointer(A, LinearIndices(A)[2,1]) == pointer(av2, 2)
+            @test pointer(A, LinearIndices(A)[4,3]) == pointer(view(A, :, 3), 4) == pointer(view(A, 4, :), 3)
+        end
     end
     
     @testset "vec" begin


### PR DESCRIPTION
The added tests don't work on current master. They're in the `SizedArray` tests file because views of `MArray`s create a `SizedArray` wrapper.