### PR TITLE
Bugfix: newsize not defined in error message

### DIFF
--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -348,25 +348,14 @@ end
         j += 1
     end
 
-    if v <: StaticArray
-        @boundscheck if Length(v) != prod(linearsizes)
-            return DimensionMismatch("tried to assign $(length(v))-element array to $newsize destination")
+    quote
+        @_propagate_inbounds_meta
+        if length(v) != $(prod(linearsizes))
+            newsize = $linearsizes
+            throw(DimensionMismatch("tried to assign $(length(v))-element array to $newsize destination"))
         end
-        quote
-            @_propagate_inbounds_meta
-            $(exprs...)
-            return a
-        end
-    else
-        quote
-            @_propagate_inbounds_meta
-            if length(v) != $(prod(linearsizes))
-                newsize = $linearsizes
-                throw(DimensionMismatch("tried to assign $(length(v))-element array to $newsize destination"))
-            end
-            $(exprs...)
-            return a
-        end
+        $(exprs...)
+        return a
     end
 end
 

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -142,6 +142,10 @@ using StaticArrays, Test
         # SOneTo
         @test (mm = MMatrix{2,2,Int}(undef); mm[SOneTo(1),:] = sm[SOneTo(1),:]; (@inferred getindex(mm, SOneTo(1), :))::MMatrix == @MMatrix [1 3])
         @test (mm = MMatrix{2,2,Int}(undef); mm[:,SOneTo(1)] = sm[:,SOneTo(1)]; (@inferred getindex(mm, :, SOneTo(1)))::MMatrix == @MMatrix [1;2])
+
+        # #866
+        @test_throws DimensionMismatch setindex!(MMatrix(SA[1 2; 3 4], SA[3,4], 1, SA[1,2,3]))
+        @test_throws DimensionMismatch setindex!(MMatrix(SA[1 2; 3 4], [3,4], 1, SA[1,2,3]))
     end
 
     @testset "3D scalar indexing" begin


### PR DESCRIPTION
Looking at the history, this is pretty old code, and the special case
`v <: StaticArray` seems unnecessary now — the compiler should have no
trouble computing `length(v)` as a constant and eliminating the branch
when `v` is a static array.

Fixes #866