### PR TITLE
`permutedims` for vectors and matrices

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StaticArrays"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "1.2.8"
+version = "1.2.9"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/abstractarray.jl
+++ b/src/abstractarray.jl
@@ -226,13 +226,19 @@ end
 
 # TODO permutedims? So far just the cases without perm:
 
+Base.permutedims(A::SVector{N}) where {N} = SMatrix{1,N}(A.data...)
+Base.permutedims(A::MVector{N}) where {N} = MMatrix{1,N}(A.data...)
+Base.permutedims(A::SizedVector{N}) where {N} = SizedMatrix{1,N}(permutedims(A.data))
+
 @generated function Base.permutedims(A::SMatrix{M,N}) where {M,N}
     exs = permutedims([:(getindex(A,$i,$j)) for i in 1:M, j in 1:N])
     return :(SMatrix{N,M}($(exs...)))
 end
-
-Base.permutedims(A::SVector{N}) where {N} = SMatrix{1,N}(A.data...)
-Base.permutedims(A::MVector{N}) where {N} = MMatrix{1,N}(A.data...)
+@generated function Base.permutedims(A::MMatrix{M,N}) where {M,N}
+    exs = permutedims([:(getindex(A,$i,$j)) for i in 1:M, j in 1:N])
+    return :(MMatrix{N,M}($(exs...)))
+end
+Base.permutedims(A::SizedMatrix{M,N}) where {M,N} = SizedMatrix{N,M}(permutedims(A.data))
 
 #--------------------------------------------------
 # Concatenation

--- a/src/abstractarray.jl
+++ b/src/abstractarray.jl
@@ -228,7 +228,7 @@ end
 
 @generated function Base.permutedims(A::SMatrix{M,N}) where {M,N}
     exs = permutedims([:(getindex(A,$i,$j)) for i in 1:M, j in 1:N])
-    return :(SMatrix{M,N}($(exs...)))
+    return :(SMatrix{N,M}($(exs...)))
 end
 
 Base.permutedims(A::SVector{N}) where {N} = SMatrix{1,N}(A.data...)

--- a/src/abstractarray.jl
+++ b/src/abstractarray.jl
@@ -224,7 +224,15 @@ for rot in [:rotl90, :rotr90]
     end
 end
 
-# TODO permutedims?
+# TODO permutedims? So far just the cases without perm:
+
+@generated function Base.permutedims(A::SMatrix{M,N}) where {M,N}
+    exs = permutedims([:(getindex(A,$i,$j)) for i in 1:M, j in 1:N])
+    return :(SMatrix{M,N}($(exs...)))
+end
+
+Base.permutedims(A::SVector{N}) where {N} = SMatrix{1,N}(A.data...)
+Base.permutedims(A::MVector{N}) where {N} = MMatrix{1,N}(A.data...)
 
 #--------------------------------------------------
 # Concatenation

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -222,6 +222,7 @@ end
     @test @inferred(permutedims(SVector(1,2,3))) === SMatrix{1,3}(1,2,3)
     @test @inferred(permutedims(MVector(1,2,3))) == MMatrix{1,3}(1,2,3)
     @test @inferred(permutedims(MVector(1,2,3))) isa MMatrix{1,3}
+    @test @inferred(permutedims(SizedVector{3}(rand(3)))) isa SizedMatrix{1,3}
 
     @test @inferred(permutedims(SMatrix{2,2}(1,2,3,4))) === SMatrix{2,2}(1,3,2,4)
     @test @inferred(permutedims(MMatrix{2,2}(1,2,3,4))) == MMatrix{2,2}(1,3,2,4)
@@ -229,6 +230,8 @@ end
 
     A = rand(2,3)
     @test @inferred(permutedims(SMatrix{2,3}(A))) === SMatrix{3,2}(A')
+    @test @inferred(permutedims(MMatrix{2,3}(A))) == MMatrix{3,2}(A')
+    @test @inferred(permutedims(SizedMatrix{2,3}(A))) == SizedMatrix{3,2}(A')
 end
 
 @testset "vcat() and hcat()" begin

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -218,6 +218,16 @@ using StaticArrays, Test, LinearAlgebra
     end
 end
 
+@testset "permutedims" begin
+    @test @inferred(permutedims(SVector(1,2,3))) === SMatrix{1,3}(1,2,3)
+    @test @inferred(permutedims(MVector(1,2,3))) == MMatrix{1,3}(1,2,3)
+    @test @inferred(permutedims(MVector(1,2,3))) isa MMatrix{1,3}
+
+    @test @inferred(permutedims(SMatrix{2,2}(1,2,3,4))) === SMatrix{2,2}(1,3,2,4)
+    @test @inferred(permutedims(MMatrix{2,2}(1,2,3,4))) == MMatrix{2,2}(1,3,2,4)
+    @test @inferred(permutedims(MMatrix{2,2}(1,2,3,4))) isa MMatrix{2,2}
+end
+
 @testset "vcat() and hcat()" begin
     @test @inferred(vcat(SVector(1,2,3))) === SVector(1,2,3)
     @test @inferred(hcat(SVector(1,2,3))) === SMatrix{3,1}(1,2,3)

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -219,19 +219,21 @@ using StaticArrays, Test, LinearAlgebra
 end
 
 @testset "permutedims" begin
+    # vector -> one-row matrix
     @test @inferred(permutedims(SVector(1,2,3))) === SMatrix{1,3}(1,2,3)
-    @test @inferred(permutedims(MVector(1,2,3))) == MMatrix{1,3}(1,2,3)
     @test @inferred(permutedims(MVector(1,2,3))) isa MMatrix{1,3}
-    @test @inferred(permutedims(SizedVector{3}(rand(3)))) isa SizedMatrix{1,3}
+    @test @inferred(permutedims(MVector(1,2,3))) == [1 2 3]
+    @test @inferred(permutedims(SizedVector{3}([1,2,3]))) isa SizedMatrix{1,3}
+    @test @inferred(permutedims(SizedVector{3}([1,2,3]))) == [1 2 3]
 
+    # matrix
     @test @inferred(permutedims(SMatrix{2,2}(1,2,3,4))) === SMatrix{2,2}(1,3,2,4)
-    @test @inferred(permutedims(MMatrix{2,2}(1,2,3,4))) == MMatrix{2,2}(1,3,2,4)
-    @test @inferred(permutedims(MMatrix{2,2}(1,2,3,4))) isa MMatrix{2,2}
-
     A = rand(2,3)
     @test @inferred(permutedims(SMatrix{2,3}(A))) === SMatrix{3,2}(A')
-    @test @inferred(permutedims(MMatrix{2,3}(A))) == MMatrix{3,2}(A')
-    @test @inferred(permutedims(SizedMatrix{2,3}(A))) == SizedMatrix{3,2}(A')
+    @test @inferred(permutedims(MMatrix{2,3}(A))) isa MMatrix{3,2}
+    @test @inferred(permutedims(MMatrix{2,3}(A))) == A'
+    @test @inferred(permutedims(SizedMatrix{2,3}(A))) isa SizedMatrix{3,2}
+    @test @inferred(permutedims(SizedMatrix{2,3}(A))) == A'
 end
 
 @testset "vcat() and hcat()" begin

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -226,6 +226,9 @@ end
     @test @inferred(permutedims(SMatrix{2,2}(1,2,3,4))) === SMatrix{2,2}(1,3,2,4)
     @test @inferred(permutedims(MMatrix{2,2}(1,2,3,4))) == MMatrix{2,2}(1,3,2,4)
     @test @inferred(permutedims(MMatrix{2,2}(1,2,3,4))) isa MMatrix{2,2}
+
+    A = rand(2,3)
+    @test @inferred(permutedims(SMatrix{2,3}(A))) === SMatrix{3,2}(A')
 end
 
 @testset "vcat() and hcat()" begin


### PR DESCRIPTION
Before:
```
julia> permutedims(SA[1,2,3])
1×3 reshape(::SVector{3, Int64}, 1, 3) with eltype Int64:
 1  2  3

julia> axes(ans)
(Base.OneTo(1), Base.OneTo(3))

julia> permutedims(SA[1 2; 3 4])
2×2 MMatrix{2, 2, Int64, 4} with indices SOneTo(2)×SOneTo(2):
 1  3
 2  4
```
After:
```
julia> permutedims(SA[1,2,3])
1×3 SMatrix{1, 3, Int64, 3} with indices SOneTo(1)×SOneTo(3):
 1  2  3

julia> permutedims(SA[1 2;3 4])
2×2 SMatrix{2, 2, Int64, 4} with indices SOneTo(2)×SOneTo(2):
 1  3
 2  4 
```
Unchanged are all the cases taking `perm`, discussed in #806.
```
julia> permutedims(@SArray(rand(1,2,3)), (3,2,1))
3×2×1 MArray{Tuple{3, 2, 1}, Float64, 3, 6} with indices SOneTo(3)×SOneTo(2)×SOneTo(1):
```

~~I'm not too sure what should happen for MArrays or SizedArrays.~~