### PR TITLE
Fix url in docs/make.jl to deploy document

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -18,4 +18,4 @@ makedocs(;
     sitename = "StaticArrays.jl",
 )
 
-deploydocs(; repo = "github.com/juliaarrays/StaticArrays.jl")
+deploydocs(; repo = "github.com/JuliaArrays/StaticArrays.jl")


### PR DESCRIPTION
The document deployment is still failing. (see #870, #872, [gh-pages branch](https://github.com/JuliaArrays/StaticArrays.jl/tree/gh-pages))

Here's a screenshot from [github actions](https://github.com/JuliaArrays/StaticArrays.jl/runs/2211769463?check_suite_focus=true).
![image](https://user-images.githubusercontent.com/7488140/113511426-a45d1d00-959a-11eb-8c0c-9bb684646930.png)

This seems because of [this commit](https://github.com/JuliaArrays/StaticArrays.jl/pull/872/commits/5ed6b41ca9125d216ec5454df146541376ad98f8), and I've fixed it.

@fredrikekre
Do you have any ideas?