### PR TITLE
Allow cholesky to fail without error

### DIFF
--- a/src/cholesky.jl
+++ b/src/cholesky.jl
@@ -1,21 +1,50 @@
 # Generic Cholesky decomposition for fixed-size matrices, mostly unrolled
 non_hermitian_error() = throw(LinearAlgebra.PosDefException(-1))
-@inline function LinearAlgebra.cholesky(A::StaticMatrix)
-    ishermitian(A) || non_hermitian_error()
+@inline function LinearAlgebra.cholesky(A::StaticMatrix; check=true)
+    !ishermitian(A) && (check && non_hermitian_error())
     C = _cholesky(Size(A), A)
-    return Cholesky(C, 'U', 0)
+    loc = _checkpsd(C)
+    if check && loc != 0
+        throw(PosDefException(loc))
+    end
+    return Cholesky(C, 'U', loc)
 end
 
-@inline function LinearAlgebra.cholesky(A::LinearAlgebra.RealHermSymComplexHerm{<:Real, <:StaticMatrix})
+"""
+    _checkpsd(C::StaticMatrix{M,M,T})
+
+Checks of an upper-triangular Cholesky factor `C` was successfully factored.
+If the original matrix `A = C'C` was positive definite, return 0. 
+Otherwise, return the location of the first zero element on the diagonal of `C`.
+
+Used to fill in the `info` field of the `LinearAlgebra.Cholesky` type.
+"""
+function _checkpsd(C::StaticMatrix{M,M,T}) where {M,T}
+    ispsd = abs(prod(diag(C))) > zero(real(eltype(C))) 
+    loc = ispsd ? 0 : findfirst(diag(C) .== zero(eltype(C)))
+    return loc
+end
+
+function LinearAlgebra.isposdef(A::StaticMatrix{M,M,T}) where {M,T}
+    C = _cholesky(Size(A), A)
+    return real(prod(diag(C))) > zero(real(T)) 
+end
+
+@inline function LinearAlgebra.cholesky(A::LinearAlgebra.RealHermSymComplexHerm{<:Real, <:StaticMatrix}; check=true)
     C = _cholesky(Size(A), A.data)
-    return Cholesky(C, 'U', 0)
+    loc = _checkpsd(C)
+    if check && loc != 0
+        throw(PosDefException(loc))
+    end
+    return Cholesky(C, 'U', loc)
 end
 @inline LinearAlgebra._chol!(A::StaticMatrix, ::Type{UpperTriangular}) = (cholesky(A).U, 0)
 
-@generated function _cholesky(::Size{S}, A::StaticMatrix{M,M}) where {S,M}
+@generated function _cholesky(::Size{S}, A::StaticMatrix{M,M,TM}) where {S,M,TM}
     @assert (M,M) == S
     M > 24 && return :(_cholesky_large(Size{$S}(), A))
     q = Expr(:block)
+    push!(q.args, :(T = promote_type(typeof(sqrt(one(eltype(A)))), Float32)))
     for n ∈ 1:M
         for m ∈ n:M
             L_m_n = Symbol(:L_,m,:_,n)
@@ -28,7 +57,7 @@ end
             push!(q.args, :($L_m_n = muladd(-$L_m_k, $L_n_k', $L_m_n)))
         end
         L_n_n = Symbol(:L_,n,:_,n)
-        push!(q.args, :($L_n_n = sqrt($L_n_n)))
+        push!(q.args, :($L_n_n = real($L_n_n) > 0 ? sqrt($L_n_n) : zero(T)))
         Linv_n_n = Symbol(:Linv_,n,:_,n)
         push!(q.args, :($Linv_n_n = inv($L_n_n)))
         for m ∈ n+1:M
@@ -36,7 +65,6 @@ end
             push!(q.args, :($L_m_n *= $Linv_n_n))
         end
     end
-    push!(q.args, :(T = promote_type(typeof(sqrt(one(eltype(A)))), Float32)))
     ret = Expr(:tuple)
     for n ∈ 1:M
         for m ∈ 1:n

--- a/test/chol.jl
+++ b/test/chol.jl
@@ -89,6 +89,7 @@ using LinearAlgebra: PosDefException
 
         @testset "indefinite matrices" for i = 1:10
             m_a = randn(elty, 5,5)
+            @test cholesky(SMatrix{5,5}(m_a), check=false).info == -1
             @test !isposdef(SMatrix{5,5}(m_a))
             m_a = m_a*m_a'
 
@@ -100,6 +101,7 @@ using LinearAlgebra: PosDefException
 
             @test_throws PosDefException cholesky(m_a)
             @test_throws PosDefException cholesky(m)
+            @test_throws PosDefException cholesky(Hermitian(m))
             @test cholesky(m_a, check=false).info != 0 
             @test cholesky(m, check=false).info != 0 
             @test cholesky(Hermitian(m), check=false).info != 0 


### PR DESCRIPTION
This allows the Cholesky factorization to continue to completion, even for indefinite matrices. This is important since Cholesky is the most efficient way to check for positive definiteness, and it's often extremely useful to attempt a Cholesky factorization and then check to see if it was successful. 

This PR adds a very simple change to the existing `_cholesky` method that checks of the real part of the diagonal element is negative prior to taking the square root, and sets the element to 0 if it is negative. This allows the algorithm to continue without errors (likely accumulating some `Inf` values along the way), and allows for a simple check for positive-definiteness after the factorization is complete. It adds minimal overhead, as shown by the graph below:

![chol_comp](https://user-images.githubusercontent.com/9097986/101937062-5cf7ee80-3baf-11eb-8728-8dcd32a9bb00.png)

This change also allows easy implementation of `isposdef`, addressing issue #373. This is far more computationally efficient than converting to a dynamic matrix, as shown below:
![isposdef](https://user-images.githubusercontent.com/9097986/101937268-a2b4b700-3baf-11eb-9eb9-f87fdccacef5.png)

It's also cheaper than converting a real matrix to Complex to avoid the domain error for `sqrt` and then checking for imaginary values on the diagonal (plot not shown, but this is pretty intuitive since the conversion will take time, and operating on complex numbers requires at least 2x the number of flops). 

I'm pretty this code works generally for complex values as well, but I'm not well-versed on applying Cholesky to complex-valued matrices. I believe the condition I added into the algorithm is the correct one, namely that the real part of the diagonal elements must be positive prior to taking the square root for the matrix to be positive definite. 