### PR TITLE
specialize muladd

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StaticArrays"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "1.2.10"
+version = "1.2.11"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -45,6 +45,11 @@ end
 @inline \(a::UniformScaling, b::Union{StaticMatrix,StaticVector}) = a.λ \ b
 @inline /(a::StaticMatrix, b::UniformScaling) = a / b.λ
 
+
+# Ternary ops
+@inline Base.muladd(scalar::Number, a::StaticArray, b::StaticArray) = map((ai, bi) -> muladd(scalar, ai, bi), a, b)
+@inline Base.muladd(a::StaticArray, scalar::Number, b::StaticArray) = map((ai, bi) -> muladd(ai, scalar, bi), a, b)
+
 #--------------------------------------------------
 # Matrix algebra
 

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -51,6 +51,24 @@ StaticArrays.similar_type(::Union{RotMat2,Type{RotMat2}}) = SMatrix{2,2,Float64,
         end
     end
 
+    @testset "Ternary operators" begin
+        for T in (Int, Float32, Float64)
+            c = convert(T, 2)
+            v1 = @SVector T[2, 4, 6, 8]
+            v2 = @SVector T[4, 3, 2, 1]
+            m1 = @SMatrix T[2 4; 6 8]
+            m2 = @SMatrix T[4 3; 2 1]
+
+            # Use that these small integers can be represetnted exactly
+            # as floating point numbers. In general, the comparison of
+            # floats should use `≈` instead of `===`.
+            @test @inferred(muladd(c, v1, v2)) === @SVector T[8, 11, 14, 17]
+            @test @inferred(muladd(v1, c, v2)) === @SVector T[8, 11, 14, 17]
+            @test @inferred(muladd(c, m1, m2)) === @SMatrix T[8 11; 14 17]
+            @test @inferred(muladd(m1, c, m2)) === @SMatrix T[8 11; 14 17]
+        end
+    end
+
     @testset "Interaction with `UniformScaling`" begin
         @test @inferred(@SMatrix([0 1; 2 3]) + I) === @SMatrix [1 1; 2 4]
         @test @inferred(I + @SMatrix([0 1; 2 3])) === @SMatrix [1 1; 2 4]


### PR DESCRIPTION
This avoids hitting the general fallback https://github.com/JuliaLang/julia/blob/5118a1babf9d2963f31e98e427cc99a969d5ca46/base/math.jl#L1167 
Depending on the processor, LLVM can turn this into efficient FMA calls. Depending on the workload, this can speed-up number crunching quite a bit.

I increased the version number since I would really like to be able to use this performance improvement.