### PR TITLE
Fixes to `norm` and friends (closes #915)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StaticArrays"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "1.2.7"
+version = "1.2.8"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -208,11 +208,13 @@ end
 
 #--------------------------------------------------
 # Norms
-function _inner_eltype(v::AbstractArray)
-    return eltype(v) <: AbstractArray ? _inner_eltype(first(v)) : eltype(v)
+function _inner_eltype(v::StaticArray)
+    isempty(v) && return float(norm(zero(eltype(v))))
+    return _inner_eltype(first(v))
 end
 _inner_eltype(x::Number) = typeof(x)
-@inline _init_zero(v::AbstractArray) = zero(float(real(_inner_eltype(v))))
+@inline _init_zero(v::StaticArray) = float(norm(zero(_inner_eltype(v))))
+
 @inline function LinearAlgebra.norm_sqr(v::StaticArray)
     return mapreduce(LinearAlgebra.norm_sqr, +, v; init=_init_zero(v))
 end
@@ -235,7 +237,7 @@ end
 end
 
 function _norm_p0(x)
-    T = float(real(_inner_eltype(x)))
+    T = isempty(x) ? eltype(x) : float(norm(zero(first(x))))
     return iszero(x) ? zero(T) :  one(T)
 end
 

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -208,10 +208,7 @@ end
 
 #--------------------------------------------------
 # Norms
-function _inner_eltype(v::StaticArray)
-    isempty(v) && return float(norm(zero(eltype(v))))
-    return _inner_eltype(first(v))
-end
+_inner_eltype(v::AbstractArray) = isempty(v) ? eltype(v) : _inner_eltype(first(v))
 _inner_eltype(x::Number) = typeof(x)
 @inline _init_zero(v::StaticArray) = float(norm(zero(_inner_eltype(v))))
 
@@ -237,8 +234,8 @@ end
 end
 
 function _norm_p0(x)
-    T = isempty(x) ? eltype(x) : float(norm(zero(first(x))))
-    return iszero(x) ? zero(T) :  one(T)
+    T = _inner_eltype(x)
+    return float(norm(iszero(x) ? zero(T) : one(T)))
 end
 
 @inline norm(a::StaticArray, p::Real) = _norm(Size(a), a, p)

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -234,7 +234,10 @@ end
     end
 end
 
-_norm_p0(x) = iszero(x) ? zero(float(_inner_eltype(x))) : one(float(_inner_eltype(x)))
+function _norm_p0(x)
+    T = float(real(_inner_eltype(x)))
+    return iszero(x) ? zero(T) :  one(T)
+end
 
 @inline norm(a::StaticArray, p::Real) = _norm(Size(a), a, p)
 @generated function _norm(::Size{S}, a::StaticArray, p::Real) where {S}

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -208,12 +208,12 @@ end
 
 #--------------------------------------------------
 # Norms
-function _inner_eltype(v::AbstractVector)
-    return eltype(v) <: AbstractVector ? _inner_eltype(first(v)) : eltype(v)
+function _inner_eltype(v::AbstractArray)
+    return eltype(v) <: AbstractArray ? _inner_eltype(first(v)) : eltype(v)
 end
 _inner_eltype(x::Number) = typeof(x)
-@inline _init_zero(v::AbstractVector) = zero(float(real(_inner_eltype(v))))
-@inline function LinearAlgebra.norm_sqr(v::StaticVector)
+@inline _init_zero(v::AbstractArray) = zero(float(real(_inner_eltype(v))))
+@inline function LinearAlgebra.norm_sqr(v::StaticArray)
     return mapreduce(LinearAlgebra.norm_sqr, +, v; init=_init_zero(v))
 end
 

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -205,16 +205,15 @@ StaticArrays.similar_type(::Union{RotMat2,Type{RotMat2}}) = SMatrix{2,2,Float64,
 
         # nested vectors
         a  = SA[SA[1, 2], SA[3, 4]]
-        a′ = convert(Vector{Vector{Int}}, a)
-        @test norm(a) ≈ norm(a′)
-        aa   = SVector(a,a)
-        a′a′ = [a′,a′]
-        @test norm(SA[a,a]) ≈ norm([a,a])
+        av = convert(Vector{Vector{Int}}, a)
+        aa = SA[a,a]
+        @test norm(a) ≈ norm(av)
+        @test norm(aa) ≈ norm([a,a])
+        @test norm(aa) ≈ norm([av,av])
         @test norm(SVector{0,Int}()) === norm(Vector{Float64}()) === 0.0
 
         # do not overflow for Int
         c = SA[typemax(Int)÷2, typemax(Int)÷3]
-        c′ = Vector(c)
         @test norm(c) ≈ norm(Vector(c))
         @test norm(SA[c,c]) ≈ norm([Vector(c), Vector(c)])
 
@@ -223,11 +222,19 @@ StaticArrays.similar_type(::Union{RotMat2,Type{RotMat2}}) = SMatrix{2,2,Float64,
         @test norm(SA[[0,0],[1,1]], 0) == norm([[0,0],[1,1]], 0) == 1.0
         @test norm(SA[[0,1],[1,1]], 0) == norm([[0,1],[1,1]], 0) == 2.0
 
+        # complex numbers
+        @test norm(SA[1+im, 2+3im]) ≈ norm([1+im, 2+3im])
+        @test norm(SA[22.0+0.1im, 2.0-23.0im]) ≈ norm([22.0+0.1im, 2.0-23.0im])
+        a_c, av_c = a+1im*a, av+1im*av
+        @test norm(a_c) ≈ norm(av_c)
+
         # p-norms for nested vectors
-        @test norm(a, 2) ≈ norm(a′,2)
-        @test norm(a, Inf) ≈ norm(a′, Inf)
-        @test norm(a, 1) ≈ norm(a′, 1)
-        @test norm(a, 0) ≈ norm(a′, 0)
+        for (x,xv) in ((a,av), (a_c, av_c))
+            @test norm(x, 2) ≈ norm(xv,2)
+            @test norm(x, Inf) ≈ norm(xv, Inf)
+            @test norm(x, 1) ≈ norm(xv, 1)
+            @test norm(x, 0) ≈ norm(xv, 0)
+        end
 
         # type-stability
         if VERSION ≥ v"1.2"
@@ -237,6 +244,7 @@ StaticArrays.similar_type(::Union{RotMat2,Type{RotMat2}}) = SMatrix{2,2,Float64,
             @test (@inferred norm(a)) == (@inferred norm(a, 2))
             @test (@inferred norm(aa)) == (@inferred norm(aa, 2))
             @test (@inferred norm(float.(aa))) == (@inferred norm(float.(aa), 2))
+            @test (@inferred norm(SVector{0,Int}())) == (@inferred norm(SVector{0,Int}(), 2))
         end
 
         # norm of empty SVector

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -230,10 +230,14 @@ StaticArrays.similar_type(::Union{RotMat2,Type{RotMat2}}) = SMatrix{2,2,Float64,
         @test norm(a, 0) ≈ norm(a′, 0)
 
         # type-stability
-        @test (@inferred norm(a[1])) == (@inferred norm(a[1], 2))
-        @test (@inferred norm(a)) == (@inferred norm(a, 2))
-        @test (@inferred norm(aa)) == (@inferred norm(aa, 2))
-        @test (@inferred norm(float.(aa))) == (@inferred norm(float.(aa), 2))
+        if VERSION ≥ v"1.2"
+            # only test strict type-stability on v1.2+, since there were Base-related type
+            # instabilities in `norm` prior to https://github.com/JuliaLang/julia/pull/30481
+            @test (@inferred norm(a[1])) == (@inferred norm(a[1], 2))
+            @test (@inferred norm(a)) == (@inferred norm(a, 2))
+            @test (@inferred norm(aa)) == (@inferred norm(aa, 2))
+            @test (@inferred norm(float.(aa))) == (@inferred norm(float.(aa), 2))
+        end
 
         # norm of empty SVector
         @test norm(SVector{0,Int}()) isa float(Int)

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -234,6 +234,7 @@ StaticArrays.similar_type(::Union{RotMat2,Type{RotMat2}}) = SMatrix{2,2,Float64,
             @test norm(x, Inf) ≈ norm(xv, Inf)
             @test norm(x, 1) ≈ norm(xv, 1)
             @test norm(x, 0) ≈ norm(xv, 0)
+            @test norm(SA[Int[], [1,2]], 0) ≈ norm([Int[], [1,2]], 0)
         end
 
         # type-stability


### PR DESCRIPTION
This closes the issue noted in #915, i.e. the following now works:
```jl
a  = SA[SA[1, 2], SA[3, 4]]
norm(a)
```
which threw before. It also fixes a similar issue for the "p"-`norm`.

This also fixes a few other issues with `norm` and friends:

- Previously, the implementation of both the `norm` and "p"-`norm` were susceptible to integer overflow because they didn't convert to float early. They do now. This reduces performance a slight bit for `::SVector{Int}` but that seems preferable to quietly overflowing.
- Previously, the "p"-`norm` implementation was type-unstable for `SVector{Int}` inputs (sometimes returning `Float64` sometimes `Int`, depending on `p`). It now always returns a floating point value, consistently with Base.

