### PR TITLE
implement `float` and `real` for `StaticArray` (fix #935)

### DIFF
--- a/src/StaticArrays.jl
+++ b/src/StaticArrays.jl
@@ -13,7 +13,7 @@ import Statistics: mean
 using Random
 import Random: rand, randn, randexp, rand!, randn!, randexp!
 using Core.Compiler: return_type
-import Base: sqrt, exp, log
+import Base: sqrt, exp, log, float, real
 using LinearAlgebra
 import LinearAlgebra: transpose, adjoint, dot, eigvals, eigen, lyap, tr,
                       kron, diag, norm, dot, diagm, lu, svd, svdvals,

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -47,3 +47,11 @@ length_val(a::Type{T}) where {T<:StaticArrayLike} = length_val(Size(T))
         @inbounds return $(Expr(:tuple, exprs...))
     end
 end
+
+# `float` and `real` of StaticArray types, analogously to application to scalars (issue 935)
+for SAT in (:SArray, :MArray)
+    @eval begin
+        float(::Type{$SAT{S,T,N,L}}) where {S,T,N,L} = $SAT{S,float(T),N,L}
+        real(::Type{$SAT{S,T,N,L}}) where {S,T,N,L} = $SAT{S,real(T),N,L}
+    end
+end

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -49,9 +49,5 @@ length_val(a::Type{T}) where {T<:StaticArrayLike} = length_val(Size(T))
 end
 
 # `float` and `real` of StaticArray types, analogously to application to scalars (issue 935)
-for SAT in (:SArray, :MArray)
-    @eval begin
-        float(::Type{$SAT{S,T,N,L}}) where {S,T,N,L} = $SAT{S,float(T),N,L}
-        real(::Type{$SAT{S,T,N,L}}) where {S,T,N,L} = $SAT{S,real(T),N,L}
-    end
-end
+float(::Type{SA}) where SA<:StaticArray{_S,T,_N} where {_S,T,_N} = similar_type(SA, float(T))
+real(::Type{SA}) where SA<:StaticArray{_S,T,_N} where {_S,T,_N} = similar_type(SA, real(T))

--- a/test/convert.jl
+++ b/test/convert.jl
@@ -19,3 +19,26 @@ end # testset
     @test Scalar{Int}[SVector{1,Int}(3), SVector{1,Float64}(2.0)] == [Scalar{Int}(3), Scalar{Int}(2)]
     @test Scalar[SVector{1,Int}(3), SVector{1,Float64}(2.0)] == [Scalar{Int}(3), Scalar{Float64}(2.0)]
 end
+
+@testset "`real` and `float` of SArray/MArray" begin
+    # Issue 935
+    for SAT in (SArray, MArray)
+        vInt = SAT(SA[1,2,3])           # S/MVector{3, Int}
+        @test real(typeof(vInt)) === typeof(vInt)
+        @test float(typeof(vInt)) === typeof(float.(vInt))
+
+        vCInt = vInt + 1im*vInt         # S/MVector{3, Complex{Int}}
+        @test real(typeof(vCInt)) === typeof(vInt)
+        @test float(typeof(vCInt)) === typeof(float.(vCInt))
+        
+        vvInt = SAT(SA[vInt, vInt])    # S/MVector{2, S/MVector{3, Int}}
+        @test real(typeof(vvInt)) === SAT{Tuple{2}, SAT{Tuple{3}, Int, 1, 3}, 1, 2}
+        @test float(typeof(vvInt)) === SAT{Tuple{2}, SAT{Tuple{3}, Float64, 1, 3}, 1, 2}
+
+        vvCInt = SAT(SA[vCInt, vCInt]) # S/MVector{2, S/MVector{3, Complex{Int}}}
+        @test real(typeof(vvCInt)) === SAT{Tuple{2}, SAT{Tuple{3}, Int, 1, 3}, 1, 2}
+        @test float(typeof(vvCInt)) === SAT{Tuple{2}, SAT{Tuple{3}, Complex{Float64}, 1, 3}, 1, 2}
+    end
+    mInt = SA[Int16(1) Int16(2) Int16(3); Int16(4) Int16(5) Int16(6)] # SMatrix{3,2,Int16}
+    @test float(typeof(mInt)) === SMatrix{2, 3, float(Int16), 6}
+end


### PR DESCRIPTION
This just implements the suggestion in #935 for `SArray` and `MArray` and includes some tests.
I put the definitions in `src/convert.jl` - but let me know if they fit better elsewhere.