### PR TITLE
Better handling of subtypes of StaticVector in views of SizedArray

### DIFF
--- a/src/SizedArray.jl
+++ b/src/SizedArray.jl
@@ -200,13 +200,17 @@ end
 
 ### Code that makes views of statically sized arrays also statically sized (where possible)
 
+# _get_static_vector_length is used in a generated function so using a generic function
+# may not be a good idea
+_get_static_vector_length(::Type{<:StaticVector{N}}) where {N} = N
+
 @generated function new_out_size(::Type{Size}, inds...) where Size
     os = []
     map(Size.parameters, inds) do s, i
         if i <: Integer
             # dimension is fixed
         elseif i <: StaticVector
-            push!(os, i.parameters[1].parameters[1])
+            push!(os, _get_static_vector_length(i))
         elseif i == Colon || i <: Base.Slice
             push!(os, s)
         elseif i <: SOneTo

--- a/src/SizedArray.jl
+++ b/src/SizedArray.jl
@@ -200,8 +200,7 @@ end
 
 ### Code that makes views of statically sized arrays also statically sized (where possible)
 
-# _get_static_vector_length is used in a generated function so using a generic function
-# may not be a good idea
+# Note, _get_static_vector_length is used in a generated function so it's strictly internal and can't be extended
 _get_static_vector_length(::Type{<:StaticVector{N}}) where {N} = N
 
 @generated function new_out_size(::Type{Size}, inds...) where Size

--- a/test/SizedArray.jl
+++ b/test/SizedArray.jl
@@ -206,6 +206,10 @@
         x5 = view(x, :)
         @test isa(x5, SizedArray{Tuple{24},Float64,1,1,<:SubArray{Float64,1}})
         @test x5 == view(x.data, :)
+
+        x6 = view(x, StaticArrays.SUnitRange(2, 3), :, 2)
+        @test isa(x6, SizedArray{Tuple{2,3},Float64,2,2,<:SubArray{Float64,2}})
+        @test x6 == view(x.data, StaticArrays.SUnitRange(2, 3), :, 2)
     end
 
     @testset "views of MArray" begin


### PR DESCRIPTION
While working on https://github.com/mateuszbaran/HybridArrays.jl/issues/31 I noticed that the code for calculating size of views of `SizedArray` doesn't work for some subtypes of `StaticVector`. This PR fixes this problem.