### PR TITLE
Compact show for SArray and MArray

### DIFF
--- a/src/MArray.jl
+++ b/src/MArray.jl
@@ -280,3 +280,9 @@ function Base.view(
 end
 
 Base.elsize(::Type{<:MArray{S,T}}) where {S,T} = sizeof(T)
+
+function Base.show(io::IO, S::MArray)
+    print(io, typeof(S), "(")
+    show(io, Tuple(S))
+    print(io, ")")
+end

--- a/src/SArray.jl
+++ b/src/SArray.jl
@@ -286,6 +286,6 @@ end
 
 function Base.show(io::IO, S::SArray)
     print(io, typeof(S), "(")
-    show(io, S.data)
+    show(io, Tuple(S))
     print(io, ")")
 end

--- a/src/SArray.jl
+++ b/src/SArray.jl
@@ -283,3 +283,9 @@ end
 function promote_rule(::Type{<:SArray{S,T,N,L}}, ::Type{<:SArray{S,U,N,L}}) where {S,T,U,N,L}
     SArray{S,promote_type(T,U),N,L}
 end
+
+function Base.show(io::IO, S::SArray)
+    print(io, typeof(S), "(")
+    show(io, S.data)
+    print(io, ")")
+end

--- a/test/MArray.jl
+++ b/test/MArray.jl
@@ -188,4 +188,18 @@
         v[] = 2
         @test v[] == 2
     end
+
+    @testset "show" begin
+        io = IOBuffer()
+
+        S = MVector{2,Float64}(1,2)
+        show(io, S)
+        S_str = String(take!(io))
+        @test S_str == "MVector{2, Float64}((1.0, 2.0))"
+
+        S = MMatrix{1, 2, Int, 2}(1, 2)
+        show(io, S)
+        S_str = String(take!(io))
+        @test S_str == "MMatrix{1, 2, $Int, 2}((1, 2))"
+    end
 end

--- a/test/SArray.jl
+++ b/test/SArray.jl
@@ -149,7 +149,7 @@
 
     @testset "show" begin
         io = IOBuffer()
-        S = SVector{2, Float64}(1.0, 2.0)
+        S = SVector{2, Float64}(1, 2)
         show(io, S)
         S_str = String(take!(io))
         @test S_str == "SVector{2, Float64}((1.0, 2.0))"

--- a/test/SArray.jl
+++ b/test/SArray.jl
@@ -146,4 +146,17 @@
         @test @inferred(promote_type(SVector{2,Int}, SVector{2,Float64})) === SVector{2,Float64}
         @test @inferred(promote_type(SMatrix{2,3,Float32,6}, SMatrix{2,3,Complex{Float64},6})) === SMatrix{2,3,Complex{Float64},6}
     end
+
+    @testset "show" begin
+        io = IOBuffer()
+        S = SVector{2, Float64}(1.0, 2.0)
+        show(io, S)
+        S_str = String(take!(io))
+        @test S_str == "SVector{2, Float64}((1.0, 2.0))"
+
+        S = SMatrix{1, 2, Int, 2}(1, 2)
+        show(io, S)
+        S_str = String(take!(io))
+        @test S_str == "SMatrix{1, 2, $Int, 2}((1, 2))"
+    end
 end


### PR DESCRIPTION
Along the lines of https://github.com/JuliaLang/julia/pull/40722, this changes the way `show(io, ::SArray)` and `show(io, ::MArray)` displays the contents. The type information printed as a prefix distinguishes these from other dense arrays. Also makes the output valid as a constructor.

After this PR:
```julia
julia> show(SVector{2, Int64}((1, 2)))
SVector{2, Int64}((1, 2))

julia> show(MVector{2, Int64}((1, 2)))
MVector{2, Int64}((1, 2))
```