### PR TITLE
Fix method ambiguity for `qr` (#931) and lingering ambiguities for `lu`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StaticArrays"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "1.2.4"
+version = "1.2.5"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/lu.jl
+++ b/src/lu.jl
@@ -45,8 +45,11 @@ end
 
 @static if VERSION >= v"1.7-DEV"
     # disambiguation
-    function lu(A::StaticMatrix{N,N}, pivot::Val{true}) where {N}
-        Base.@invoke lu(A::StaticMatrix{N,N} where N, pivot::Union{Val{false},Val{true}})
+    for p in (:true, :false)
+        @eval function lu(A::StaticMatrix{N,N}, pivot::Val{$p}; check = true) where {N}
+            Base.@invoke lu(A::StaticMatrix{N,N} where N, 
+                            pivot::Union{Val{false},Val{true}}; check)
+        end
     end
 end
 

--- a/src/qr.jl
+++ b/src/qr.jl
@@ -47,6 +47,15 @@ true
     end
 end
 
+@static if VERSION >= v"1.7-DEV"
+    # disambiguation
+    for p in (:true, :false)
+        @eval function qr(A::StaticMatrix, pivot::Val{$p})
+            Base.@invoke qr(A::StaticMatrix, pivot::Union{Val{false},Val{true}})
+        end
+    end
+end
+
 function identity_perm(R::StaticMatrix{N,M,T}) where {N,M,T}
     return similar_type(R, Int, Size((M,)))(ntuple(x -> x, Val{M}()))
 end

--- a/src/qr.jl
+++ b/src/qr.jl
@@ -11,10 +11,26 @@ Base.iterate(S::QR, ::Val{:R}) = (S.R, Val(:p))
 Base.iterate(S::QR, ::Val{:p}) = (S.p, Val(:done))
 Base.iterate(S::QR, ::Val{:done}) = nothing
 
+for pv in (:true, :false)
+    @eval begin
+        @inline function qr(A::StaticMatrix, pivot::Val{$pv})
+            QRp = _qr(Size(A), A, pivot)
+            if length(QRp) === 2
+                # create an identity permutation since that is cheap,
+                # and much safer since, in the case of isbits types, we can't
+                # safely leave the field undefined.
+                p = identity_perm(QRp[2])
+                return QR(QRp[1], QRp[2], p)
+            else # length(QRp) === 3
+                return QR(QRp[1], QRp[2], QRp[3])
+            end 
+        end
+    end
+end
 """
-    qr(A::StaticMatrix, pivot=Val(false))
+    qr(A::StaticMatrix, pivot::Union{Val{true}, Val{false}} = Val(false))
 
-Compute the QR factorization of `A`. The factors can be obtain by iteration:
+Compute the QR factorization of `A`. The factors can be obtained by iteration:
 
 ```julia
 julia> A = @SMatrix rand(3,4);
@@ -34,27 +50,7 @@ julia> F.Q * F.R ≈ A
 true
 ```
 """
-@inline function qr(A::StaticMatrix, pivot::Union{Val{false}, Val{true}} = Val(false))
-    QRp = _qr(Size(A), A, pivot)
-    if length(QRp) === 2
-        # create an identity permutation since that is cheap,
-        # and much safer since, in the case of isbits types, we can't
-        # safely leave the field undefined.
-        p = identity_perm(QRp[2])
-        return QR(QRp[1], QRp[2], p)
-    else # length(QRp) === 3
-        return QR(QRp[1], QRp[2], QRp[3])
-    end
-end
-
-@static if VERSION >= v"1.7-DEV"
-    # disambiguation
-    for p in (:true, :false)
-        @eval function qr(A::StaticMatrix, pivot::Val{$p})
-            Base.@invoke qr(A::StaticMatrix, pivot::Union{Val{false},Val{true}})
-        end
-    end
-end
+qr(A::StaticMatrix) = qr(A, Val(false))
 
 function identity_perm(R::StaticMatrix{N,M,T}) where {N,M,T}
     return similar_type(R, Int, Size((M,)))(ntuple(x -> x, Val{M}()))

--- a/test/lu.jl
+++ b/test/lu.jl
@@ -68,10 +68,11 @@ end
 
 @testset "LU method ambiguity" begin
     # Issue #920; just test that methods do not throw an ambiguity error when called
-    A = @SMatrix [1.0 2.0; 3.0 4.0]
-    @test isa(lu(A),              StaticArrays.LU)
-    @test isa(lu(A, Val(true)),   StaticArrays.LU)
-    @test isa(lu(A, Val(false)),  StaticArrays.LU)
-    @test isa(lu(A; check=false), StaticArrays.LU)
-    @test isa(lu(A; check=true),  StaticArrays.LU)
+    for A in ((@SMatrix [1.0 2.0; 3.0 4.0]), (@SMatrix [1.0 2.0 3.0; 4.0 5.0 6.0]))
+        @test isa(lu(A),              StaticArrays.LU)
+        @test isa(lu(A, Val(true)),   StaticArrays.LU)
+        @test isa(lu(A, Val(false)),  StaticArrays.LU)
+        @test isa(lu(A; check=false), StaticArrays.LU)
+        @test isa(lu(A; check=true),  StaticArrays.LU)
+    end
 end

--- a/test/lu.jl
+++ b/test/lu.jl
@@ -65,3 +65,13 @@ end
     @test_throws SingularException lu(A)
     @test !issuccess(lu(A; check = false))
 end
+
+@testset "LU method ambiguity" begin
+    # Issue #920; just test that methods do not throw an ambiguity error when called
+    A = @SMatrix [1.0 2.0; 3.0 4.0]
+    @test isa(lu(A),              StaticArrays.LU)
+    @test isa(lu(A, Val(true)),   StaticArrays.LU)
+    @test isa(lu(A, Val(false)),  StaticArrays.LU)
+    @test isa(lu(A; check=false), StaticArrays.LU)
+    @test isa(lu(A; check=true),  StaticArrays.LU)
+end

--- a/test/qr.jl
+++ b/test/qr.jl
@@ -60,3 +60,11 @@ Random.seed!(42)
         test_qr(arr)
     end
 end
+
+@testset "QR method ambiguity" begin
+    # Issue #931; just test that methods do not throw an ambiguity error when called
+    A = @SMatrix [1.0 2.0 3.0; 4.0 5.0 6.0]
+    @test isa(qr(A),              StaticArrays.QR)
+    @test isa(qr(A, Val(true)),   StaticArrays.QR)
+    @test isa(qr(A, Val(false)),  StaticArrays.QR)
+end


### PR DESCRIPTION
This basically does just what #921 did to fix #920 for #931; i.e., removes the ambiguity for `qr`.

While doing that, I noticed that #921 hadn't completely resolved the ambiguity for `lu`; e.g., if called as `lu(A, Val(false))` there would still be an ambiguity error; so I fixed that as well. Similarly, I believe it would previously have been ambiguous if provided with a `check` keyword argument.

Added a few tests as well.