### PR TITLE
Fix tests from #868

### DIFF
--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -144,8 +144,8 @@ using StaticArrays, Test
         @test (mm = MMatrix{2,2,Int}(undef); mm[:,SOneTo(1)] = sm[:,SOneTo(1)]; (@inferred getindex(mm, :, SOneTo(1)))::MMatrix == @MMatrix [1;2])
 
         # #866
-        @test_throws DimensionMismatch setindex!(MMatrix(SA[1 2; 3 4], SA[3,4], 1, SA[1,2,3]))
-        @test_throws DimensionMismatch setindex!(MMatrix(SA[1 2; 3 4], [3,4], 1, SA[1,2,3]))
+        @test_throws DimensionMismatch setindex!(MMatrix(SA[1 2; 3 4]), SA[3,4], 1, SA[1,2,3])
+        @test_throws DimensionMismatch setindex!(MMatrix(SA[1 2; 3 4]), [3,4], 1, SA[1,2,3])
     end
 
     @testset "3D scalar indexing" begin


### PR DESCRIPTION
Strangely enough the tests from #868 were broken with a misplaced paren, but CI appeared to have passed on that PR (other than nightly which failed due to upstream changes)  No idea what happened there...