### PR TITLE
Implement vector indexing for SDiagonal with statically sized indices

### DIFF
--- a/src/SDiagonal.jl
+++ b/src/SDiagonal.jl
@@ -17,6 +17,11 @@ SDiagonal(a::StaticMatrix{N,N,T}) where {N,T} = Diagonal(diag(a))
 size(::Type{<:SDiagonal{N}}) where {N} = (N,N)
 size(::Type{<:SDiagonal{N}}, d::Int) where {N} = d > 2 ? 1 : N
 
+Base.axes(D::SDiagonal) = (ax = axes(diag(D), 1); (ax, ax))
+Base.axes(D::SDiagonal, d) = d <= 2 ? axes(D)[d] : SOneTo(1)
+
+Base.reshape(a::SDiagonal, s::Tuple{SOneTo,Vararg{SOneTo}}) = reshape(a, homogenize_shape(s))
+
 # define specific methods to avoid allocating mutable arrays
 \(D::SDiagonal, b::AbstractVector) = D.diag .\ b
 \(D::SDiagonal, b::StaticVector) = D.diag .\ b # catch ambiguity

--- a/test/SDiagonal.jl
+++ b/test/SDiagonal.jl
@@ -70,6 +70,15 @@ using StaticArrays, Test, LinearAlgebra
 
         @test length(m) === 4*4
 
+        m2 = SMatrix{4,4}(m)
+        @test axes(m) === axes(m2)
+        @test axes(m, 1) === axes(m2, 1)
+        @test axes(m, 3) == SOneTo(1)
+
+        @test m[:, 1] === SVector{4}(m[1,1], 0, 0, 0)
+        @test m[:, :] === m2
+        @test m[2, 2, 1] === m[2, 2]
+
         @test_throws Exception m[1] = 1
 
         b = @SVector [2,-1,2,1]


### PR DESCRIPTION
On master:

```julia
julia> m = SDiagonal(@SVector [11, 12, 13, 14])
4×4 Diagonal{Int64, SVector{4, Int64}}:
 11   ⋅   ⋅   ⋅
  ⋅  12   ⋅   ⋅
  ⋅   ⋅  13   ⋅
  ⋅   ⋅   ⋅  14

julia> axes(m)
(Base.OneTo(4), Base.OneTo(4))

julia> @btime $m[:, 1]
  256.280 ns (4 allocations: 256 bytes)
4-element SparseArrays.SparseVector{Int64, Int64} with 1 stored entry:
  [1]  =  11

julia> @btime $m[:,:]
  714.179 ns (5 allocations: 384 bytes)
4×4 SparseArrays.SparseMatrixCSC{Int64, Int64} with 4 stored entries:
 11   ⋅   ⋅   ⋅
  ⋅  12   ⋅   ⋅
  ⋅   ⋅  13   ⋅
  ⋅   ⋅   ⋅  14

julia> @btime $m[:]
  521.792 ns (4 allocations: 256 bytes)
16-element SparseArrays.SparseVector{Int64, Int64} with 4 stored entries:
  [1 ]  =  11
  [6 ]  =  12
  [11]  =  13
  [16]  =  14
```

After this PR:

```julia
julia> axes(m)
(SOneTo(4), SOneTo(4))

julia> @btime $m[:,1]
  2.676 ns (0 allocations: 0 bytes)
4-element SVector{4, Int64} with indices SOneTo(4):
 11
  0
  0
  0

julia> @btime $m[:,:]
  5.316 ns (0 allocations: 0 bytes)
4×4 SMatrix{4, 4, Int64, 16} with indices SOneTo(4)×SOneTo(4):
 11   0   0   0
  0  12   0   0
  0   0  13   0
  0   0   0  14

julia> @btime $m[:]
  18.406 ns (0 allocations: 0 bytes)
16-element SVector{16, Int64} with indices SOneTo(16):
 11
  0
  0
  0
  0
 12
  0
  0
  0
  0
 13
  0
  0
  0
  0
 14
```