### PR TITLE
specialize `mul_fast` and `add_fast` to allow FMA

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StaticArrays"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "1.3.2"
+version = "1.3.3"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -50,6 +50,15 @@ end
 @inline Base.muladd(scalar::Number, a::StaticArray, b::StaticArray) = map((ai, bi) -> muladd(scalar, ai, bi), a, b)
 @inline Base.muladd(a::StaticArray, scalar::Number, b::StaticArray) = map((ai, bi) -> muladd(ai, scalar, bi), a, b)
 
+
+# @fastmath operators
+@inline Base.FastMath.mul_fast(a::Number, b::StaticArray) = map(c -> Base.FastMath.mul_fast(a, c), b)
+@inline Base.FastMath.mul_fast(a::StaticArray, b::Number) = map(c -> Base.FastMath.mul_fast(c, b), a)
+
+@inline Base.FastMath.add_fast(a::StaticArray, b::StaticArray) = map(Base.FastMath.add_fast, a, b)
+@inline Base.FastMath.sub_fast(a::StaticArray, b::StaticArray) = map(Base.FastMath.sub_fast, a, b)
+
+
 #--------------------------------------------------
 # Matrix algebra
 

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -69,6 +69,31 @@ StaticArrays.similar_type(::Union{RotMat2,Type{RotMat2}}) = SMatrix{2,2,Float64,
         end
     end
 
+    @testset "@fastmath operators" begin
+        for T in (Int, Float32, Float64)
+            s0 = convert(T, 2)
+            v1 = @SVector T[2, 4, 6, 8]
+            v2 = @SVector T[4, 3, 2, 1]
+            m1 = @SMatrix T[2 4; 6 8]
+            m2 = @SMatrix T[4 3; 2 1]
+
+            # Use that these small integers can be represetnted exactly
+            # as floating point numbers. In general, the comparison of
+            # floats should use `≈` instead of `===`.
+            # These should be turned into `vfmadd...` calls
+            @test @fastmath(@inferred(s0 * v1 + v2)) === @SVector T[8, 11, 14, 17]
+            @test @fastmath(@inferred(v1 * s0 + v2)) === @SVector T[8, 11, 14, 17]
+            @test @fastmath(@inferred(s0 * m1 + m2)) === @SMatrix T[8 11; 14 17]
+            @test @fastmath(@inferred(m1 * s0 + m2)) === @SMatrix T[8 11; 14 17]
+
+            # These should be turned into `vfmsub...` calls
+            @test @fastmath(@inferred(s0 * v1 - v2)) === @SVector T[0, 5, 10, 15]
+            @test @fastmath(@inferred(v1 * s0 - v2)) === @SVector T[0, 5, 10, 15]
+            @test @fastmath(@inferred(s0 * m1 - m2)) === @SMatrix T[0 5; 10 15]
+            @test @fastmath(@inferred(m1 * s0 - m2)) === @SMatrix T[0 5; 10 15]
+        end
+    end
+
     @testset "Interaction with `UniformScaling`" begin
         @test @inferred(@SMatrix([0 1; 2 3]) + I) === @SMatrix [1 1; 2 4]
         @test @inferred(I + @SMatrix([0 1; 2 3])) === @SMatrix [1 1; 2 4]


### PR DESCRIPTION
This avoids hitting the general fallback https://github.com/JuliaLang/julia/blob/5864e4341b0f11879a566bb6dbc571e230c26691/base/fastmath.jl#L265
Depending on the processor, LLVM can turn this into efficient FMA calls. Depending on the workload, this can speed-up number crunching quite a bit. For example I get
```julia
julia> using StaticArrays

julia> foo_add(a, b, c) = @fastmath a * b + c
foo_add (generic function with 1 method)

julia> foo_sub(a, b, c) = @fastmath a * b - c
foo_sub (generic function with 1 method)

julia> a = 1.5; b = SVector(1.0, 2.0, 3.0, 4.0); c = SVector(1.0, 2.0, 3.0, 4.0);

julia> @code_native debuginfo=:none foo_add(a, b, c)
        .text
        movq    %rdi, %rax
        vbroadcastsd    %xmm0, %ymm0
        vmulpd  (%rsi), %ymm0, %ymm0
        vaddpd  (%rdx), %ymm0, %ymm0
        vmovupd %ymm0, (%rdi)
        vzeroupper
        retq
        nopl    (%rax,%rax)

julia> @code_native debuginfo=:none foo_sub(a, b, c)
        .text
        movq    %rdi, %rax
        vbroadcastsd    %xmm0, %ymm0
        vmulpd  (%rsi), %ymm0, %ymm0
        vsubpd  (%rdx), %ymm0, %ymm0
        vmovupd %ymm0, (%rdi)
        vzeroupper
        retq
        nopl    (%rax,%rax)
```
with v1.3.2 of StaticArrays.jl and
```julia
julia> using StaticArrays

julia> foo_add(a, b, c) = @fastmath a * b + c
foo_add (generic function with 1 method)

julia> foo_sub(a, b, c) = @fastmath a * b - c
foo_sub (generic function with 1 method)

julia> a = 1.5; b = SVector(1.0, 2.0, 3.0, 4.0); c = SVector(1.0, 2.0, 3.0, 4.0);

julia> @code_native debuginfo=:none foo_add(a, b, c)
        .text
        movq    %rdi, %rax
        vmovupd (%rsi), %ymm1
        vbroadcastsd    %xmm0, %ymm0
        vfmadd213pd     (%rdx), %ymm1, %ymm0    # ymm0 = (ymm1 * ymm0) + mem
        vmovupd %ymm0, (%rdi)
        vzeroupper
        retq
        nopl    (%rax)

julia> @code_native debuginfo=:none foo_sub(a, b, c)
        .text
        movq    %rdi, %rax
        vmovupd (%rsi), %ymm1
        vbroadcastsd    %xmm0, %ymm0
        vfmsub213pd     (%rdx), %ymm1, %ymm0    # ymm0 = (ymm1 * ymm0) - mem
        vmovupd %ymm0, (%rdi)
        vzeroupper
        retq
        nopl    (%rax)
```
with this PR. Note that the individual operations ahve been fused into `vfmadd213pd` and `vfmsub213pd`.

I increased the version number since I would really like to be able to use this performance improvement.

Xref #949