### PR TITLE
add ConstructionBase interface

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,9 +6,11 @@ version = "1.1.1"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
 
 [compat]
 julia = "1"
+ConstructionBase = "1.0, 1.1.0"
 
 [extras]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/src/StaticArrays.jl
+++ b/src/StaticArrays.jl
@@ -10,6 +10,7 @@ import Base: getindex, setindex!, size, similar, vec, show, length, convert, pro
 
 import Statistics: mean
 
+using ConstructionBase
 using Random
 import Random: rand, randn, randexp, rand!, randn!, randexp!
 using Core.Compiler: return_type
@@ -143,6 +144,7 @@ include("qr.jl")
 include("deque.jl")
 include("flatten.jl")
 include("io.jl")
+include("constructorof.jl")
 
 if Base.VERSION >= v"1.4.2"
     include("precompile.jl")

--- a/src/constructorof.jl
+++ b/src/constructorof.jl
@@ -1,0 +1,15 @@
+struct SArrayConstructor{S,N,L} end
+struct MArrayConstructor{S,N,L} end
+struct SizedArrayConstructor{S,N,M} end
+
+(::SArrayConstructor{S,N,L})(data::NTuple{L,T}) where {S,T,N,L} = SArray{S,T,N,L}(data)
+(::MArrayConstructor{S,N,L})(data::NTuple{L,T}) where {S,T,N,L} = MArray{S,T,N,L}(data)
+(::SizedArrayConstructor{S,N,M})(data::AbstractArray{T,M}) where {S,T,N,M} = 
+    SizedArray{S,T,N,M}(data)
+
+ConstructionBase.constructorof(sa::Type{<:SArray{S,<:Any,N,L}}) where {S,N,L} = 
+    SArrayConstructor{S,N,L}()
+ConstructionBase.constructorof(sa::Type{<:MArray{S,<:Any,N,L}}) where {S,N,L} = 
+    MArrayConstructor{S,N,L}()
+ConstructionBase.constructorof(sa::Type{<:SizedArray{S,<:Any,N,M}}) where {S,N,M} = 
+    SizedArrayConstructor{S,N,M}()

--- a/test/constructorof.jl
+++ b/test/constructorof.jl
@@ -1,0 +1,17 @@
+using StaticArrays, Test, ConstructionBase
+
+@testset "constructorof" begin
+    sa = @SVector [2, 4, 6, 8]
+    sa2 = ConstructionBase.constructorof(typeof(sa))((3.0, 5.0, 7.0, 9.0))
+    @test sa2 === @SVector [3.0, 5.0, 7.0, 9.0]
+
+    ma = @MMatrix [2.0 4.0; 6.0 8.0]
+    ma2 = ConstructionBase.constructorof(typeof(ma))((1, 2, 3, 4))
+    @test ma2 isa MArray{Tuple{2,2},Int,2,4}
+    @test all(ma2 .=== @MMatrix [1 3; 2 4])
+
+    sz = SizedArray{Tuple{2,2}}([1 2;3 4])
+    sz2 = ConstructionBase.constructorof(typeof(sz))([:a :b; :c :d]) 
+    @test sz2 == SizedArray{Tuple{2,2}}([:a :b; :c :d])
+    @test typeof(sz2) <: SizedArray{Tuple{2,2},Symbol,2,2}
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,6 +34,7 @@ addtests("SUnitRange.jl")
 addtests("SizedArray.jl")
 addtests("SDiagonal.jl")
 addtests("SHermitianCompact.jl")
+addtests("constructorof.jl")
 
 addtests("ambiguities.jl")
 addtests("custom_types.jl")


### PR DESCRIPTION
This PR adds an interface for [ConstructionBase.jl](https://github.com/JuliaObjects/ConstructionBase.jl).

This has been requested in #839. I realize there will be resistance to adding a dependency here, with good reason. But ConstrucitonBase.jl is a very small package that seems to make no difference to compile times here, and has some compelling use-cases.

StaticArrays are immutable. Modifying them requires calling their constructor. Packages like Flatten.jl, BangBand.jl, Setfield.jl, Accessors.jl facilitate modifying immutable objects. But objects with types that can't be derived from their fields, like `SArray`, need a `constructorof` method for this to work generically. Setfield.jl can already modify `SArray` by setting array indices, but just replacing e.g. the `SArray` tuple entirely in a generic way (that has no dep on StaticArrays) is not possible.

To illustrate a little more, the main use cases I have for this PR are:
- reconstructing large, complex objects (that often contain `SArrray`) automatically with e.g. all Float64 swapped to Float32 For use on GPU, using Flatten.jl.
- ModelParamaters.jl working with static arrays of parameters - parameter wrappers can be placed anywhere in a model, and used for control or optimisation, and stripped out later. Currently they cant go in a static array because you can't remove them later.
- Swapping `Array` for `CuArray` and similar while re-wrapping `SizedArray`. The goal is that all arrays in an object can be swapped for `CuArray` without needing an explicit Adapt.jl inteface, see e.g. https://github.com/JuliaObjects/ConstructionBase.jl/issues/34

Static arrays are the most common objects that don't work with ConstuctionBase.jl, and the most friction for scaling this kind of functionality. Currently doing these things requires adding  `constructorof` manually in a script.

The other option is for this code to be moved into a glue package (maybe StaticArraysConstructors.jl at JuliaObjects). I haven't done that because a) it would be type pyracy,  and should at least be blessed pyracy, and b) It would be a tiny package (10 lines) probably not worth the maintenance, c) that would require users to load and depend on it to get this functionality, instead of it just working, and d) packages that wanted to ensure that `constructorof` works in most case will need a StaticArrays.jl dependency.