### PR TITLE
note named access for SVector in FieldVector docs

### DIFF
--- a/docs/src/pages/api.md
+++ b/docs/src/pages/api.md
@@ -189,7 +189,7 @@ even permute the coordinates with `p[SVector(3,2,1)]`). Furthermore, `Point3D`
 is a complete `AbstractVector` implementation where you can add, subtract or
 scale vectors, multiply them by matrices, etc.
 
-*Note*: the first three components of an ordinary `v::SVector` can also be
+*Note*: the three components of an ordinary `v::SVector{3}` can also be
 accessed as `v.x`, `v.y`, and `v.z`, so there is no need for a `FieldVector`
 to use this convention.
 

--- a/docs/src/pages/api.md
+++ b/docs/src/pages/api.md
@@ -189,6 +189,10 @@ even permute the coordinates with `p[SVector(3,2,1)]`). Furthermore, `Point3D`
 is a complete `AbstractVector` implementation where you can add, subtract or
 scale vectors, multiply them by matrices, etc.
 
+*Note*: the first three components of an ordinary `v::SVector` can also be
+accessed as `v.x`, `v.y`, and `v.z`, so there is no need for a `FieldVector`
+to use this convention.
+
 It is also worth noting that `FieldVector`s may be mutable or immutable, and
 that `setindex!` is defined for use on mutable types. For immutable containers,
 you may want to define a method for `similar_type` so that operations leave the


### PR DESCRIPTION
Since #980 allows named access to `SVector` fields, this should be noted in the `FieldVector` docs so that users realize that they don't need a `FieldVector` for these particular names.