### PR TITLE
Added check option to cholesky

### DIFF
--- a/src/cholesky.jl
+++ b/src/cholesky.jl
@@ -24,7 +24,7 @@ end
 @generated function _cholesky(::Size{S}, A::StaticMatrix{M,M}, check::Bool) where {S,M}
     @assert (M,M) == S
     M > 24 && return :(_cholesky_large(Size{$S}(), A, check))
-    q = Expr(:block, :(info = 0), :(failure = false))
+    q = Expr(:block)
     for n ∈ 1:M
         for m ∈ n:M
             L_m_n = Symbol(:L_,m,:_,n)

--- a/src/cholesky.jl
+++ b/src/cholesky.jl
@@ -23,7 +23,7 @@ end
 
 @generated function _cholesky(::Size{S}, A::StaticMatrix{M,M}, check::Bool) where {S,M}
     @assert (M,M) == S
-    M > 24 && return :(_cholesky_large(Size{$S}(), A))
+    M > 24 && return :(_cholesky_large(Size{$S}(), A, check))
     q = Expr(:block, :(info = 0), :(failure = false))
     for n ∈ 1:M
         for m ∈ n:M
@@ -61,8 +61,10 @@ end
 end
 
 # Otherwise default algorithm returning wrapped SizedArray
-@inline _cholesky_large(::Size{S}, A::StaticArray) where {S} =
-    Cholesky(similar_type(A)(cholesky(Hermitian(Matrix(A))).U), 'U', 0)
+@inline function _cholesky_large(::Size{S}, A::StaticArray, check::Bool) where {S}
+    C = cholesky(Hermitian(Matrix(A)); check=check)
+    Cholesky(similar_type(A)(C.U), 'U', C.info)
+end
 
 LinearAlgebra.hermitian_type(::Type{SA}) where {T, S, SA<:SArray{S,T}} = Hermitian{T,SA}
 

--- a/test/chol.jl
+++ b/test/chol.jl
@@ -34,6 +34,16 @@ using LinearAlgebra: PosDefException
             m_a = randn(elty, 4,4)
             #non hermitian
             @test_throws PosDefException cholesky(SMatrix{4,4}(m_a))
+            nonpd = SVector{4}(@view(m_a[:,1])) |> x -> x * x'
+            if elty <: Real
+                @test_throws PosDefException cholesky(nonpd)
+                @test !issuccess(cholesky(nonpd,check=false))
+                @test_throws PosDefException cholesky(Hermitian(nonpd))
+                @test !issuccess(cholesky(Symmetric(nonpd),check=false))
+            else
+                @test issuccess(cholesky(Hermitian(nonpd),check=false))
+            end
+            
             m_a = m_a*m_a'
             m = SMatrix{4,4}(m_a)
             @test cholesky(m).L ≈ cholesky(m_a).L

--- a/test/chol.jl
+++ b/test/chol.jl
@@ -34,15 +34,6 @@ using LinearAlgebra: PosDefException
             m_a = randn(elty, 4,4)
             #non hermitian
             @test_throws PosDefException cholesky(SMatrix{4,4}(m_a))
-            nonpd = SVector{4}(@view(m_a[:,1])) |> x -> x * x'
-            if elty <: Real
-                @test_throws PosDefException cholesky(nonpd)
-                @test !issuccess(cholesky(nonpd,check=false))
-                @test_throws PosDefException cholesky(Hermitian(nonpd))
-                @test !issuccess(cholesky(Symmetric(nonpd),check=false))
-            else
-                @test issuccess(cholesky(Hermitian(nonpd),check=false))
-            end
             
             m_a = m_a*m_a'
             m = SMatrix{4,4}(m_a)
@@ -95,6 +86,21 @@ using LinearAlgebra: PosDefException
             v = SVector{3}(v_a)
             @test (@inferred c \ v) isa SVector{3,elty}
             @test c \ v ≈ c_a \ v_a
+        end
+
+        @testset "Check" begin
+            for i ∈ [1,3,7,25]
+                x = SVector(ntuple(elty, i))
+                nonpd = x * x'
+                if i > 1
+                    @test_throws PosDefException cholesky(nonpd)
+                    @test !issuccess(cholesky(nonpd,check=false))
+                    @test_throws PosDefException cholesky(Hermitian(nonpd))
+                    @test !issuccess(cholesky(Hermitian(nonpd),check=false))
+                else
+                    @test issuccess(cholesky(Hermitian(nonpd),check=false))
+                end
+            end
         end
     end
 


### PR DESCRIPTION
4x4 cholesky factor is more or less the same fast before:
```julia
julia> @benchmark cholesky(Symmetric($(Ref(Sa))[]))
BenchmarkTools.Trial:
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     8.304 ns (0.00% GC)
  median time:      8.556 ns (0.00% GC)
  mean time:        8.628 ns (0.00% GC)
  maximum time:     13.635 ns (0.00% GC)
  --------------
  samples:          10000
evals/sample:     999
```
as after
```julia
julia> @benchmark cholesky(Symmetric($(Ref(Sa))[]))
BenchmarkTools.Trial:
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     8.305 ns (0.00% GC)
  median time:      8.620 ns (0.00% GC)
  mean time:        8.739 ns (0.00% GC)
  maximum time:     28.546 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     999
```
I didn't thoroughly test performance across sizes and machines, but seems like adding these checks and replacing potential complex domain errors with `PosDefExprion`s should hurt performance.

Now we have:
```julia
julia> nonpd = @SVector(rand(4)) |> x -> x*x'
4×4 SMatrix{4, 4, Float64, 16} with indices SOneTo(4)×SOneTo(4):
 0.578918   0.194674   0.490644   0.0660168
 0.194674   0.0654633  0.16499    0.0221996
 0.490644   0.16499    0.41583    0.0559505
 0.0660168  0.0221996  0.0559505  0.00752821

julia> cholesky(nonpd)
ERROR: PosDefException: matrix is not positive definite; Cholesky factorization failed.
Stacktrace:
 [1] _check_chol
   @ ~/.julia/dev/StaticArrays/src/cholesky.jl:19 [inlined]
 [2] macro expansion
   @ ~/.julia/dev/StaticArrays/src/cholesky.jl:0 [inlined]
 [3] _cholesky
   @ ~/.julia/dev/StaticArrays/src/cholesky.jl:27 [inlined]
 [4] #cholesky#674
   @ ~/.julia/dev/StaticArrays/src/cholesky.jl:5 [inlined]
 [5] cholesky(A::SMatrix{4, 4, Float64, 16})
   @ StaticArrays ~/.julia/dev/StaticArrays/src/cholesky.jl:4
 [6] top-level scope
   @ REPL[100]:1

julia> cholesky(nonpd,check=false)
Failed factorization of type Cholesky{Float64, SMatrix{4, 4, Float64, 16}}
```