### PR TITLE
Drop support for versions of Julia lower than v1.6

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@latest
         with:
-          version: 1.4
+          version: 1.6
       - name: Install dependencies
         run: julia -e 'using Pkg; pkg"add PkgBenchmark BenchmarkCI@0.1"'
       - name: Run benchmarks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,8 @@ jobs:
     strategy:
       matrix:
         version:
+          - '1.6'
           - '1'
-          - '1.0'
-          - '1.1'
-          - '1.2'
-          - '1.3'
-          - '1.4'
           - 'nightly'
         os:
           - ubuntu-latest
@@ -32,13 +28,6 @@ jobs:
           # See https://github.com/marketplace/actions/setup-julia-environment
           # MacOS not available on x86
           - {os: 'macOS-latest', arch: 'x86'}
-          # Don't test on all versions
-          - {os: 'macOS-latest', version: '1.1'}
-          - {os: 'macOS-latest', version: '1.2'}
-          - {os: 'macOS-latest', version: '1.3'}
-          - {os: 'windows-latest', version: '1.1'}
-          - {os: 'windows-latest', version: '1.2'}
-          - {os: 'windows-latest', version: '1.3'}
     steps:
       - uses: actions/checkout@v1
       - uses: julia-actions/setup-julia@latest
@@ -57,7 +46,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: julia-actions/setup-julia@latest
         with:
-          version: '1.4'
+          version: '1.6'
       - run: julia --project=docs -e '
           using Pkg;
           Pkg.develop(PackageSpec(; path=pwd()));

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StaticArrays"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "1.3.1"
+version = "1.4.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -8,7 +8,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-julia = "1"
+julia = "1.6"
 
 [extras]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/benchmark/bench_matrix_ops.jl
+++ b/benchmark/bench_matrix_ops.jl
@@ -39,7 +39,7 @@ for f in [*, \]
         s2["SMatrix"] = @benchmarkable $f($SA, $SB)
         s2["Matrix"] = @benchmarkable $f($A, $B)
     end
-end 
+end
 
 # Multiply-add
 function benchmark_matmul(s,N1,N2,ArrayType)

--- a/benchmark/bench_matrix_ops.jl
+++ b/benchmark/bench_matrix_ops.jl
@@ -7,9 +7,9 @@ using StaticArrays
 
 const suite = BenchmarkGroup()
 const matrix_sizes = if haskey(ENV, "GITHUB_EVENT_PATH")
-    (1, 2, 3, 4, 10, 20)
+    (1, 2, 3, 4, 10)
 else
-    1:20
+    1:10
 end
 
 # Use same arrays across processes (at least with the same Julia version):
@@ -39,7 +39,7 @@ for f in [*, \]
         s2["SMatrix"] = @benchmarkable $f($SA, $SB)
         s2["Matrix"] = @benchmarkable $f($A, $B)
     end
-end
+end 
 
 # Multiply-add
 function benchmark_matmul(s,N1,N2,ArrayType)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -2,11 +2,14 @@
 *Statically sized arrays for Julia*
 
 **StaticArrays** provides a framework for implementing statically sized arrays
-in Julia (≥ 0.5), using the abstract type `StaticArray{Size,T,N} <: AbstractArray{T,N}`.
+in Julia (≥ v1.6)[^1], using the abstract type `StaticArray{Size,T,N} <: AbstractArray{T,N}`.
 Subtypes of [`StaticArray`](@ref) will provide fast implementations of common array and
 linear algebra operations. Note that here "statically sized" means that the
 size can be determined from the *type*, and "static" does **not** necessarily
 imply `immutable`.
+
+[^1]:
+    Support for Julia versions lower than v1.6 was dropped in StaticArrays v1.4.
 
 The package also provides some concrete static array types: [`SVector`](@ref), [`SMatrix`](@ref)
 and [`SArray`](@ref), which may be used as-is (or else embedded in your own type).

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -2,14 +2,11 @@
 *Statically sized arrays for Julia*
 
 **StaticArrays** provides a framework for implementing statically sized arrays
-in Julia (≥ v1.6)[^1], using the abstract type `StaticArray{Size,T,N} <: AbstractArray{T,N}`.
+in Julia, using the abstract type `StaticArray{Size,T,N} <: AbstractArray{T,N}`.
 Subtypes of [`StaticArray`](@ref) will provide fast implementations of common array and
 linear algebra operations. Note that here "statically sized" means that the
 size can be determined from the *type*, and "static" does **not** necessarily
 imply `immutable`.
-
-[^1]:
-    Support for Julia versions lower than v1.6 was dropped in StaticArrays v1.4.
 
 The package also provides some concrete static array types: [`SVector`](@ref), [`SMatrix`](@ref)
 and [`SArray`](@ref), which may be used as-is (or else embedded in your own type).

--- a/src/SizedArray.jl
+++ b/src/SizedArray.jl
@@ -33,9 +33,7 @@ struct SizedArray{S<:Tuple,T,N,M,TData<:AbstractArray{T,M}} <: StaticArray{S,T,N
 end
 
 # Julia v1.0 has some weird bug that prevents this from working
-@static if VERSION >= v"1.1"
-    @inline SizedArray(a::StaticArray{S,T,N}) where {S<:Tuple,T,N} = SizedArray{S,T,N}(a)
-end
+@inline SizedArray(a::StaticArray{S,T,N}) where {S<:Tuple,T,N} = SizedArray{S,T,N}(a)
 @inline function SizedArray{S,T,N}(
     a::TData,
 ) where {S,T,N,M,TData<:AbstractArray{T,M}}
@@ -151,10 +149,7 @@ end
 
 const SizedMatrix{S1,S2,T} = SizedArray{Tuple{S1,S2},T,2}
 
-# Julia v1.0 has some weird bug that prevents this from working
-@static if VERSION >= v"1.1"
-    SizedMatrix(a::StaticMatrix{N,M,T}) where {N,M,T} = SizedMatrix{N,M,T}(a)
-end
+SizedMatrix(a::StaticMatrix{N,M,T}) where {N,M,T} = SizedMatrix{N,M,T}(a)
 @inline function SizedMatrix{S1,S2}(
     a::TData,
 ) where {S1,S2,T,M,TData<:AbstractArray{T,M}}

--- a/src/StaticArrays.jl
+++ b/src/StaticArrays.jl
@@ -144,9 +144,7 @@ include("deque.jl")
 include("flatten.jl")
 include("io.jl")
 
-if Base.VERSION >= v"1.4.2"
-    include("precompile.jl")
-    _precompile_()
-end
+include("precompile.jl")
+_precompile_()
 
 end # module

--- a/src/abstractarray.jl
+++ b/src/abstractarray.jl
@@ -306,13 +306,11 @@ end
     end
 end
 
-if VERSION >= v"1.6.0-DEV.1334"
-    # FIXME: This always assumes one-based linear indexing and that subtypes of StaticArray
-    # don't overload iterate
-    @inline function Base.rest(a::StaticArray{S}, (_, i) = (nothing, 0)) where {S}
-        newlen = tuple_prod(S) - i
-        return similar_type(typeof(a), Size(newlen))(Base.rest(Tuple(a), i + 1))
-    end
+# FIXME: This always assumes one-based linear indexing and that subtypes of StaticArray
+# don't overload iterate
+@inline function Base.rest(a::StaticArray{S}, (_, i) = (nothing, 0)) where {S}
+    newlen = tuple_prod(S) - i
+    return similar_type(typeof(a), Size(newlen))(Base.rest(Tuple(a), i + 1))
 end
 
 # SArrays may avoid the SubArray wrapper and consequently an additional level of indirection

--- a/test/SHermitianCompact.jl
+++ b/test/SHermitianCompact.jl
@@ -40,11 +40,6 @@ end
 
 fill3(x) = fill(3, x)
 
-# @allocated behaves differently on 1.4, but the differences appear spurious in
-# practice. See
-# https://github.com/JuliaArrays/StaticArrays.jl/issues/710
-allocated_workaround = VERSION >= v"1.4-DEV"
-
 @testset "SHermitianCompact" begin
     @testset "Inner Constructor" begin
         for (N, L) in ((3, 6), (4, 10), (6, 21))
@@ -164,9 +159,6 @@ allocated_workaround = VERSION >= v"1.4-DEV"
         let a = a
             @test -a == -SMatrix(a)
             @test -a isa SHermitianCompact{3, Int, 6}
-            if !allocated_workaround
-                @test_noalloc -a
-            end
         end
         for (x, y) in ((a, b), (a, c), (c, a))
             @eval begin
@@ -210,15 +202,9 @@ allocated_workaround = VERSION >= v"1.4-DEV"
         let a = SHermitianCompact(SVector{21, Int}(1 : 21))
             @test a + 3I == SMatrix(a) + 3I
             @test a + 3I isa typeof(a)
-            if !allocated_workaround
-                @test_noalloc a + 3I
-            end
 
             @test a - 4I == SMatrix(a) - 4I
             @test a - 4I isa typeof(a)
-            if !allocated_workaround
-                @test_noalloc a - 4I
-            end
 
             @test a * 3I === a * 3
             @test 3I * a === 3 * a

--- a/test/SizedArray.jl
+++ b/test/SizedArray.jl
@@ -41,9 +41,7 @@
         @test size(SizedArray{Tuple{4,5},Int}(undef).data) == (4, 5)
 
         # 0-element constructor
-        if VERSION >= v"1.1"
-            @test (@inferred SizedArray(MMatrix{0,0,Float64}()))::SizedMatrix{0,0,Float64} == SizedMatrix{0,0,Float64}()
-        end
+        @test (@inferred SizedArray(MMatrix{0,0,Float64}()))::SizedMatrix{0,0,Float64} == SizedMatrix{0,0,Float64}()
 
         # From Tuple
         @test @inferred(SizedArray{Tuple{2},Float64,1,1}((1,2)))::SizedArray{Tuple{2},Float64,1,1,Vector{Float64}} == [1.0, 2.0]
@@ -82,9 +80,7 @@
         @test convert(Matrix, SizedMatrix{2,2}([1 2;3 4])) == [1 2; 3 4]
 
         # 0-element constructor
-        if VERSION >= v"1.1"
-            @test (@inferred SizedMatrix(MMatrix{0,0,Float64}()))::SizedMatrix{0,0,Float64} == SizedMatrix{0,0,Float64}()
-        end
+        @test (@inferred SizedMatrix(MMatrix{0,0,Float64}()))::SizedMatrix{0,0,Float64} == SizedMatrix{0,0,Float64}()
     end
 
     # setindex
@@ -98,15 +94,14 @@
     # pointer
     @testset "pointer" begin
         @test pointer(sa) === pointer(sa.data)
-        if VERSION ≥ v"1.5"
-            A = MMatrix{32,3,Float64}(undef);
-            av1 = view(A, 1, :);
-            av2 = view(A, :, 1);
-            @test pointer(A) == pointer(av1) == pointer(av2)
-            @test pointer(A, LinearIndices(A)[1,2]) == pointer(av1, 2)
-            @test pointer(A, LinearIndices(A)[2,1]) == pointer(av2, 2)
-            @test pointer(A, LinearIndices(A)[4,3]) == pointer(view(A, :, 3), 4) == pointer(view(A, 4, :), 3)
-        end
+
+        A = MMatrix{32,3,Float64}(undef);
+        av1 = view(A, 1, :);
+        av2 = view(A, :, 1);
+        @test pointer(A) == pointer(av1) == pointer(av2)
+        @test pointer(A, LinearIndices(A)[1,2]) == pointer(av1, 2)
+        @test pointer(A, LinearIndices(A)[2,1]) == pointer(av2, 2)
+        @test pointer(A, LinearIndices(A)[4,3]) == pointer(view(A, :, 3), 4) == pointer(view(A, 4, :), 3)
     end
     
     @testset "vec" begin

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -327,38 +327,36 @@ end
     @test @inferred(hcat(SA[1 2 3])) === SA[1 2 3]
 end
 
-@static if VERSION >= v"1.6.0-DEV.1334"
-    @testset "Base.rest" begin
-        x = SA[1, 2, 3]
+@testset "Base.rest" begin
+    x = SA[1, 2, 3]
+    @test Base.rest(x) == x
+    a, b... = x
+    @test b == SA[2, 3]
+
+    x = SA[1 2; 3 4]
+    @test Base.rest(x) == vec(x)
+    a, b... = x
+    @test b == SA[3, 2, 4]
+
+    a, b... = SA[1]
+    @test b == []
+    @test b isa SVector{0}
+
+    for (Vec, Mat) in [(MVector, MMatrix), (SizedVector, SizedMatrix)]
+        x = Vec(1, 2, 3)
         @test Base.rest(x) == x
+        @test pointer(Base.rest(x)) != pointer(x)
         a, b... = x
-        @test b == SA[2, 3]
+        @test b == Vec(2, 3)
 
-        x = SA[1 2; 3 4]
+        x = Mat{2,2}(1, 2, 3, 4)
         @test Base.rest(x) == vec(x)
+        @test pointer(Base.rest(x)) != pointer(x)
         a, b... = x
-        @test b == SA[3, 2, 4]
+        @test b == Vec(2, 3, 4)
 
-        a, b... = SA[1]
+        a, b... = Vec(1)
         @test b == []
-        @test b isa SVector{0}
-
-        for (Vec, Mat) in [(MVector, MMatrix), (SizedVector, SizedMatrix)]
-            x = Vec(1, 2, 3)
-            @test Base.rest(x) == x
-            @test pointer(Base.rest(x)) != pointer(x)
-            a, b... = x
-            @test b == Vec(2, 3)
-
-            x = Mat{2,2}(1, 2, 3, 4)
-            @test Base.rest(x) == vec(x)
-            @test pointer(Base.rest(x)) != pointer(x)
-            a, b... = x
-            @test b == Vec(2, 3, 4)
-
-            a, b... = Vec(1)
-            @test b == []
-            @test b isa Vec{0}
-        end
+        @test b isa Vec{0}
     end
 end

--- a/test/accumulate.jl
+++ b/test/accumulate.jl
@@ -33,7 +33,6 @@ using StaticArrays, Test
         ]
             @test cumsum(a; dims = 2) == cumsum(collect(a); dims = 2)
             @test cumsum(a; dims = 2) isa similar_type(a)
-            v"1.1" <= VERSION < v"1.2" && continue
             @inferred cumsum(a; dims = Val(2))
         end
     end
@@ -43,7 +42,6 @@ using StaticArrays, Test
         a = similar_type(SArray, Int, Size(shape))(1:prod(shape))
         @test cumsum(a; dims = i) == cumsum(collect(a); dims = i)
         @test cumsum(a; dims = i) isa SArray
-        v"1.1" <= VERSION < v"1.2" && continue
         @inferred cumsum(a; dims = Val(i))
     end
 

--- a/test/ambiguities.jl
+++ b/test/ambiguities.jl
@@ -1,8 +1,11 @@
 # Allow no new ambiguities (see #18), unless you fix some old ones first!
 
-const allowable_ambiguities = 55
+const allowable_ambiguities = VERSION ≥ v"1.7" ? 60 :
+                              VERSION ≥ v"1.6" ? 61 : error("version must be ≥1.6")
 
 # TODO: Revisit and fix. See
 #   https://github.com/JuliaLang/julia/pull/36962
 #   https://github.com/JuliaLang/julia/issues/36951
-@test length(detect_ambiguities(#=LinearAlgebra, =#StaticArrays)) <= allowable_ambiguities
+# Let's not allow new ambiguities. If any change makes the ambiguity count decrease, the
+# change should decrement `allowable_ambiguities` accordingly
+@test length(detect_ambiguities(#=LinearAlgebra, =#StaticArrays)) == allowable_ambiguities

--- a/test/ambiguities.jl
+++ b/test/ambiguities.jl
@@ -1,8 +1,8 @@
 # Allow no new ambiguities (see #18), unless you fix some old ones first!
 
-const allowable_ambiguities = 0
+const allowable_ambiguities = 55
 
 # TODO: Revisit and fix. See
 #   https://github.com/JuliaLang/julia/pull/36962
 #   https://github.com/JuliaLang/julia/issues/36951
-@test_broken length(detect_ambiguities(#=LinearAlgebra, =#StaticArrays)) <= allowable_ambiguities
+@test length(detect_ambiguities(#=LinearAlgebra, =#StaticArrays)) <= allowable_ambiguities

--- a/test/ambiguities.jl
+++ b/test/ambiguities.jl
@@ -1,20 +1,8 @@
-
 # Allow no new ambiguities (see #18), unless you fix some old ones first!
 
-const allowable_ambiguities =
-    if VERSION < v"1.1"
-        3
-    elseif VERSION < v"1.2"
-        1
-    else
-        0
-    end
+const allowable_ambiguities = 0
 
-if VERSION ≥ v"1.6.0"
-    # TODO: Revisit and fix. See
-    #   https://github.com/JuliaLang/julia/pull/36962
-    #   https://github.com/JuliaLang/julia/issues/36951
-    @test_broken length(detect_ambiguities(#=LinearAlgebra, =#StaticArrays)) <= allowable_ambiguities
-else
-    @test length(detect_ambiguities(Base, LinearAlgebra, StaticArrays)) <= allowable_ambiguities
-end
+# TODO: Revisit and fix. See
+#   https://github.com/JuliaLang/julia/pull/36962
+#   https://github.com/JuliaLang/julia/issues/36951
+@test_broken length(detect_ambiguities(#=LinearAlgebra, =#StaticArrays)) <= allowable_ambiguities

--- a/test/chol.jl
+++ b/test/chol.jl
@@ -74,13 +74,10 @@ using LinearAlgebra: PosDefException
             @test (@inferred c \ Symmetric(d)) isa SMatrix{3,3,elty}
             @test c \ Symmetric(d) ≈ c_a \ Symmetric(d_a)
 
-            if VERSION >= v"1.3"
-                # on earlier versions of Julia d_a / c_a fails
-                @test (@inferred d / c) isa SMatrix{3,3,elty}
-                @test d / c ≈ d_a / c_a
-                @test (@inferred Symmetric(d) / c) isa SMatrix{3,3,elty}
-                @test Symmetric(d) / c ≈ Symmetric(d_a) / c_a
-            end
+            @test (@inferred d / c) isa SMatrix{3,3,elty}
+            @test d / c ≈ d_a / c_a
+            @test (@inferred Symmetric(d) / c) isa SMatrix{3,3,elty}
+            @test Symmetric(d) / c ≈ Symmetric(d_a) / c_a
 
             v_a = randn(elty, 3)
             v = SVector{3}(v_a)

--- a/test/core.jl
+++ b/test/core.jl
@@ -19,11 +19,7 @@
     @testset "Type parameter errors" begin
         # (not sure what type of exception these should be?)
         @test_throws Exception SVector{1.0,Int}((1,))
-        @static if VERSION < v"1.6-"
-            @test_throws DimensionMismatch("No precise constructor for SArray{Tuple{2},$Int,1,2} found. Length of input was 1.") SVector{2,Int}((1,))
-        else
-            @test_throws DimensionMismatch("No precise constructor for SVector{2, $Int} found. Length of input was 1.") SVector{2,Int}((1,))
-        end
+        @test_throws DimensionMismatch("No precise constructor for SVector{2, $Int} found. Length of input was 1.") SVector{2,Int}((1,))
         @test_throws Exception SVector{1,3}((1,))
 
         @test_throws Exception SMatrix{1.0,1,Int,1}((1,))

--- a/test/eigen.jl
+++ b/test/eigen.jl
@@ -89,8 +89,8 @@ using StaticArrays, Test, LinearAlgebra
         m2_a = randn(2,2)
         m2_a = m2_a*m2_a'
         m2 = SMatrix{2,2}(m2_a)
-        @test (@inferred_maybe_allow SVector{2,ComplexF64} eigvals(m1, m2)) ≈ eigvals(m1_a, m2_a)
-        @test (@inferred_maybe_allow SVector{2,ComplexF64} eigvals(Symmetric(m1), Symmetric(m2))) ≈ eigvals(Symmetric(m1_a), Symmetric(m2_a))
+        @test (@inferred SVector{2,ComplexF64} eigvals(m1, m2)) ≈ eigvals(m1_a, m2_a)
+        @test (@inferred SVector{2,ComplexF64} eigvals(Symmetric(m1), Symmetric(m2))) ≈ eigvals(Symmetric(m1_a), Symmetric(m2_a))
     end
 
     @test_throws DimensionMismatch eigvals(SA[1 2 3; 4 5 6], SA[1 2 3; 4 5 5])
@@ -131,7 +131,7 @@ using StaticArrays, Test, LinearAlgebra
         m2_a = randn(3,3)
         m2_a = m2_a*m2_a'
         m2 = SMatrix{3,3}(m2_a)
-        @test (@inferred_maybe_allow SVector{3,ComplexF64} eigvals(m1, m2)) ≈ eigvals(m1_a, m2_a)
+        @test (@inferred SVector{3,ComplexF64} eigvals(m1, m2)) ≈ eigvals(m1_a, m2_a)
     end
 
     @testset "3x3 degenerate cases" begin
@@ -256,7 +256,7 @@ using StaticArrays, Test, LinearAlgebra
 
             # Test that general eigen() gives a small union of concrete types
             SEigen{T} = Eigen{T, T, SArray{Tuple{n,n},T,2,n*n}, SArray{Tuple{n},T,1,n}}
-            @inferred_maybe_allow Union{SEigen{ComplexF64},SEigen{Float64}} eigen(m)
+            @inferred Union{SEigen{ComplexF64},SEigen{Float64}} eigen(m)
 
             mc = @SMatrix randn(ComplexF64, n, n)
             @inferred eigen(Hermitian(mc + mc'))

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -40,15 +40,13 @@ StaticArrays.similar_type(::Union{RotMat2,Type{RotMat2}}) = SMatrix{2,2,Float64,
         #@test @inferred(v1 - v4) === @SVector [-2, 1, 4, 7]
         #@test @inferred(v3 - v2) === @SVector [-2, 1, 4, 7]
 
-        if VERSION ≥ v"1.2"
-            # #899 matrix-of-matrix
-            A = SMatrix{1,1}([1])
-            B = SMatrix{1,1}([A])
-            @test @inferred(1.0 * B) === SMatrix{1, 1, SMatrix{1, 1, Float64, 1}, 1}(B)
-            @test @inferred(1.0 \ B) === SMatrix{1, 1, SMatrix{1, 1, Float64, 1}, 1}(B)
-            @test @inferred(B * 1.0) === SMatrix{1, 1, SMatrix{1, 1, Float64, 1}, 1}(B)
-            @test @inferred(B / 1.0) === SMatrix{1, 1, SMatrix{1, 1, Float64, 1}, 1}(B)
-        end
+        # #899 matrix-of-matrix
+        A = SMatrix{1,1}([1])
+        B = SMatrix{1,1}([A])
+        @test @inferred(1.0 * B) === SMatrix{1, 1, SMatrix{1, 1, Float64, 1}, 1}(B)
+        @test @inferred(1.0 \ B) === SMatrix{1, 1, SMatrix{1, 1, Float64, 1}, 1}(B)
+        @test @inferred(B * 1.0) === SMatrix{1, 1, SMatrix{1, 1, Float64, 1}, 1}(B)
+        @test @inferred(B / 1.0) === SMatrix{1, 1, SMatrix{1, 1, Float64, 1}, 1}(B)
     end
 
     @testset "Ternary operators" begin
@@ -117,10 +115,7 @@ StaticArrays.similar_type(::Union{RotMat2,Type{RotMat2}}) = SMatrix{2,2,Float64,
     end
 
     @testset "diagm()" begin
-        if VERSION >= v"1.3"
-            @test diagm() isa BitArray # issue #961: type piracy of zero-arg diagm
-            # `diagm()` fails on older version of Julia even without StaticArrays.jl
-        end
+        @test diagm() isa BitArray # issue #961: type piracy of zero-arg diagm
         @test @inferred(diagm(SA[1,2])) === SA[1 0; 0 2]
         @test @inferred(diagm(Val(0) => SVector(1,2))) === @SMatrix [1 0; 0 2]
         @test @inferred(diagm(Val(2) => SVector(1,2,3)))::SMatrix == diagm(2 => [1,2,3])
@@ -225,17 +220,16 @@ StaticArrays.similar_type(::Union{RotMat2,Type{RotMat2}}) = SMatrix{2,2,Float64,
         @test normalize!(MVector(1.,2.,3.)) ≈ normalize([1.,2.,3.])
         @test normalize!(MVector(1.,2.,3.), 1) ≈ normalize([1.,2.,3.], 1)
 
-        if VERSION ≥ v"1.5" # `normalize` with `AbstractArray` signature added in v1.5
-            @test normalize(SA[1 2 3; 4 5 6; 7 8 9]) ≈ normalize([1 2 3; 4 5 6; 7 8 9])
-            @test normalize(SA[1 2 3; 4 5 6; 7 8 9], 1) ≈ normalize([1 2 3; 4 5 6; 7 8 9], 1)
-            @test normalize!((@MMatrix [1. 2. 3.; 4. 5. 6.; 7. 8. 9.])) ≈ normalize!([1. 2. 3.; 4. 5. 6.; 7. 8. 9.])
-            @test normalize!((@MMatrix [1. 2. 3.; 4. 5. 6.; 7. 8. 9.]), 1) ≈ normalize!([1. 2. 3.; 4. 5. 6.; 7. 8. 9.], 1)
+        @test normalize(SA[1 2 3; 4 5 6; 7 8 9]) ≈ normalize([1 2 3; 4 5 6; 7 8 9])
+        @test normalize(SA[1 2 3; 4 5 6; 7 8 9], 1) ≈ normalize([1 2 3; 4 5 6; 7 8 9], 1)
+        @test normalize!((@MMatrix [1. 2. 3.; 4. 5. 6.; 7. 8. 9.])) ≈ normalize!([1. 2. 3.; 4. 5. 6.; 7. 8. 9.])
+        @test normalize!((@MMatrix [1. 2. 3.; 4. 5. 6.; 7. 8. 9.]), 1) ≈ normalize!([1. 2. 3.; 4. 5. 6.; 7. 8. 9.], 1)
 
-            D3 = Array{Float64, 3}(undef, 2, 2, 3)
-            D3[:] .= 1.0:12.0
-            SA_D3 = convert(SArray{Tuple{2,2,3}, Float64, 3, 12}, D3)
-            @test normalize(SA_D3) ≈ normalize(D3)
-        end
+        D3 = Array{Float64, 3}(undef, 2, 2, 3)
+        D3[:] .= 1.0:12.0
+        SA_D3 = convert(SArray{Tuple{2,2,3}, Float64, 3, 12}, D3)
+        @test normalize(SA_D3) ≈ normalize(D3)
+
         # nested vectors
         a  = SA[SA[1, 2], SA[3, 4]]
         av = convert(Vector{Vector{Int}}, a)
@@ -271,15 +265,11 @@ StaticArrays.similar_type(::Union{RotMat2,Type{RotMat2}}) = SMatrix{2,2,Float64,
         end
 
         # type-stability
-        if VERSION ≥ v"1.2"
-            # only test strict type-stability on v1.2+, since there were Base-related type
-            # instabilities in `norm` prior to https://github.com/JuliaLang/julia/pull/30481
-            @test (@inferred norm(a[1])) == (@inferred norm(a[1], 2))
-            @test (@inferred norm(a)) == (@inferred norm(a, 2))
-            @test (@inferred norm(aa)) == (@inferred norm(aa, 2))
-            @test (@inferred norm(float.(aa))) == (@inferred norm(float.(aa), 2))
-            @test (@inferred norm(SVector{0,Int}())) == (@inferred norm(SVector{0,Int}(), 2))
-        end
+        @test (@inferred norm(a[1])) == (@inferred norm(a[1], 2))
+        @test (@inferred norm(a)) == (@inferred norm(a, 2))
+        @test (@inferred norm(aa)) == (@inferred norm(aa, 2))
+        @test (@inferred norm(float.(aa))) == (@inferred norm(float.(aa), 2))
+        @test (@inferred norm(SVector{0,Int}())) == (@inferred norm(SVector{0,Int}(), 2))
 
         # norm of empty SVector
         @test norm(SVector{0,Int}()) isa float(Int)

--- a/test/matrix_multiply_add.jl
+++ b/test/matrix_multiply_add.jl
@@ -5,10 +5,8 @@ using Test
 
 macro test_noalloc(ex)
     esc(quote
-        if VERSION < v"1.5"
-            $ex
-            @test(@allocated($ex) == 0)
-        end
+        $ex
+        @test(@allocated($ex) == 0)
     end)
 end
 

--- a/test/matrix_multiply_add.jl
+++ b/test/matrix_multiply_add.jl
@@ -96,17 +96,13 @@ function test_multiply_add(N1,N2,ArrayType=MArray)
     mul!(b,At,c,1.0,2.0)
     @test b ≈ 5A'c
 
-    @static if VERSION < v"1.5-"
+    if !(ArrayType <: SizedArray)
         @test_noalloc mul!(c,A,b)
     else
-        if !(ArrayType <: SizedArray)
-            @test_noalloc mul!(c,A,b)
-        else
-            mul!(c,A,b)
-            @test_broken(@allocated(mul!(c,A,b)) == 0)
-        end
+        mul!(c,A,b)
+        @test_broken(@allocated(mul!(c,A,b)) == 0)
     end
-    expected_transpose_allocs = VERSION < v"1.5" ? 1 : 0
+    expected_transpose_allocs = 0
     bmark = @benchmark mul!($c,$A,$b,$α,$β) samples=10 evals=10
     @test minimum(bmark).allocs == 0
     # @test_noalloc mul!(c, A, b, α, β)  # records 32 bytes

--- a/test/svd.jl
+++ b/test/svd.jl
@@ -71,19 +71,14 @@ using StaticArrays, Test, LinearAlgebra
         @testinf svd(m_sing2'; full=Val(true)) \ v2 ≈ svd(Matrix(m_sing2'); full=true) \ Vector(v2)
         @testinf svd(m_sing2; full=Val(true)) \ m23' ≈ svd(Matrix(m_sing2); full=true) \ Matrix(m23')
         @testinf svd(m_sing2'; full=Val(true)) \ m23 ≈ svd(Matrix(m_sing2'); full=true) \ Matrix(m23)
-        if VERSION >= v"1.5"
-            # Test that svd of rectangular matrix is inferred.
-            # Note the placement of @inferred brackets is important.
-            #
-            # This only seems to work on v"1.5" due to unknown compiler improvements; seems
-            # to have stopped working again on v"1.6" and later?
-            svd_full_false(A) = svd(A, full=false)
-            if VERSION < v"1.6"
-                @test        @inferred(svd_full_false(m_sing2)).S ≈ svd(Matrix(m_sing2)).S
-            else
-                @test_broken @inferred(svd_full_false(m_sing2)).S ≈ svd(Matrix(m_sing2)).S
-            end
-        end
+
+        # Test that svd of rectangular matrix is inferred.
+        # Note the placement of @inferred brackets is important.
+        #
+        # This only seems to work on v"1.5" due to unknown compiler improvements; seems
+        # to have stopped working again on v"1.6" and later?
+        svd_full_false(A) = svd(A, full=false)
+        @test_broken @inferred(svd_full_false(m_sing2)).S ≈ svd(Matrix(m_sing2)).S
 
         @testinf svd(mc_sing) \ v ≈ svd(Matrix(mc_sing)) \ Vector(v)
         @testinf svd(mc_sing) \ vc ≈ svd(Matrix(mc_sing)) \ Vector(vc)

--- a/test/testutil.jl
+++ b/test/testutil.jl
@@ -79,20 +79,6 @@ should_be_inlined(x) = x*x
 should_not_be_inlined(x) = _should_not_be_inlined(x)
 
 """
-    @inferred_maybe_allow allow ex
-
-Expands to `@inferred allow ex` on Julia 1.2 and newer and
-`ex` on Julia 1.0 and 1.1.
-"""
-macro inferred_maybe_allow(allow, ex)
-    if VERSION < v"1.2"
-        return esc(:($ex))
-    else
-        return esc(:(@inferred $allow $ex))
-    end
-end
-
-"""
     @test_was_once_broken good_version ex
 
 Expands to `@test ex` if `VERSION ≥ good_version` and to `@test_broken ex` if 


### PR DESCRIPTION
We discussed this briefly on Slack: now that the new Julia LTS is v1.6, it would make sense to drop support for earlier versions. There's at least two good reasons for doing so: 

1. CI takes forever to run when it needs to go through so many Julia versions.
2. Development becomes tedious and somewhat fragile because one has to guard what may or may not work on different Julia versions. As a result, there's a lot of `VERSION` checks in StaticArrays currently (in source files and in tests).

I'm putting this up mainly for discussion - but the relevant bits to actually do this should also be here and are split across independent commits. 

I also bumped the minor version of StaticArrays to v1.4: quoting @c42f from Slack:
> [...] we can release patches versions 1.3.x if really necessary for older Julia versions.

One obvious counter-point is that this could cause a lot of downstream "noise" for packages that try to support pre-LTS versions of Julia. A similar fear could be that this could cause some fracturing of the compat versions of StaticArrays in the ecosystem, which could lead to compat conflicts.
Conversely, since StaticArrays is so widely used, this could also be seen as good thing, in that it would help speed up a broader transition to move on to v1.6+.