### PR TITLE
Add a two-argument show method for SUnitRange.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StaticArrays"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "1.0.2"
+version = "1.2.7"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/SUnitRange.jl
+++ b/src/SUnitRange.jl
@@ -25,7 +25,9 @@ end
     return Start + i - 1
 end
 
-# Shorten show for REPL use.
-function show(io::IO, ::MIME"text/plain", ::SUnitRange{Start, L}) where {Start, L}
+function show(io::IO, ::SUnitRange{Start, L}) where {Start, L}
     print(io, "SUnitRange($Start,$(Start + L - 1))")
 end
+
+# Shorten show for REPL use.
+show(io::IO, ::MIME"text/plain", su::SUnitRange) = show(io, su)

--- a/test/SUnitRange.jl
+++ b/test/SUnitRange.jl
@@ -10,4 +10,13 @@
 
     @test_throws Exception StaticArrays.SUnitRange{1, -1}()
     @test_throws TypeError StaticArrays.SUnitRange{1, 1.5}()
+
+    let su = StaticArrays.SUnitRange(1, 2),
+        str = "SUnitRange(1,2)",
+        str2 = "($(str), $(str))"
+        @test repr(su) == str
+        @test repr("text/plain", su) == str
+        @test repr((su, su)) == str2
+        @test repr("text/plain", (su, su)) == str2
+    end
 end


### PR DESCRIPTION
This allows recovery of containers etc with `SUnitRange` from printed output.

Cf [discussion](https://discourse.julialang.org/t/print-sunitrange-within-tuple-as-is-not-as-a-vector/64678/).