### PR TITLE
Add simple 3- and 4-arg `*` methods

### DIFF
--- a/src/matrix_multiply.jl
+++ b/src/matrix_multiply.jl
@@ -15,11 +15,15 @@ import LinearAlgebra: BlasFloat, matprod, mul!
 @inline *(A::StaticArray{Tuple{N,1},<:Any,2}, B::Adjoint{<:Any,<:StaticVector}) where {N} = vec(A) * B
 @inline *(A::StaticArray{Tuple{N,1},<:Any,2}, B::Transpose{<:Any,<:StaticVector}) where {N} = vec(A) * B
 
+# Avoid LinearAlgebra._quad_matmul's order calculation on equal sizes
+@inline *(A::StaticMatrix{N,N}, B::StaticMatrix{N,N}, C::StaticMatrix{N,N}) where {N} = (A*B)*C
+@inline *(A::StaticMatrix{N,N}, B::StaticMatrix{N,N}, C::StaticMatrix{N,N}, D::StaticMatrix{N,N}) where {N} = ((A*B)*C)*D
+
 """
     mul_result_structure(a::Type, b::Type)
 
 Get a structure wrapper that should be applied to the result of multiplication of matrices
-of given types (a*b). 
+of given types (a*b).
 """
 function mul_result_structure(a, b)
     return identity
@@ -114,7 +118,6 @@ end
         b::Union{Transpose{Tb, <:StaticVector}, Adjoint{Tb, <:StaticVector}}) where {sa, sb, Ta, Tb}
     newsize = (sa[1], sb[2])
     exprs = [:(a[$i]*b[$j]) for i = 1:sa[1], j = 1:sb[2]]
-    
     return quote
         @_inline_meta
         T = promote_op(*, Ta, Tb)
@@ -209,7 +212,7 @@ end
         while m < M
             mu = min(M, m + M_r)
             mrange = m+1:mu
-            
+
             atemps_init = [:($(atemps[k1]) = a[$k1]) for k1 = mrange]
             exprs_init = [:($(tmps[k1,k2])  = $(atemps[k1]) * b[$(1 + (k2-1) * sb[1])]) for k1 = mrange, k2 = nrange]
             atemps_loop_init = [:($(atemps[k1]) = a[$(k1-sa[1]) + $(sa[1])*j]) for k1 = mrange]

--- a/test/matrix_multiply.jl
+++ b/test/matrix_multiply.jl
@@ -173,6 +173,9 @@ mul_wrappers = [
         @test m*transpose(n) === @SMatrix [8 14; 18 32]
         @test transpose(m)*transpose(n) === @SMatrix [11 19; 16 28]
 
+        @test @inferred(m*n*m)  === @SMatrix [49 72; 109 160]
+        @test @inferred(m*n*m*n)  === @SMatrix [386 507; 858 1127]
+
         # check different sizes because there are multiple implementations for matrices of different sizes
         for (mm, nn) in [
             (m, n),


### PR DESCRIPTION
This PR repairs a small slowdown due to https://github.com/JuliaLang/julia/pull/37898. When all matrices are the same size, that wastes a few ns thinking about their sizes, while this PR restores the left-to-right behaviour: 
```julia
julia> s1,s2,s3,s4,s5 = fill(3,5);

julia> a=@SMatrix rand(s1,s2); b=@SMatrix rand(s2,s3); c=@SMatrix rand(s3,s4); d=@SMatrix rand(s4,s5);

julia> @btime *($(Ref(a))[],$(Ref(b))[],$(Ref(c))[],$(Ref(d))[]);  # after 37898, this thinks about the sizes
  9.291 ns (0 allocations: 0 bytes)

julia> @btime (($(Ref(a))[] * $(Ref(b))[]) * $(Ref(c))[]) * $(Ref(d))[];  # simply left to right
  5.208 ns (0 allocations: 0 bytes)
```
When the matrices are of different sizes, things aren't so clear-cut. Sometimes the re-ordering does speed things up, sometimes it doesn't.