### PR TITLE
Fix return type for `setindex!(::SizedArray, ...)`

### DIFF
--- a/src/SizedArray.jl
+++ b/src/SizedArray.jl
@@ -120,7 +120,7 @@ end
 end
 
 @propagate_inbounds getindex(a::SizedArray, i::Int) = getindex(a.data, i)
-@propagate_inbounds setindex!(a::SizedArray, v, i::Int) = setindex!(a.data, v, i)
+@propagate_inbounds setindex!(a::SizedArray, v, i::Int) = (setindex!(a.data, v, i); a)
 
 Base.parent(sa::SizedArray) = sa.data
 

--- a/test/MMatrix.jl
+++ b/test/MMatrix.jl
@@ -102,6 +102,8 @@
         m[3] = 13
         m[4] = 14
         @test m.data === (11, 12, 13, 14)
+        @test setindex!(m, 13, 3) === m
+        @test setindex!(m, 12, 2, 1) === m
 
         m = @MMatrix [0 0; 0 0]
         m[1] = Int8(11)

--- a/test/MVector.jl
+++ b/test/MVector.jl
@@ -81,6 +81,7 @@
         v[2] = 12
         v[3] = 13
         @test v.data === (11, 12, 13)
+        @test setindex!(v, 13, 3) === v
 
         v = @MVector [1.,2.,3.]
         v[1] = Float16(11)

--- a/test/SizedArray.jl
+++ b/test/SizedArray.jl
@@ -84,11 +84,23 @@
     end
 
     # setindex
-    sa = SizedArray{Tuple{2}, Int, 1}([3, 4])
-    sa[1] = 2
-    @test sa.data == [2, 4]
+    @testset "setindex" begin
+        sa = SizedArray{Tuple{2}, Int, 1}([3, 4])
+        sa[1] = 2
+        @test sa.data == [2, 4]
+        @test setindex!(sa, 2, 1) === sa
+
+        sm = SizedArray{Tuple{4,3}}(rand(4, 3))
+        sm[1] = 2
+        @test sa.data[1] == 2
+        sm[2, 3] = 4
+        @test sm.data[2, 3] == 4
+        @test setindex!(sm, 0.5, 1) === sm
+        @test setindex!(sm, 0.5, 2, 3) === sm
+    end
 
     # parent
+    sa = SizedArray{Tuple{2}, Int, 1}([3, 4])
     @test parent(sa) === sa.data
 
     # pointer


### PR DESCRIPTION
This fixes the following:
```julia
julia> using StaticArrays

julia> sa = SizedVector{2}([1,2]);

julia> setindex!(sa, 99, 1)  # doesn't return the array itself, like Base does
2-element Vector{Int64}:
 99
  2

julia> sa
2-element SizedVector{2, Int64, Vector{Int64}} with indices SOneTo(2):
 99
  2
```
For a SizedMatrix there is no problem, nor for an MArray. But this also adds tests for those cases. 