### PR TITLE
specialize axes(S, dim) to return SOneTo

### DIFF
--- a/src/abstractarray.jl
+++ b/src/abstractarray.jl
@@ -12,6 +12,7 @@ Base.axes(s::StaticArray) = _axes(Size(s))
 @pure function _axes(::Size{sizes}) where {sizes}
     map(SOneTo, sizes)
 end
+Base.axes(s::StaticArray, d) = d <= ndims(s) ? _axes(Size(s))[d] : SOneTo{1}()
 Base.axes(rv::Adjoint{<:Any,<:StaticVector})   = (SOneTo(1), axes(rv.parent)...)
 Base.axes(rv::Transpose{<:Any,<:StaticVector}) = (SOneTo(1), axes(rv.parent)...)
 

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -119,6 +119,10 @@ using StaticArrays, Test, LinearAlgebra
         # IndexLinear
         @test reshape(view(ones(4, 4), 1, 1:4), Size(4, 1)) == SMatrix{4,1}(ones(4, 1))
         @test_throws DimensionMismatch reshape(view(ones(4,4), 1:4, 1:2), Size(5, 2))
+
+        s = SA[1,2];
+        s2 = @inferred reshape(s, axes(s,1), axes(s,2))
+        @test s2 isa StaticArray
     end
 
     @testset "copy" begin


### PR DESCRIPTION
Currently

```julia
julia> s = SA[1,2];

julia> axes(s,2)
Base.OneTo(1)
```

After this PR
```julia
julia> axes(s,2)
SOneTo(1)
```

As a consequence,

```julia
julia> reshape(s, axes(s,1), axes(s,2))
2×1 SMatrix{2, 1, Int64, 2} with indices SOneTo(2)×SOneTo(1):
 1
 2
```

returns a `StaticArray`