### PR TITLE
Avoid underflow and overflow in norm()

### DIFF
--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -252,14 +252,13 @@ end
     return mapreduce(LinearAlgebra.norm_sqr, +, v; init=_init_zero(v))
 end
 
-@inline norm(a::StaticArray) = _norm(Size(a), a)
-@generated function _norm(::Size{S}, a::StaticArray) where {S}
-    if prod(S) == 0
+@generated function norm(a::StaticArray)
+    if prod(Size(a)) == 0
         return :(_init_zero(a))
     end
 
     expr = :(LinearAlgebra.norm_sqr(a[1]/aₘ))
-    for j = 2:prod(S)
+    for j = 2:prod(Size(a))
         expr = :($expr + LinearAlgebra.norm_sqr(a[$j]/aₘ))
     end
 
@@ -280,19 +279,18 @@ function _norm_p0(x)
     return float(norm(iszero(x) ? zero(T) : one(T)))
 end
 
-@inline norm(a::StaticArray, p::Real) = _norm(Size(a), a, p)
-@generated function _norm(::Size{S}, a::StaticArray, p::Real) where {S}
-    if prod(S) == 0
+@generated function norm(a::StaticArray, p::Real)
+    if prod(Size(a)) == 0
         return :(_init_zero(a))
     end
 
     expr = :(norm(a[1]/aₘ)^p)
-    for j = 2:prod(S)
+    for j = 2:prod(Size(a))
         expr = :($expr + norm(a[$j]/aₘ)^p)
     end
 
     expr_p1 = :(norm(a[1]/aₘ))
-    for j = 2:prod(S)
+    for j = 2:prod(Size(a))
         expr_p1 = :($expr_p1 + norm(a[$j]/aₘ))
     end
 

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -291,7 +291,6 @@ end
 
         iszero(scale) && return _init_zero(a)
         p == 1 && return @inbounds scale * $expr_p1
-        p == 2 && return norm(a)
         return @inbounds scale * ($expr)^(inv(p))
     end
 end

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -224,17 +224,17 @@ _inner_eltype(x::Number) = typeof(x)
 end
 
 @generated function norm_scaled(a::StaticArray)
-    expr = :(LinearAlgebra.norm_sqr(a[1]/aₘ))
+    expr = :(LinearAlgebra.norm_sqr(a[1]/scale))
     for j = 2:prod(Size(a))
-        expr = :($expr + LinearAlgebra.norm_sqr(a[$j]/aₘ))
+        expr = :($expr + LinearAlgebra.norm_sqr(a[$j]/scale))
     end
 
     return quote
         $(Expr(:meta, :inline))
-        aₘ = LinearAlgebra.normInf(a)
+        scale = LinearAlgebra.normInf(a)
 
-        iszero(aₘ) && return aₘ
-        return @inbounds aₘ * sqrt($expr)
+        iszero(scale) && return scale
+        return @inbounds scale * sqrt($expr)
     end
 end
 
@@ -263,24 +263,24 @@ function _norm_p0(x)
 end
 
 @generated function norm_scaled(a::StaticArray, p::Real)
-    expr = :(norm(a[1]/aₘ)^p)
+    expr = :(norm(a[1]/scale)^p)
     for j = 2:prod(Size(a))
-        expr = :($expr + norm(a[$j]/aₘ)^p)
+        expr = :($expr + norm(a[$j]/scale)^p)
     end
 
-    expr_p1 = :(norm(a[1]/aₘ))
+    expr_p1 = :(norm(a[1]/scale))
     for j = 2:prod(Size(a))
-        expr_p1 = :($expr_p1 + norm(a[$j]/aₘ))
+        expr_p1 = :($expr_p1 + norm(a[$j]/scale))
     end
 
     return quote
         $(Expr(:meta, :inline))
-        aₘ = LinearAlgebra.normInf(a)
+        scale = LinearAlgebra.normInf(a)
 
-        iszero(aₘ) && return aₘ
-        p == 1 && return @inbounds aₘ * $expr_p1
+        iszero(scale) && return scale
+        p == 1 && return @inbounds scale * $expr_p1
         p == 2 && return norm(a)
-        return @inbounds aₘ * ($expr)^(inv(p))
+        return @inbounds scale * ($expr)^(inv(p))
     end
 end
 

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -237,11 +237,11 @@ end
     return quote
         $(Expr(:meta, :inline))
         zero_a = _init_zero(a)
-        aₘ = mapreduce(norm, max, a)::typeof(zero_a)
+        aₘ = mapreduce(norm, max, a)
         if iszero(aₘ)
             return zero_a
         else
-            @inbounds return aₘ * sqrt($expr)
+            @inbounds return (aₘ * sqrt($expr))::typeof(zero_a)
         end
     end
 end
@@ -270,19 +270,19 @@ end
     return quote
         $(Expr(:meta, :inline))
         zero_a = _init_zero(a)
-        aₘ = mapreduce(norm, max, a)::typeof(zero_a)
+        aₘ = mapreduce(norm, max, a)
         if iszero(aₘ)
             return zero_a
         elseif p == Inf
             return aₘ
         elseif p == 1
-            @inbounds return aₘ * $expr_p1
+            @inbounds return (aₘ * $expr_p1)::typeof(zero_a)
         elseif p == 2
             return norm(a)
         elseif p == 0
             return mapreduce(_norm_p0, +, a)
         else
-            @inbounds return aₘ * ($expr)^(inv(p))
+            @inbounds return (aₘ * ($expr)^(inv(p)))::typeof(zero_a)
         end
     end
 end

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -260,13 +260,10 @@ end
 
     return quote
         $(Expr(:meta, :inline))
-        zero_a = _init_zero(a)
         aₘ = maxabs_nested(a)
-        if iszero(aₘ)
-            return zero_a
-        else
-            @inbounds return aₘ * sqrt($expr)
-        end
+
+        iszero(aₘ) && return aₘ
+        return @inbounds aₘ * sqrt($expr)
     end
 end
 
@@ -283,11 +280,9 @@ end
     return quote
         $(Expr(:meta, :inline))
         l = @inbounds sqrt($expr)
-        if iszero(l) || isinf(l)
-            return norm_scaled(a)
-        else
-            return l
-        end
+
+        (iszero(l) || isinf(l)) && return norm_scaled(a)
+        return l
     end
 end
 

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -245,7 +245,7 @@ end
         $(Expr(:meta, :inline))
         scale = maxabs_nested(a)
 
-        iszero(scale) && return _init_zero(a)
+        scale==0 && return _init_zero(a)
         return @inbounds scale * sqrt($expr)
     end
 end
@@ -289,7 +289,7 @@ end
         $(Expr(:meta, :inline))
         scale = maxabs_nested(a)
 
-        iszero(scale) && return _init_zero(a)
+        scale==0 && return _init_zero(a)
         p == 1 && return @inbounds scale * $expr_p1
         return @inbounds scale * ($expr)^(inv(p))
     end

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -231,7 +231,7 @@ end
 
     return quote
         $(Expr(:meta, :inline))
-        scale = LinearAlgebra.normInf(a)
+        scale = mapreduce(norm, @fastmath(max), a)
 
         iszero(scale) && return scale
         return @inbounds scale * sqrt($expr)
@@ -275,7 +275,7 @@ end
 
     return quote
         $(Expr(:meta, :inline))
-        scale = LinearAlgebra.normInf(a)
+        scale = mapreduce(norm, @fastmath(max), a)
 
         iszero(scale) && return scale
         p == 1 && return @inbounds scale * $expr_p1

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -217,7 +217,7 @@ end
 # Norms
 _inner_eltype(v::AbstractArray) = isempty(v) ? eltype(v) : _inner_eltype(first(v))
 _inner_eltype(x::Number) = typeof(x)
-@inline _init_zero(v::StaticArray) = float(norm(zero(_inner_eltype(v))))
+@inline _init_zero(v::AbstractArray) = float(norm(zero(_inner_eltype(v))))
 
 @inline function LinearAlgebra.norm_sqr(v::StaticArray)
     return mapreduce(LinearAlgebra.norm_sqr, +, v; init=_init_zero(v))

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -263,8 +263,8 @@ end
         $(Expr(:meta, :inline))
         l = @inbounds sqrt($expr)
 
-        (iszero(l) || isinf(l)) && return _norm_scaled(Size(a), a)
-        return l
+        0<l<Inf && return l
+        return _norm_scaled(Size(a), a)
     end
 end
 
@@ -316,8 +316,8 @@ end
         p == Inf && return mapreduce(norm, max, a)  # no need for scaling
 
         l = p==1 ? @inbounds($expr_p1) : @inbounds(($expr)^(inv(p)))
-        (iszero(l) || isinf(l)) && return _norm_scaled(Size(a), a, p)  # p != 0, 2, Inf
-        return l
+        0<l<Inf && return l
+        return _norm_scaled(Size(a), a, p)  # p != 0, 2, Inf
     end
 end
 

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -234,7 +234,7 @@ end
 
 @generated function maxabs_nested(a::StaticArray)
     if prod(Size(a)) == 0
-        return :(StaticArrays._init_zero(a))
+        return :(_init_zero(a))
     end
 
     expr = :(maxabs_nested(a[1]))

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -208,7 +208,10 @@ StaticArrays.similar_type(::Union{RotMat2,Type{RotMat2}}) = SMatrix{2,2,Float64,
     end
 
     @testset "normalization" begin
-        @test norm(SVector(0.0,1e-180)) == 1e-180
+        @test norm(SVector(0.0,1e-180)) == 1e-180  # avoid underflow
+        @test all([norm(SVector(0.0,1e-180), p) == 1e-180 for p = [2,3,Inf]])  # avoid underflow
+        @test norm(SVector(0.0,1e155)) == 1e155  # avoid overflow
+        @test all([norm(SVector(0.0,1e155), p) == 1e155 for p = [2,3,Inf]])  # avoid overflow
         @test norm(SVector(1.0,2.0,2.0)) ≈ 3.0
         @test norm(SVector(1.0,2.0,2.0),2) ≈ 3.0
         @test norm(SVector(1.0,2.0,2.0),Inf) ≈ 2.0

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -209,8 +209,8 @@ StaticArrays.similar_type(::Union{RotMat2,Type{RotMat2}}) = SMatrix{2,2,Float64,
 
     @testset "normalization" begin
         @test norm(SVector(0.0,1e-180)) == 1e-180  # avoid underflow
-        @test all([norm(SVector(0.0,1e-180), p) == 1e-180 for p = [2,3,Inf]])  # avoid underflow
         @test norm(SVector(0.0,1e155)) == 1e155  # avoid overflow
+        @test all([norm(SVector(0.0,1e-180), p) == 1e-180 for p = [2,3,Inf]])  # avoid underflow
         @test all([norm(SVector(0.0,1e155), p) == 1e155 for p = [2,3,Inf]])  # avoid overflow
         @test norm(SVector(1.0,2.0,2.0)) ≈ 3.0
         @test norm(SVector(1.0,2.0,2.0),2) ≈ 3.0

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -208,6 +208,7 @@ StaticArrays.similar_type(::Union{RotMat2,Type{RotMat2}}) = SMatrix{2,2,Float64,
     end
 
     @testset "normalization" begin
+        @test norm(SVector(0.0,1e-180)) == 1e-180
         @test norm(SVector(1.0,2.0,2.0)) ≈ 3.0
         @test norm(SVector(1.0,2.0,2.0),2) ≈ 3.0
         @test norm(SVector(1.0,2.0,2.0),Inf) ≈ 2.0


### PR DESCRIPTION
This PR fixes #913 by avoiding underflow in `norm()`.  In the referenced issue, `norm(SA[0, 1e-180])` generates `0.0` instead of the accurate value `1e-180`, because squaring `1e-180` inside `norm()` produces `1e-360`, whose exponent is less than the [smallest exponent allowed in the IEEE double-precision floating point standard](https://en.wikipedia.org/wiki/Double-precision_floating-point_format#Exponent_encoding): `2^-1022 ≈ 1e-308`.  

The standard practice to avoid this underflow is to pre-normalize the vector by its largest-magnitude entry, calculate the norm, and then undo the normalization outside `norm()`:
```julia
# Calculate norm(v) without underflow.
vmax = maximum(abs, v)
norm_v = vmax * norm(v ./ vmax)
```

This PR implements the above procedure for `StaticArrays`.  This PR also fixes https://github.com/JuliaDiff/ForwardDiff.jl/issues/547.
