### PR TITLE
Add an outer `@testset` for LU tests

### DIFF
--- a/test/lu.jl
+++ b/test/lu.jl
@@ -1,5 +1,7 @@
 using StaticArrays, Test, LinearAlgebra
 
+@testset "LU" begin
+
 @testset "LU utils" begin
     F = lu(SA[1 2; 3 4])
 
@@ -76,3 +78,5 @@ end
         @test isa(lu(A; check=true),  StaticArrays.LU)
     end
 end
+
+end # @testset "LU"


### PR DESCRIPTION
Very small nit: the LU tests were missing an "outer" `@testset` and consequently appeared unnecessarily many times in the listings of test-progress - this PR fixes that.