### PR TITLE
Add a precompile for `(*)(::SMatrix, ::SVector)`

### DIFF
--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -11,6 +11,7 @@ function _precompile_()
         for S = 2:4                    # some common sizes
             L = S*S
             @assert precompile(Tuple{typeof(*),SMatrix{S, S, T, L},SMatrix{S, S, T, L}})
+            @assert precompile(Tuple{typeof(*),SMatrix{S, S, T, L},SVector{S, T}})
             @assert precompile(Tuple{typeof(inv),SMatrix{S, S, T, L}})
             @assert precompile(Tuple{typeof(transpose),SMatrix{S, S, T, L}})
             @assert precompile(Tuple{typeof(_adjoint),Size{(S, S)},SMatrix{S, S, T, L}})


### PR DESCRIPTION
I was doing some profiling with SnoopCompile of a package of mine and this method came up as somewhat expensive - I figured this might be worth fixing here since that operation is likely to be widely used by users of StaticArrays.