### PR TITLE
Run CI on latest released 1.x version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
     strategy:
       matrix:
         version:
+          - '1'
           - '1.0'
           - '1.1'
           - '1.2'

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -185,19 +185,21 @@ using StaticArrays, Test, LinearAlgebra
         @test @inferred(convert(AbstractArray{Float64}, diag)) isa Diagonal{Float64,SVector{2,Float64}}
         @test convert(AbstractArray{Float64}, diag) == diag
         # The following cases currently convert the SMatrix into an MMatrix, because
-        # the constructor in Base invokes `similar`, rather than `convert`, on the static array
+        # the constructor in Base invokes `similar`, rather than `convert`, on the static 
+        # array. This was fixed in https://github.com/JuliaLang/julia/pull/40831; so should
+        # work from Julia v1.8.0-DEV.55
         trans = Transpose(SVector(1,2))
-        @test_broken @inferred(convert(AbstractArray{Float64}, trans)) isa Transpose{Float64,SVector{2,Float64}}
+        @test_was_once_broken v"1.8.0-DEV.55" @inferred(convert(AbstractArray{Float64}, trans)) isa Transpose{Float64,SVector{2,Float64}}
         adj = Adjoint(SVector(1,2))
-        @test_broken @inferred(convert(AbstractArray{Float64}, adj)) isa Adjoint{Float64,SVector{2,Float64}}
+        @test_was_once_broken v"1.8.0-DEV.55" @inferred(convert(AbstractArray{Float64}, adj)) isa Adjoint{Float64,SVector{2,Float64}}
         uptri = UpperTriangular(SA[1 2; 0 3])
-        @test_broken @inferred(convert(AbstractArray{Float64}, uptri)) isa UpperTriangular{Float64,SMatrix{2,2,Float64,4}}
+        @test_was_once_broken v"1.8.0-DEV.55" @inferred(convert(AbstractArray{Float64}, uptri)) isa UpperTriangular{Float64,SMatrix{2,2,Float64,4}}
         lotri = LowerTriangular(SA[1 0; 2 3])
-        @test_broken @inferred(convert(AbstractArray{Float64}, lotri)) isa LowerTriangular{Float64,SMatrix{2,2,Float64,4}}
+        @test_was_once_broken v"1.8.0-DEV.55" @inferred(convert(AbstractArray{Float64}, lotri)) isa LowerTriangular{Float64,SMatrix{2,2,Float64,4}}
         unituptri = UnitUpperTriangular(SA[1 2; 0 1])
-        @test_broken @inferred(convert(AbstractArray{Float64}, unituptri)) isa UnitUpperTriangular{Float64,SMatrix{2,2,Float64,4}}
+        @test_was_once_broken v"1.8.0-DEV.55" @inferred(convert(AbstractArray{Float64}, unituptri)) isa UnitUpperTriangular{Float64,SMatrix{2,2,Float64,4}}
         unitlotri = UnitLowerTriangular(SA[1 0; 2 1])
-        @test_broken @inferred(convert(AbstractArray{Float64}, unitlotri)) isa UnitLowerTriangular{Float64,SMatrix{2,2,Float64,4}}
+        @test_was_once_broken v"1.8.0-DEV.55" @inferred(convert(AbstractArray{Float64}, unitlotri)) isa UnitLowerTriangular{Float64,SMatrix{2,2,Float64,4}}
     end
 end
 

--- a/test/ambiguities.jl
+++ b/test/ambiguities.jl
@@ -10,8 +10,8 @@ const allowable_ambiguities =
         0
     end
 
-if v"1.6.0-DEV.816" <= VERSION < v"1.6.0-rc"
-    # Revisit in 1.6.0-rc1 or before. See
+if VERSION ≥ v"1.6.0"
+    # TODO: Revisit and fix. See
     #   https://github.com/JuliaLang/julia/pull/36962
     #   https://github.com/JuliaLang/julia/issues/36951
     @test_broken length(detect_ambiguities(#=LinearAlgebra, =#StaticArrays)) <= allowable_ambiguities

--- a/test/arraymath.jl
+++ b/test/arraymath.jl
@@ -86,9 +86,27 @@ import StaticArrays.arithmetic_closure
         @test (t-t) isa T
         @test (t*t) isa T
         @test (t/t) isa T
+    end
 
-        if isbitstype(T0)
-            @test @allocated(arithmetic_closure(T0)) == 0
-        end
+    @testset "arithmetic_closure allocation" begin
+        # a little icky, but `@allocated` seems to be too fragile to use in a loop with
+        # types assigned in variables (see #924); so we write out a test explicitly for
+        # every `isbitstype` type of interest
+        @test (@allocated arithmetic_closure(UInt128))        == 0
+        @test (@allocated arithmetic_closure(UInt16))         == 0
+        @test (@allocated arithmetic_closure(UInt32))         == 0
+        @test (@allocated arithmetic_closure(UInt64))         == 0
+        @test (@allocated arithmetic_closure(UInt8))          == 0
+        @test (@allocated arithmetic_closure(Int128))         == 0
+        @test (@allocated arithmetic_closure(Int16))          == 0
+        @test (@allocated arithmetic_closure(Int32))          == 0
+        @test (@allocated arithmetic_closure(Int64))          == 0
+        @test (@allocated arithmetic_closure(Int8))           == 0
+        @test (@allocated arithmetic_closure(Float16))        == 0
+        @test (@allocated arithmetic_closure(Float32))        == 0
+        @test (@allocated arithmetic_closure(Float64))        == 0
+        @test (@allocated arithmetic_closure(Bool))           == 0
+        @test (@allocated arithmetic_closure(Complex{Int64})) == 0
+        @test (@allocated arithmetic_closure(ComplexF64))     == 0
     end
 end

--- a/test/svd.jl
+++ b/test/svd.jl
@@ -76,7 +76,7 @@ using StaticArrays, Test, LinearAlgebra
             # Note the placement of @inferred brackets is important.
             #
             # This only seems to work on >= v"1.5" due to unknown compiler improvements.
-            svd_full_false(A) = svd(m_sing2, full=false)
+            svd_full_false(A) = svd(A, full=false)
             @test @inferred(svd_full_false(m_sing2)).S ≈ svd(Matrix(m_sing2)).S
         end
 

--- a/test/svd.jl
+++ b/test/svd.jl
@@ -71,11 +71,12 @@ using StaticArrays, Test, LinearAlgebra
         @testinf svd(m_sing2'; full=Val(true)) \ v2 ≈ svd(Matrix(m_sing2'); full=true) \ Vector(v2)
         @testinf svd(m_sing2; full=Val(true)) \ m23' ≈ svd(Matrix(m_sing2); full=true) \ Matrix(m23')
         @testinf svd(m_sing2'; full=Val(true)) \ m23 ≈ svd(Matrix(m_sing2'); full=true) \ Matrix(m23)
-        if VERSION >= v"1.5-DEV"
+        if v"1.6" > VERSION >= v"1.5-DEV"
             # Test that svd of rectangular matrix is inferred.
             # Note the placement of @inferred brackets is important.
             #
-            # This only seems to work on >= v"1.5" due to unknown compiler improvements.
+            # This only seems to work on v"1.5" due to unknown compiler improvements; seems
+            # to have stopped working again on v"1.6" and later?
             svd_full_false(A) = svd(A, full=false)
             @test @inferred(svd_full_false(m_sing2)).S ≈ svd(Matrix(m_sing2)).S
         end

--- a/test/svd.jl
+++ b/test/svd.jl
@@ -71,14 +71,18 @@ using StaticArrays, Test, LinearAlgebra
         @testinf svd(m_sing2'; full=Val(true)) \ v2 ≈ svd(Matrix(m_sing2'); full=true) \ Vector(v2)
         @testinf svd(m_sing2; full=Val(true)) \ m23' ≈ svd(Matrix(m_sing2); full=true) \ Matrix(m23')
         @testinf svd(m_sing2'; full=Val(true)) \ m23 ≈ svd(Matrix(m_sing2'); full=true) \ Matrix(m23)
-        if v"1.6" > VERSION >= v"1.5-DEV"
+        if VERSION >= v"1.5"
             # Test that svd of rectangular matrix is inferred.
             # Note the placement of @inferred brackets is important.
             #
             # This only seems to work on v"1.5" due to unknown compiler improvements; seems
             # to have stopped working again on v"1.6" and later?
             svd_full_false(A) = svd(A, full=false)
-            @test @inferred(svd_full_false(m_sing2)).S ≈ svd(Matrix(m_sing2)).S
+            if VERSION < v"1.6"
+                @test        @inferred(svd_full_false(m_sing2)).S ≈ svd(Matrix(m_sing2)).S
+            else
+                @test_broken @inferred(svd_full_false(m_sing2)).S ≈ svd(Matrix(m_sing2)).S
+            end
         end
 
         @testinf svd(mc_sing) \ v ≈ svd(Matrix(mc_sing)) \ Vector(v)

--- a/test/testutil.jl
+++ b/test/testutil.jl
@@ -92,6 +92,23 @@ macro inferred_maybe_allow(allow, ex)
     end
 end
 
+"""
+    @test_was_once_broken good_version ex
+
+Expands to `@test ex` if `VERSION ≥ good_version` and to `@test_broken ex` if 
+`VERSION ≥ good_version`. Useful for tests that are broken on earlier versions of Julia
+that are fixed on later versions.
+"""
+macro test_was_once_broken(good_version, ex)
+    esc(quote
+        if VERSION < $good_version
+            @test_broken $ex
+        else
+            @test $ex
+        end
+    end)
+end
+
 @testset "test utils" begin
     @testset "@testinf" begin
         @testinf [1,2] == [1,2]


### PR DESCRIPTION

I noticed that CI wasn't running on 1.6, which I figured would be a good idea, even if it increases the run-time.

With this PR, it still doesn't run on 1.5, and won't run on 1.6 after 1.7 is released (then it'll run on 1.7) - but it seems better than not to run at all, and doesn't increase CI time very much compared to adding everything.