### PR TITLE
Benchmark on latest Julia and scale back large-matrix benchmarking

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@latest
         with:
-          version: 1.6
+          version: 1
       - name: Install dependencies
         run: julia -e 'using Pkg; pkg"add PkgBenchmark BenchmarkCI@0.1"'
       - name: Run benchmarks

--- a/benchmark/bench_mat_mul.jl
+++ b/benchmark/bench_mat_mul.jl
@@ -26,7 +26,7 @@ mul_wrappers_reduced = [
     (m -> Transpose(m), "transpo"),
     (m -> Diagonal(m), "diag   ")]
 
-for N in [2, 4, 8, 10, 16]
+for N in [2, 4, 8, 10, 12]
 
     matvecstr = @sprintf("mat-vec  %2d", N)
     matmatstr = @sprintf("mat-mat  %2d", N)
@@ -205,7 +205,7 @@ function pick_best(results, mul_wrappers, size_iter; tol = 1.2)
 end
 
 function run_1()
-    return full_benchmark(mul_wrappers_reduced, [2, 3, 4, 5, 8, 9, 14, 16])
+    return full_benchmark(mul_wrappers_reduced, [2, 3, 4, 5, 8, 9, 12])
 end
 
 end #module

--- a/benchmark/bench_qr.jl
+++ b/benchmark/bench_qr.jl
@@ -6,7 +6,7 @@ using StaticArrays
 
 const suite = BenchmarkGroup()
 
-for K = 1:22
+for K = [2, 3, 4, 8, 10, 12]
     a = rand(SMatrix{K,K,Float64,K*K})
     m = Matrix(a)
     s = suite["S=$K"] = BenchmarkGroup()


### PR DESCRIPTION
Following up on https://github.com/JuliaArrays/StaticArrays.jl/pull/985#issuecomment-1046936674 (cc. @KristofferC), this changes the benchmarks to run on the latest released version of Julia.

Additionally, it reduces the amount of benchmarking done for large matrices: those benchmarks currently take up the majority of benchmarking time due to their large compilation time, which doesn't seem worthwhile given that using StaticArrays for such large matrices is effectively counter to the package's focus on small sizes.