### PR TITLE
Fix `lu`/`qr` pivot deprecations and allow `PivotingStrategy` input

### DIFF
--- a/src/lu.jl
+++ b/src/lu.jl
@@ -80,7 +80,13 @@ issuccess(F::LU) = _first_zero_on_diagonal(F.U) == 0
     else
         quote
             # call through to Base to avoid excessive time spent on type inference for large matrices
-            f = lu(Matrix(A), pivot; check = check)
+            _pivot = if pivot === Val(true)
+                RowMaximum()
+            else
+                NoPivot()
+            end
+                
+            f = lu(Matrix(A), _pivot; check = check)
             # Trick to get the output eltype - can't rely on the result of f.L as
             # it's not type inferrable.
             T2 = arithmetic_closure(T)

--- a/test/lu.jl
+++ b/test/lu.jl
@@ -79,4 +79,12 @@ end
     end
 end
 
+if isdefined(LinearAlgebra, :PivotingStrategy)
+    for N = (3, 15)
+        A = (@SMatrix randn(N,N))
+        @test lu(A, Val(false)) == lu(A, NoPivot())
+        @test lu(A, Val(true)) == lu(A, RowMaximum())
+    end
+end
+
 end # @testset "LU"

--- a/test/qr.jl
+++ b/test/qr.jl
@@ -27,7 +27,7 @@ Random.seed!(42)
 
         # pivot=true cases has no StaticArrays specific version yet
         # but fallbacks to LAPACK
-        pivot = Val(true)
+        pivot = isdefined(LinearAlgebra, :PivotingStrategy) ? ColumnNorm() : Val(true)
         QRp = @inferred qr(arr, pivot)
         @test QRp isa StaticArrays.QR
         Q, R, p = QRp

--- a/test/qr.jl
+++ b/test/qr.jl
@@ -59,6 +59,14 @@ Random.seed!(42)
                ]
         test_qr(arr)
     end
+
+    if isdefined(LinearAlgebra, :PivotingStrategy)
+        for N = (3, 18)
+            A = (@SMatrix randn(N,N))
+            @test qr(A, Val(false)) == qr(A, NoPivot())
+            @test qr(A, Val(true)) == qr(A, ColumnNorm())
+        end
+    end
 end
 
 @testset "QR method ambiguity" begin


### PR DESCRIPTION
This tackles the same problem as #977 (and builds on it), but applies it to `qr` as well, and should also work on Julia v1.6, where the new `LinearAlgebra.PivotingStrategy` is not defined.

At the same time, I added accessors so that `qr(::StaticArray, pivot)` and `lu(...)` can be called with `pivot <: PivotingStrategy` instances.

Closes #977.