### PR TITLE
Remove `conj` method

### DIFF
--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -53,8 +53,7 @@ end
 #--------------------------------------------------
 # Matrix algebra
 
-# Transpose, conjugate, etc
-@inline conj(a::StaticArray) = map(conj, a)
+# Transpose, etc
 @inline transpose(m::StaticMatrix) = _transpose(Size(m), m)
 # note: transpose of StaticVector is a Transpose, handled by Base
 @inline transpose(a::Transpose{<:Any,<:Union{StaticVector,StaticMatrix}}) = a.parent


### PR DESCRIPTION
The `conj` method is defined for `AbstractArray` in `Base`, and this seems not necessary in StaticArrays.jl.
https://github.com/JuliaLang/julia/blob/master/base/abstractarraymath.jl#L120
