### PR TITLE
Adds `maxabs` check in `norm2`

### DIFF
--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -268,6 +268,8 @@ end
         elseif p == 1
             @inbounds return $expr_p1
         elseif p == 2
+            maxabs = mapreduce(norm, max, a)
+            (maxabs == 0 || isinf(maxabs)) && return maxabs
             return norm(a)
         elseif p == 0
             return mapreduce(_norm_p0, +, a)


### PR DESCRIPTION
This PR addresses #963. I manually checked this and it does indeed get rid of the `NaN`s. The values of the jacobians in the MWE also agree with each other.

@mateuszbaran, could you please review these changes? I am not sure if the check should be done where I put it. Thank you!