### PR TITLE
Avoid using deprecated macro `@_inline_meta`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StaticArrays"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "1.3.3"
+version = "1.3.4"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/SArray.jl
+++ b/src/SArray.jl
@@ -65,7 +65,7 @@ shape_string(inds::CartesianIndex) = join(Tuple(inds), '×')
     (x === nothing && generator_too_short_error(inds, i); x)
 
 @generated function sacollect(::Type{SA}, gen) where {SA <: StaticArray{S}} where {S <: Tuple}
-    stmts = [:(Base.@_inline_meta)]
+    stmts = [:(@_inline_meta)]
     args = []
     iter = :(iterate(gen))
     inds = CartesianIndices(size_to_tuple(S))

--- a/src/SHermitianCompact.jl
+++ b/src/SHermitianCompact.jl
@@ -100,7 +100,7 @@ end
         end
     end
     quote
-        Base.@_inline_meta
+        @_inline_meta
         return $(tuple(indexmat...))
     end
 end

--- a/src/StaticArrays.jl
+++ b/src/StaticArrays.jl
@@ -1,6 +1,6 @@
 module StaticArrays
 
-import Base: @_inline_meta, @_propagate_inbounds_meta, @_pure_meta, @propagate_inbounds, @pure
+import Base: @_propagate_inbounds_meta, @propagate_inbounds, @pure
 
 import Base: getindex, setindex!, size, similar, vec, show, length, convert, promote_op,
              promote_rule, map, map!, reduce, mapreduce, foldl, mapfoldl, broadcast,

--- a/src/util.jl
+++ b/src/util.jl
@@ -1,3 +1,9 @@
+@static if VERSION < v"1.8.0-DEV.410"
+    using Base: @_inline_meta
+else
+    const var"@_inline_meta" = Base.var"@inline"
+end
+
 # For convenience
 TupleN{T,N} = NTuple{N,T}
 


### PR DESCRIPTION
`@_inline_meta` is deprecated in 1.8-DEV.

```console
$ julia1.8 --depwarn=error --project -e 'using StaticArrays; zeros(SVector{3,Int})'
ERROR: LoadError: `@_inline_meta` is deprecated, use `@inline` instead.
```

This patch defines `const var"@_inline_meta" = Base.var"@inline"` for 1.8-DEV.

It also removes the import of unused macro `@_pure_meta`.