### PR TITLE
Improve BitonicSort performance for sorting floats

### DIFF
--- a/benchmark/bench_sort.jl
+++ b/benchmark/bench_sort.jl
@@ -1,0 +1,97 @@
+module BenchSort
+
+using BenchmarkTools
+using Random: rand!
+using StaticArrays
+using StaticArrays: BitonicSort
+
+const SUITE = BenchmarkGroup()
+
+# 1 second is sufficient for reasonably consistent timings.
+BenchmarkTools.DEFAULT_PARAMETERS.seconds = 1
+
+const LEN = 1000
+
+const Floats = (Float16, Float32, Float64)
+const Ints = (Int8, Int16, Int32, Int64, Int128)
+const UInts = (UInt8, UInt16, UInt32, UInt64, UInt128)
+
+map_sort!(vs; kwargs...) = map!(v -> sort(v; kwargs...), vs, vs)
+
+addgroup!(SUITE, "BitonicSort")
+
+g = addgroup!(SUITE["BitonicSort"], "SVector")
+for lt in (isless, <)
+    n = 1
+    while (n = nextprod([2, 3], n + 1)) <= 24
+        for T in (Floats..., Ints..., UInts...)
+            (lt === <) && (T <: Integer) && continue  # For Integers, isless is <.
+            vs = Vector{SVector{n, T}}(undef, LEN)
+            g[lt, n, T] = @benchmarkable(
+                map_sort!($vs; alg=BitonicSort, lt=$lt),
+                evals=1,  # Redundant on @benchmarkable as of BenchmarkTools 1.1.3.
+                # We need evals=1 so that setup runs before every eval. But PkgBenchmark
+                # always `tunes!` benchmarks before running, which overrides this. As a
+                # workaround, use the unhygienic symbol `__params` to set evals just before
+                # execution at
+                # https://github.com/JuliaCI/BenchmarkTools.jl/blob/v1.1.3/src/execution.jl#L482
+                # See also: https://github.com/JuliaCI/PkgBenchmark.jl/issues/120
+                setup=(__params.evals = 1; rand!($vs)),
+            )
+        end
+    end
+end
+
+g = addgroup!(SUITE["BitonicSort"], "MVector")
+for (lt, n, T) in ((isless, 16, Int64), (isless, 16, Float64), (<, 16, Float64))
+    vs = Vector{MVector{n, T}}(undef, LEN)
+    g[lt, n, T] = @benchmarkable(
+        map_sort!($vs; alg=BitonicSort, lt=$lt),
+        evals=1,
+        setup=(__params.evals = 1; rand!($vs)),
+    )
+end
+
+g = addgroup!(SUITE["BitonicSort"], "SizedVector")
+for (lt, n, T) in ((isless, 16, Int64), (isless, 16, Float64), (<, 16, Float64))
+    vs = Vector{SizedVector{n, T, Vector{T}}}(undef, LEN)
+    g[lt, n, T] = @benchmarkable(
+        map_sort!($vs; alg=BitonicSort, lt=$lt),
+        evals=1,
+        setup=(__params.evals = 1; rand!($vs)),
+    )
+end
+
+# @generated to unroll the tuple.
+@generated function floats_nans(::Type{SVector{N, T}}, p) where {N, T}
+    exprs = (:(ifelse(rand(Float32) < p, T(NaN), rand(T))) for _ in 1:N)
+    return quote
+        Base.@_inline_meta
+        return SVector(($(exprs...),))
+    end
+end
+
+function floats_nans!(vs::Vector{SVector{N, T}}, p) where {N, T}
+    for i in eachindex(vs)
+        @inbounds vs[i] = floats_nans(SVector{N, T}, p)
+    end
+    return vs
+end
+
+g = addgroup!(SUITE["BitonicSort"], "NaNs")
+for p in (0.001, 0.01, 0.05, 0.1, 0.25, 0.5, 0.75, 1.0)
+    (lt, n, T) = (isless, 16, Float64)
+    vs = Vector{SVector{n, T}}(undef, LEN)
+    g[lt, n, T, p] = @benchmarkable(
+        map_sort!($vs; alg=BitonicSort, lt=$lt),
+        evals=1,
+        setup=(__params.evals = 1; floats_nans!($vs, $p)),
+    )
+end
+
+end # module BenchSort
+
+# Allow PkgBenchmark.benchmarkpkg to call this file directly.
+@isdefined(SUITE) || (SUITE = BenchSort.SUITE)
+
+BenchSort.SUITE

--- a/src/StaticArrays.jl
+++ b/src/StaticArrays.jl
@@ -124,6 +124,7 @@ include("indexing.jl")
 include("broadcast.jl")
 include("mapreduce.jl")
 include("sort.jl")
+using .Sort
 include("arraymath.jl")
 include("linalg.jl")
 include("matrix_multiply_add.jl")

--- a/test/sort.jl
+++ b/test/sort.jl
@@ -1,4 +1,13 @@
+module SortTests
+
 using StaticArrays, Test
+using Base.Order: Forward, Reverse
+
+_inttype(::Type{Float64}) = Int64
+_inttype(::Type{Float32}) = Int32
+_inttype(::Type{Float16}) = Int16
+
+float_or(x::T, y::T) where T = reinterpret(T, |(reinterpret.(_inttype(T), (x, y))...))
 
 @testset "sort" begin
 
@@ -30,4 +39,88 @@ using StaticArrays, Test
         @test sortperm(SA[1, 1, 1, 0]) == SA[4, 1, 2, 3]
     end
 
-end
+    @testset "NaNs" begin
+        # Return an SVector with floats and NaNs that have random sign and payload bits.
+        @generated function floats_randnans(::Type{SVector{N, T}}, p) where {N, T}
+            exprs = Base.Generator(1:N) do _
+                quote
+                    r = rand(T)
+                    # The bitwise or of any T with T(Inf) is either ±T(Inf) or a NaN.
+                    ifelse(rand(Float32) < p, float_or(typemax(T), r - T(0.5)), r)
+                end
+            end
+            return quote
+                Base.@_inline_meta
+                return SVector(($(exprs...),))
+            end
+        end
+
+        # Sort floats and arbitrary NaNs.
+        for T in (Float16, Float32, Float64)
+            buffer = Vector{T}(undef, 16)
+            @test all(floats_randnans(SVector{16, T}, 0.5) for _ in 1:10_000) do a
+                copyto!(buffer, a)
+                isequal(sort(a), sort!(buffer))
+            end
+        end
+
+        # Sort signed Infs, signed zeros, and NaNs with extremal payloads.
+        for T in (Float16, Float32, Float64)
+            U = _inttype(T)
+            small_nan = reinterpret(T, reinterpret(U, typemax(T)) + one(U))
+            large_nan = reinterpret(T, typemax(U))
+            nans = (small_nan, large_nan, T(NaN), -small_nan, -large_nan, -T(NaN))
+            (a, b, c, d) = (-T(Inf), -zero(T), zero(T), T(Inf))
+            sorted = [a, b, c, d, nans..., nans...]
+            @test isequal(sorted, sort(SA[nans..., d, c, b, a, nans...]))
+            @test isequal(sorted, sort(SA[d, c, nans..., nans..., b, a]))
+        end
+    end
+
+    # These tests are selected from Julia's test/ordering.jl and test/sorting.jl.
+    @testset "Base tests" begin
+        # This testset partially fails on Julia versions < 1.5 because order could be
+        # discarded: https://github.com/JuliaLang/julia/pull/34719
+        if VERSION >= v"1.5"
+            @testset "ordering" begin
+                for (s1, rev) in enumerate([nothing, true, false])
+                    for (s2, lt) in enumerate([>, <, (a, b) -> a - b > 0, (a, b) -> a - b < 0])
+                        for (s3, by) in enumerate([-, +])
+                            for (s4, order) in enumerate([Reverse, Forward])
+                                if isodd(s1 + s2 + s3 + s4)
+                                    target = SA[1, 2, 3]
+                                else
+                                    target = SA[3, 2, 1]
+                                end
+                                @test target == sort(SA[2, 3, 1], rev=rev, lt=lt, by=by, order=order)
+                            end
+                        end
+                    end
+                end
+
+                @test SA[1 => 3, 2 => 5, 3 => 1] ==
+                            sort(SA[1 => 3, 2 => 5, 3 => 1]) ==
+                            sort(SA[1 => 3, 2 => 5, 3 => 1], by=first) ==
+                            sort(SA[1 => 3, 2 => 5, 3 => 1], rev=true, order=Reverse) ==
+                            sort(SA[1 => 3, 2 => 5, 3 => 1], lt= >, order=Reverse)
+
+                @test SA[3 => 1, 1 => 3, 2 => 5] ==
+                            sort(SA[1 => 3, 2 => 5, 3 => 1], by=last) ==
+                            sort(SA[1 => 3, 2 => 5, 3 => 1], by=last, rev=true, order=Reverse) ==
+                            sort(SA[1 => 3, 2 => 5, 3 => 1], by=last, lt= >, order=Reverse)
+            end
+        end
+
+        @testset "sort" begin
+            @test sort(SA[2,3,1]) == SA[1,2,3] == sort(SA[2,3,1]; order=Forward)
+            @test sort(SA[2,3,1], rev=true) == SA[3,2,1] == sort(SA[2,3,1], order=Reverse)
+            @test sort(SA['z':-1:'a'...]) == SA['a':'z'...]
+            @test sort(SA['a':'z'...], rev=true) == SA['z':-1:'a'...]
+        end
+
+        @test sortperm(SA[2,3,1]) == SA[3,1,2]
+    end
+
+end # @testset "sort"
+
+end # module SortTests


### PR DESCRIPTION
Also: add docstring, extend tests, and add benchmarks.

The speedup (for sorting `isbits` floats under `isless`) is based on @stev47's [improvement to `isless`](https://github.com/JuliaLang/julia/pull/39090) in Julia 1.7 (stev47 also authored the [BitonicSort implementation](https://github.com/JuliaArrays/StaticArrays.jl/pull/754)!), but instead of NaN-checking we subtract an offset to wrap the NaNs with negative sign to the greatest integers (see code for details), giving branchless code. We apply this transformation only once at the start of each sort to sort them as integers, then apply the inverse transformation at the end to get back the floats. (This technique cannot be used for `isless` in Julia Base because `isless(NaN, NaN)` returns false regardless of payload and sign.)

Comparative benchmark results on Julia 1.7.0-beta3:
- [x86-64](https://gist.github.com/vyu/efa31fd6776014503d88cac1810b08d4) (Intel Haswell, mobile)
- [x86-64](https://gist.github.com/vyu/4e9d384573a7c119d2ee3500ccb099c1) (Intel Silvermont, microserver)
- [AArch64](https://gist.github.com/vyu/744dbd6b9912dabb0e173b9b25d0d606) (Ampere A1, instance on Oracle Cloud)

(The couple of timing fluctuations that show up for integer sorting are just noise.)

I have a vectorized implementation that I hope to contribute later after cleaning it up. (SIMD performance is of course heavily dependent on CPU capabilities and compiler support, which is why I'm benchmarking on three machines. Didn't matter for this PR, though.)