### PR TITLE
Fix eigvals for complex 3x3 matrices

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StaticArrays"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "1.3.5"
+version = "1.3.6"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/eigen.jl
+++ b/src/eigen.jl
@@ -50,7 +50,11 @@ end
 end
 
 @inline function _eigvals(::Size{(3,3)}, A::LinearAlgebra.RealHermSymComplexHerm{T}, permute, scale) where {T <: Real}
-    S = arithmetic_closure(T)
+    S = if typeof(A) <: Hermitian{Complex{T}}
+        complex(arithmetic_closure(T))
+    else
+        arithmetic_closure(T)
+    end
     Sreal = real(S)
 
     @inbounds a11 = convert(Sreal, A.data[1])

--- a/test/eigen.jl
+++ b/test/eigen.jl
@@ -134,6 +134,15 @@ using StaticArrays, Test, LinearAlgebra
         @test (@inferred_maybe_allow SVector{3,ComplexF64} eigvals(m1, m2)) ≈ eigvals(m1_a, m2_a)
     end
 
+    @testset "3×3 complex" begin
+        m = SMatrix{3,3}(ComplexF64[
+            0.0 + 0.0im -0.0 - 1.3823165541274323im -0.0 - 0.29894503384118465im;
+            0.0 + 1.3823165541274323im 0.0 + 0.0im -0.0 - 1.9507754416262268im;
+            0.0 + 0.29894503384118465im 0.0 + 1.9507754416262268im 0.0 + 0.0im])
+        vals = eigvals(m)
+        @test isapprox(vals, eigvals(Matrix(m)))
+    end
+
     @testset "3x3 degenerate cases" begin
         # Rank 1
         v = randn(SVector{3,Float64})


### PR DESCRIPTION
As in the title, currently `eigvals` doesn't work for complex 3x3 matrices (see test for an example). This fixes the problem.