### PR TITLE
Expand signature of `normalize` from `StaticVector` to `StaticArray` (fixes #887)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StaticArrays"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "1.2.11"
+version = "1.2.12"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -270,11 +270,11 @@ end
     end
 end
 
-@inline normalize(a::StaticVector) = inv(norm(a))*a
-@inline normalize(a::StaticVector, p::Real) = inv(norm(a, p))*a
+@inline normalize(a::StaticArray) = inv(norm(a))*a
+@inline normalize(a::StaticArray, p::Real) = inv(norm(a, p))*a
 
-@inline normalize!(a::StaticVector) = (a .*= inv(norm(a)); return a)
-@inline normalize!(a::StaticVector, p::Real) = (a .*= inv(norm(a, p)); return a)
+@inline normalize!(a::StaticArray) = (a .*= inv(norm(a)); return a)
+@inline normalize!(a::StaticArray, p::Real) = (a .*= inv(norm(a, p)); return a)
 
 @inline tr(a::StaticMatrix) = _tr(Size(a), a)
 @generated function _tr(::Size{S}, a::StaticMatrix) where {S}

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -203,6 +203,17 @@ StaticArrays.similar_type(::Union{RotMat2,Type{RotMat2}}) = SMatrix{2,2,Float64,
         @test normalize!(MVector(1.,2.,3.)) ≈ normalize([1.,2.,3.])
         @test normalize!(MVector(1.,2.,3.), 1) ≈ normalize([1.,2.,3.], 1)
 
+        if VERSION ≥ v"1.5" # `normalize` with `AbstractArray` signature added in v1.5
+            @test normalize(SA[1 2 3; 4 5 6; 7 8 9]) ≈ normalize([1 2 3; 4 5 6; 7 8 9])
+            @test normalize(SA[1 2 3; 4 5 6; 7 8 9], 1) ≈ normalize([1 2 3; 4 5 6; 7 8 9], 1)
+            @test normalize!((@MMatrix [1. 2. 3.; 4. 5. 6.; 7. 8. 9.])) ≈ normalize!([1. 2. 3.; 4. 5. 6.; 7. 8. 9.])
+            @test normalize!((@MMatrix [1. 2. 3.; 4. 5. 6.; 7. 8. 9.]), 1) ≈ normalize!([1. 2. 3.; 4. 5. 6.; 7. 8. 9.], 1)
+
+            D3 = Array{Float64, 3}(undef, 2, 2, 3)
+            D3[:] .= 1.0:12.0
+            SA_D3 = convert(SArray{Tuple{2,2,3}, Float64, 3, 12}, D3)
+            @test normalize(SA_D3) ≈ normalize(D3)
+        end
         # nested vectors
         a  = SA[SA[1, 2], SA[3, 4]]
         av = convert(Vector{Vector{Int}}, a)


### PR DESCRIPTION
Fixes #887 in the simplest way possible.

Note that the existing `normalize` implementation doesn't have many guard-rails (e.g., no over/underflow detection) and `normalize!` has some rough edges (e.g., doesn't work for arrays with `Int` eltype) - but I figured I'd just keep this to the scope of #887.