### PR TITLE
reshape with Val

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StaticArrays"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "1.2.1"
+version = "1.2.2"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/abstractarray.jl
+++ b/src/abstractarray.jl
@@ -204,8 +204,8 @@ end
 
 reshape(a::Array, ::Size{S}) where {S} = SizedArray{Tuple{S...}}(a)
 
-Base.rdims(out::Val{N}, inds::Tuple{Vararg{SOneTo}}) where {N} = Base.rdims(ntuple(i -> SOneTo(1), Val(N)), inds)
-Base.rdims(out::Tuple{Any}, inds::Tuple{Vararg{SOneTo}}) = (SOneTo(Base.rdims_trailing(inds...)),)
+Base.rdims(out::Val{N}, inds::Tuple{SOneTo, Vararg{SOneTo}}) where {N} = Base.rdims(ntuple(i -> SOneTo(1), Val(N)), inds)
+Base.rdims(out::Tuple{Any}, inds::Tuple{SOneTo, Vararg{SOneTo}}) = (SOneTo(Base.rdims_trailing(inds...)),)
 
 @inline vec(a::StaticArray) = reshape(a, Size(prod(Size(typeof(a)))))
 

--- a/src/abstractarray.jl
+++ b/src/abstractarray.jl
@@ -204,6 +204,9 @@ end
 
 reshape(a::Array, ::Size{S}) where {S} = SizedArray{Tuple{S...}}(a)
 
+Base.rdims(out::Val{N}, inds::Tuple{Vararg{SOneTo}}) where {N} = Base.rdims(ntuple(i -> SOneTo(1), Val(N)), inds)
+Base.rdims(out::Tuple{Any}, inds::Tuple{Vararg{SOneTo}}) = (SOneTo(Base.rdims_trailing(inds...)),)
+
 @inline vec(a::StaticArray) = reshape(a, Size(prod(Size(typeof(a)))))
 
 @inline copy(a::StaticArray) = typeof(a)(Tuple(a))

--- a/test/SArray.jl
+++ b/test/SArray.jl
@@ -151,6 +151,19 @@
         @test (@inferred view(m, 1, 1, CartesianIndex(1))) === Scalar(m[1, 1])
 
         @test reverse(m) == reverse(reverse(collect(m), dims = 2), dims = 1)
+
+        m1 = reshape(m, Val(1))
+        @test m1 isa SVector
+        @test all(((x, y),) -> isequal(x,y), zip(m, m1))
+
+        m2 = reshape(m, Val(2))
+        @test m2 === m
+
+        m3 = reshape(m, Val(3))
+        @test eltype(m3) == eltype(m)
+        @test ndims(m3) == 3
+        @test size(m3) == (size(m)..., 1)
+        @test all(((x, y),) -> isequal(x,y), zip(m, m3))
     end
 
     @testset "promotion" begin

--- a/test/SArray.jl
+++ b/test/SArray.jl
@@ -153,13 +153,16 @@
         @test reverse(m) == reverse(reverse(collect(m), dims = 2), dims = 1)
 
         m1 = reshape(m, Val(1))
+
+        m1 = @inferred reshape(m, Val(1))
+
         @test m1 isa SVector
         @test all(((x, y),) -> isequal(x,y), zip(m, m1))
 
-        m2 = reshape(m, Val(2))
+        m2 = @inferred reshape(m, Val(2))
         @test m2 === m
 
-        m3 = reshape(m, Val(3))
+        m3 = @inferred reshape(m, Val(3))
         @test eltype(m3) == eltype(m)
         @test ndims(m3) == 3
         @test size(m3) == (size(m)..., 1)


### PR DESCRIPTION
I'm not too sure if these are too internal to `Base`, but with this PR the following work now:

```julia
julia> S = SMatrix{1, 2, Int, 2}(1, 2)
1×2 SMatrix{1, 2, Int64, 2} with indices SOneTo(1)×SOneTo(2):
 1  2

julia> reshape(S, Val(1))
2-element SVector{2, Int64} with indices SOneTo(2):
 1
 2

julia> reshape(S, Val(3))
1×2×1 SArray{Tuple{1, 2, 1}, Int64, 3, 2} with indices SOneTo(1)×SOneTo(2)×SOneTo(1):
[:, :, 1] =
 1  2

julia> @view S[1,1,1]
0-dimensional view(::SArray{Tuple{1, 2, 1}, Int64, 3, 2}, 1, 1, 1) with eltype Int64:
1

```