### PR TITLE
map: build output type based on first static argument.

### DIFF
--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -73,7 +73,7 @@ end
         @_inline_meta
         S = same_size(a...)
         @inbounds elements = tuple($(exprs...))
-        @inbounds return similar_type(typeof(_first(a...)), eltype(elements), S)(elements)
+        @inbounds return similar_type(typeof(a[$first_staticarray]), eltype(elements), S)(elements)
     end
 end
 

--- a/test/mapreduce.jl
+++ b/test/mapreduce.jl
@@ -5,6 +5,8 @@ using Statistics: mean
     @testset "map and map!" begin
         v1 = @SVector [2,4,6,8]
         v2 = @SVector [4,3,2,1]
+        mv1 = @MVector [2,4,6,8]
+        mv2 = @MVector [4,3,2,1]
         mv = MVector{4, Int}(undef)
 
         normal_v1 = [2,4,6,8]
@@ -12,8 +14,12 @@ using Statistics: mean
 
         @test @inferred(map(-, v1)) === @SVector [-2, -4, -6, -8]
         @test @inferred(map(+, v1, v2)) === @SVector [6, 7, 8, 9]
-        # @test @inferred(map(+, normal_v1, v2)) === @SVector [6, 7, 8, 9] # Maybe could fix this up
+        @test @inferred(map(+, normal_v1, v2)) === @SVector [6, 7, 8, 9]
         @test @inferred(map(+, v1, normal_v2)) === @SVector [6, 7, 8, 9]
+
+        # Make sure similar_type is based on first <: StaticArray
+        @test @inferred(map(+, normal_v1, mv2))::MVector{4,Int} == @MVector [6, 7, 8, 9]
+        @test @inferred(map(+, mv1, normal_v2))::MVector{4,Int} == @MVector [6, 7, 8, 9]
 
         map!(+, mv, v1, v2)
         @test mv == @MVector [6, 7, 8, 9]
@@ -29,6 +35,9 @@ using Statistics: mean
         @test @inferred(map(/, SVector{0,Int}(), SVector{0,Int}())) === SVector{0,Float64}()
         @test @inferred(map(+, SVector{0,Int}(), SVector{0,Float32}())) === SVector{0,Float32}()
         @test @inferred(map(length, SVector{0,String}())) === SVector{0,Int}()
+        # similar_type based on first <: StaticArray
+        @test @inferred(map(+, MVector{0,Int}(), Int[]))::MVector{0,Int} == MVector{0,Int}()
+        @test @inferred(map(+, Int[], MVector{0,Int}()))::MVector{0,Int} == MVector{0,Int}()
     end
 
     @testset "[map]reduce and [map]reducedim" begin


### PR DESCRIPTION
A colleague noticed the following inconsistency in the output types:
```julia
julia> struct Vec3{T} <: FieldVector{3, T}
           x::T
           y::T
           z::T
       end

julia> StaticArrays.similar_type(::Type{<:Vec3}, ::Type{T}, s::Size{(3,)}) where {T} = Vec3{T}

julia> v3 = Vec3(1, 2, 3); v = [1, 2, 3];

julia> v3 + v
3-element Vec3{Int64} with indices SOneTo(3):
 2
 4
 6

julia> v + v3
3-element SVector{3, Int64} with indices SOneTo(3):
 2
 4
 6
```

With this patch `similar_type` is called on the first argument that is `<: StaticArray`, which is actually consistent with the 0-dimensional case: https://github.com/JuliaArrays/StaticArrays.jl/blob/1858207b405ea168ecd6810ffa7bbb07e984a2b7/src/mapreduce.jl#L62