### PR TITLE
Views of SArray may use getindex to avoid the SubArray wrapper

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StaticArrays"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "1.1.3"
+version = "1.2.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/SArray.jl
+++ b/src/SArray.jl
@@ -283,3 +283,6 @@ end
 function promote_rule(::Type{<:SArray{S,T,N,L}}, ::Type{<:SArray{S,U,N,L}}) where {S,T,U,N,L}
     SArray{S,promote_type(T,U),N,L}
 end
+
+# SArrays may avoid the SubArray wrapper and consequently an additional level of indirection
+Base.view(S::SArray, I...) = getindex(S, I...)

--- a/src/SArray.jl
+++ b/src/SArray.jl
@@ -283,6 +283,3 @@ end
 function promote_rule(::Type{<:SArray{S,T,N,L}}, ::Type{<:SArray{S,U,N,L}}) where {S,T,U,N,L}
     SArray{S,promote_type(T,U),N,L}
 end
-
-# SArrays may avoid the SubArray wrapper and consequently an additional level of indirection
-Base.view(S::SArray, I...) = getindex(S, I...)

--- a/src/abstractarray.jl
+++ b/src/abstractarray.jl
@@ -301,4 +301,4 @@ end
 # wrap elements in Scalar to be consistent with 0D views
 _maybewrapscalar(S::SArray{<:Any,T}, r::T) where {T} = Scalar{T}(r)
 _maybewrapscalar(S, r) = r
-Base.view(S::SArray, I...) = _maybewrapscalar(S, getindex(S, I...))
+Base.view(S::SArray, I::Union{Colon, Integer, SOneTo}...) = _maybewrapscalar(S, getindex(S, I...))

--- a/src/abstractarray.jl
+++ b/src/abstractarray.jl
@@ -301,4 +301,4 @@ end
 # wrap elements in Scalar to be consistent with 0D views
 _maybewrapscalar(S::SArray{<:Any,T}, r::T) where {T} = Scalar{T}(r)
 _maybewrapscalar(S, r) = r
-Base.view(S::SArray, I::Union{Colon, Integer, SOneTo}...) = _maybewrapscalar(S, getindex(S, I...))
+Base.view(S::SArray, I::Union{Colon, Integer, SOneTo, StaticArray{<:Tuple, Int}}...) = _maybewrapscalar(S, getindex(S, I...))

--- a/src/abstractarray.jl
+++ b/src/abstractarray.jl
@@ -295,3 +295,6 @@ if VERSION >= v"1.6.0-DEV.1334"
         return similar_type(typeof(a), Size(newlen))(Base.rest(Tuple(a), i + 1))
     end
 end
+
+# SArrays may avoid the SubArray wrapper and consequently an additional level of indirection
+Base.view(S::SArray, I...) = getindex(S, I...)

--- a/src/abstractarray.jl
+++ b/src/abstractarray.jl
@@ -297,4 +297,8 @@ if VERSION >= v"1.6.0-DEV.1334"
 end
 
 # SArrays may avoid the SubArray wrapper and consequently an additional level of indirection
-Base.view(S::SArray, I...) = getindex(S, I...)
+# The output may use the broadcasting machinery defined for StaticArrays (see issue #892)
+# wrap elements in Scalar to be consistent with 0D views
+_maybewrapscalar(S::SArray{<:Any,T}, r::T) where {T} = Scalar{T}(r)
+_maybewrapscalar(S, r) = r
+Base.view(S::SArray, I...) = _maybewrapscalar(S, getindex(S, I...))

--- a/src/abstractarray.jl
+++ b/src/abstractarray.jl
@@ -301,4 +301,7 @@ end
 # wrap elements in Scalar to be consistent with 0D views
 _maybewrapscalar(S::SArray{<:Any,T}, r::T) where {T} = Scalar{T}(r)
 _maybewrapscalar(S, r) = r
-Base.view(S::SArray, I::Union{Colon, Integer, SOneTo, StaticArray{<:Tuple, Int}}...) = _maybewrapscalar(S, getindex(S, I...))
+function Base.view(S::SArray, I::Union{Colon, Integer, SOneTo, StaticArray{<:Tuple, Int}, CartesianIndex}...)
+    V = getindex(S, I...)
+    _maybewrapscalar(S, V)
+end

--- a/test/SArray.jl
+++ b/test/SArray.jl
@@ -140,8 +140,9 @@
 
         @test Base.dataids(m) === ()
 
-        @test (@view m[:, :]) == m
-        @test all(map(isequal, (@view m[1, 1]), m[1, 1]))
+        @test (@view m[:, :]) === m
+        @test (@view m[:, 1]) === @SArray [11, 12]
+        @test (@view m[1, 1])[] === m[1, 1]
     end
 
     @testset "promotion" begin

--- a/test/SArray.jl
+++ b/test/SArray.jl
@@ -142,6 +142,9 @@
 
         @test (@view m[:, :]) === m
         @test (@view m[:, 1]) === @SArray [11, 12]
+        @test (@view m[SVector{2,Int}(1,2), 1]) === @SArray [11, 12]
+        @test (@view m[SMatrix{2,2,Int}(1,2,3,4)]) === m
+        @test (@view m[SOneTo(2), 1]) === @SArray [11, 12]
         @test (@view m[1, 1])[] === m[1, 1]
     end
 

--- a/test/SArray.jl
+++ b/test/SArray.jl
@@ -139,6 +139,9 @@
         @test_throws Exception m[1] = 1
 
         @test Base.dataids(m) === ()
+
+        @test (@view m[:, :]) == m
+        @test all(map(isequal, (@view m[1, 1]), m[1, 1]))
     end
 
     @testset "promotion" begin

--- a/test/SArray.jl
+++ b/test/SArray.jl
@@ -140,12 +140,15 @@
 
         @test Base.dataids(m) === ()
 
-        @test (@view m[:, :]) === m
-        @test (@view m[:, 1]) === @SArray [11, 12]
-        @test (@view m[SVector{2,Int}(1,2), 1]) === @SArray [11, 12]
-        @test (@view m[SMatrix{2,2,Int}(1,2,3,4)]) === m
-        @test (@view m[SOneTo(2), 1]) === @SArray [11, 12]
-        @test (@view m[1, 1])[] === m[1, 1]
+        @test (@inferred view(m, :, :)) === m
+        @test (@inferred view(m, :, 1)) === @SArray [11, 12]
+        @test (@inferred view(m, SVector{2,Int}(1,2), 1)) === @SArray [11, 12]
+        @test (@inferred view(m, SMatrix{2,2,Int}(1,2,3,4))) === m
+        @test (@inferred view(m, SOneTo(2), 1)) === @SArray [11, 12]
+        @test (@inferred view(m, 1, 1)) === Scalar(m[1, 1])
+        @test (@inferred view(m, CartesianIndex(1, 1))) === Scalar(m[1, 1])
+        @test (@inferred view(m, CartesianIndex(1, 1, 1))) === Scalar(m[1, 1])
+        @test (@inferred view(m, 1, 1, CartesianIndex(1))) === Scalar(m[1, 1])
     end
 
     @testset "promotion" begin

--- a/test/SVector.jl
+++ b/test/SVector.jl
@@ -82,6 +82,14 @@
         @test length(v) === 3
 
         @test_throws Exception v[1] = 1
+
+        @test (@inferred view(v, :)) === v
+        @test (@inferred view(v, 1)) === Scalar(v[1])
+        @test (@inferred view(v, CartesianIndex(1))) === Scalar(v[1])
+        @test (@inferred view(v, CartesianIndex(1,1))) === Scalar(v[1])
+        @test (@inferred view(v, 1, CartesianIndex(1))) === Scalar(v[1])
+        @test (@inferred view(v, SVector{2,Int}(1,2))) === @SArray [11, 12]
+        @test (@inferred view(v, SOneTo(2))) === @SArray [11, 12]
     end
 
     @testset "CartesianIndex" begin


### PR DESCRIPTION
Since `SArrays` are immutable and support allocation-less vector indexing for certain index types, views of `SArray`s constructed with such indices do not need to retain the `SubArray` wrapper and may just return another `SArray` obtained through indexing. Fixes #892.

After this PR:
```julia
julia> s = SMatrix{3,3}(ones(3,3));

julia> sv = @view s[:, :]
3×3 SMatrix{3, 3, Float64, 9} with indices SOneTo(3)×SOneTo(3):
 1.0  1.0  1.0
 1.0  1.0  1.0
 1.0  1.0  1.0

julia> @btime $(Ref(sv))[] + $(Ref(sv))[]
  3.730 ns (0 allocations: 0 bytes)
3×3 SMatrix{3, 3, Float64, 9} with indices SOneTo(3)×SOneTo(3):
 2.0  2.0  2.0
 2.0  2.0  2.0
 2.0  2.0  2.0
```