### PR TITLE
Make `broadcast` extendable to user array wrapper.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StaticArrays"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "1.4.1"
+version = "1.4.2"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -22,7 +22,7 @@ function _precompile_()
     end
 
     # Some expensive generators
-    @assert precompile(Tuple{typeof(which(_broadcast,(Any,Size,Tuple{Vararg{Size}},Vararg{Any},)).generator.gen),Any,Any,Any,Any,Any,Any})
+    @assert precompile(Tuple{typeof(which(__broadcast,(Any,Size,Tuple{Vararg{Size}},Vararg{Any},)).generator.gen),Any,Any,Any,Any,Any,Any})
     @assert precompile(Tuple{typeof(which(_zeros,(Size,Type{<:StaticArray},)).generator.gen),Any,Any,Any,Type,Any})
     @assert precompile(Tuple{typeof(which(combine_sizes,(Tuple{Vararg{Size}},)).generator.gen),Any,Any})
     @assert precompile(Tuple{typeof(which(_mapfoldl,(Any,Any,Colon,Any,Size,Vararg{StaticArray},)).generator.gen),Any,Any,Any,Any,Any,Any,Any,Any})

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -302,13 +302,14 @@ end
 @testset "Broadcast with unknown wrapper" begin
     data = (1, 2)
     for T in (SVector{2}, MVector{2})
+        destT = T <: SArray ? SArray : MArray
         a = T(data)
         for b in (WrapArray(a), WrapArray(a'))
-            @test @inferred(b .+ a) isa T
-            @test @inferred(b .+ b) isa T
-            @test @inferred(b .+ (1, 2)) isa T
-            @test @inferred(b .+ a') isa StaticMatrix
-            @test @inferred(a' .+ b) isa StaticMatrix
+            @test @inferred(b .+ a) isa destT
+            @test @inferred(b .+ b) isa destT
+            @test @inferred(b .+ (1, 2)) isa destT
+            @test @inferred(b .+ a') isa destT
+            @test @inferred(a' .+ b) isa destT
             # @test @inferred(b' .+ a') isa StaticMatrix # Adjoint doesn't propagate style
             @test b .+ b.data == b .+ b == b.data .+ b.data
         end


### PR DESCRIPTION
This PR tries to make the current broadcast kernal reusable to more wrapped StaticArray. 
For this goal, we need to get `first_staticarray` outside the `@generated function` to make sure the type match extendable. (Not sure the reason)
Our optimizer should be clever enough to make it zero cost at runtime.

This was discussed in https://github.com/JuliaArrays/StructArrays.jl/pull/215, where we want to make 
```julia
s = StructArray{ComplexF64}((SVector(1., 2., 3.), SVector(0., 0., 0.)))
log.(s)
```
return a `SVector`.

A simple test has been added.
