### PR TITLE
Drop `combine_size`

### DIFF
--- a/src/abstractarray.jl
+++ b/src/abstractarray.jl
@@ -14,6 +14,7 @@ Base.axes(s::StaticArray) = _axes(Size(s))
 end
 Base.axes(rv::Adjoint{<:Any,<:StaticVector})   = (SOneTo(1), axes(rv.parent)...)
 Base.axes(rv::Transpose{<:Any,<:StaticVector}) = (SOneTo(1), axes(rv.parent)...)
+Base.axes(d::Diagonal{<:Any,<:StaticVector}) = (ax = axes(d.diag, 1); (ax, ax))
 
 Base.eachindex(::IndexLinear, a::StaticArray) = SOneTo(length(a))
 

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -2,9 +2,9 @@
 ## broadcast! ##
 ################
 
-import Base.Broadcast:
-BroadcastStyle, AbstractArrayStyle, Broadcasted, DefaultArrayStyle, materialize!
-import Base.Broadcast: combine_axes, instantiate, _broadcast_getindex, broadcast_shape, Style
+using Base.Broadcast: AbstractArrayStyle, DefaultArrayStyle, Style, Broadcasted
+using Base.Broadcast: broadcast_shape, _broadcast_getindex, combine_axes
+import Base.Broadcast: BroadcastStyle, materialize!, instantiate
 import Base.Broadcast: _bcs1  # for SOneTo axis information
 using Base.Broadcast: _bcsm
 # Add a new BroadcastStyle for StaticArrays, derived from AbstractArrayStyle

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -50,7 +50,7 @@ end
     else
         throw(DimensionMismatch("array could not be broadcast to match destination"))
     end
-    (ax1, static_check_broadcast_shape(Base.tail(shp), Base.tail(Ashp))...)
+    return (ax1, static_check_broadcast_shape(Base.tail(shp), Base.tail(Ashp))...)
 end
 static_check_broadcast_shape(::Tuple{}, ::Tuple{SOneTo,Vararg{SOneTo}}) =
     throw(DimensionMismatch("cannot broadcast array to have fewer non-singleton dimensions"))

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -11,8 +11,8 @@ using Base.Broadcast: _bcsm
 struct StaticArrayStyle{N} <: AbstractArrayStyle{N} end
 StaticArrayStyle{M}(::Val{N}) where {M,N} = StaticArrayStyle{N}()
 BroadcastStyle(::Type{<:StaticArray{<:Tuple, <:Any, N}}) where {N} = StaticArrayStyle{N}()
-BroadcastStyle(::Type{<:Transpose{<:Any, <:StaticArray{<:Tuple, <:Any, N}}}) where {N} = StaticArrayStyle{N}()
-BroadcastStyle(::Type{<:Adjoint{<:Any, <:StaticArray{<:Tuple, <:Any, N}}}) where {N} = StaticArrayStyle{N}()
+BroadcastStyle(::Type{<:Transpose{<:Any, <:StaticArray}}) = StaticArrayStyle{2}()
+BroadcastStyle(::Type{<:Adjoint{<:Any, <:StaticArray}}) = StaticArrayStyle{2}()
 BroadcastStyle(::Type{<:Diagonal{<:Any, <:StaticArray{<:Tuple, <:Any, 1}}}) = StaticArrayStyle{2}()
 # Precedence rules
 BroadcastStyle(::StaticArrayStyle{M}, ::DefaultArrayStyle{N}) where {M,N} =

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -4,6 +4,7 @@
 
 import Base.Broadcast:
 BroadcastStyle, AbstractArrayStyle, Broadcasted, DefaultArrayStyle, materialize!
+import Base.Broadcast: combine_axes, instantiate, _broadcast_getindex, broadcast_shape, Style
 import Base.Broadcast: _bcs1  # for SOneTo axis information
 using Base.Broadcast: _bcsm
 # Add a new BroadcastStyle for StaticArrays, derived from AbstractArrayStyle
@@ -19,6 +20,42 @@ BroadcastStyle(::StaticArrayStyle{M}, ::DefaultArrayStyle{N}) where {M,N} =
     DefaultArrayStyle(Val(max(M, N)))
 BroadcastStyle(::StaticArrayStyle{M}, ::DefaultArrayStyle{0}) where {M} =
     StaticArrayStyle{M}()
+
+# combine_axes overload (for Tuple)
+@inline static_combine_axes(A, B...) = broadcast_shape(static_axes(A), static_combine_axes(B...))
+static_combine_axes(A) = static_axes(A)
+static_axes(A) = axes(A)
+static_axes(x::Tuple) = (SOneTo{length(x)}(),)
+static_axes(bc::Broadcasted{Style{Tuple}}) = static_combine_axes(bc.args...)
+Broadcast._axes(bc::Broadcasted{<:StaticArrayStyle}, ::Nothing) = static_combine_axes(bc.args...)
+
+# instantiate overload
+@inline function instantiate(B::Broadcasted{StaticArrayStyle{M}}) where M
+    if B.axes isa Tuple{Vararg{SOneTo}} || B.axes isa Tuple && length(B.axes) > M
+        return invoke(instantiate, Tuple{Broadcasted}, B)
+    elseif B.axes isa Nothing
+        ax = static_combine_axes(B.args...)
+        return Broadcasted{StaticArrayStyle{M}}(B.f, B.args, ax)
+    else
+        # We need to update B.axes for `broadcast!` if it's not static and `ndims(dest) < M`.
+        ax = static_check_broadcast_shape(B.axes, static_combine_axes(B.args...))
+        return Broadcasted{StaticArrayStyle{M}}(B.f, B.args, ax)
+    end
+end
+@inline function static_check_broadcast_shape(shp::Tuple, Ashp::Tuple{Vararg{SOneTo}})
+    ax1 = if length(Ashp[1]) == 1
+        shp[1]
+    elseif Ashp[1] == shp[1]
+        Ashp[1]
+    else
+        throw(DimensionMismatch("array could not be broadcast to match destination"))
+    end
+    (ax1, static_check_broadcast_shape(Base.tail(shp), Base.tail(Ashp))...)
+end
+static_check_broadcast_shape(::Tuple{}, ::Tuple{SOneTo,Vararg{SOneTo}}) =
+    throw(DimensionMismatch("cannot broadcast array to have fewer non-singleton dimensions"))
+static_check_broadcast_shape(::Tuple{}, ::Tuple{SOneTo{1},Vararg{SOneTo{1}}}) = ()
+static_check_broadcast_shape(::Tuple{}, ::Tuple{}) = ()
 # copy overload
 @inline function Base.copy(B::Broadcasted{StaticArrayStyle{M}}) where M
     flat = Broadcast.flatten(B); as = flat.args; f = flat.f
@@ -42,8 +79,14 @@ end
 
 # Resolving priority between dynamic and static axes
 _bcs1(a::SOneTo, b::SOneTo) = _bcsm(b, a) ? b : (_bcsm(a, b) ? a : throw(DimensionMismatch("arrays could not be broadcast to a common size")))
-_bcs1(a::SOneTo, b::Base.OneTo) = _bcs1(Base.OneTo(a), b)
-_bcs1(a::Base.OneTo, b::SOneTo) = _bcs1(a, Base.OneTo(b))
+function _bcs1(a::SOneTo, b::Base.OneTo)
+    length(a) == 1 && return b
+    if length(b) != length(a) && length(b) != 1
+        throw(DimensionMismatch("arrays could not be broadcast to a common size"))
+    end
+    return a
+end
+_bcs1(a::Base.OneTo, b::SOneTo) = _bcs1(b, a)
 
 ###################################################
 ## Internal broadcast machinery for StaticArrays ##

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -61,10 +61,8 @@ static_check_broadcast_shape(::Tuple{}, ::Tuple{}) = ()
     flat = Broadcast.flatten(B); as = flat.args; f = flat.f
     argsizes = broadcast_sizes(as...)
     ax = axes(B)
-    if ax isa Tuple{Vararg{SOneTo}}
-        return _broadcast(f, Size(map(length, ax)), argsizes, as...)
-    end
-    return copy(convert(Broadcasted{DefaultArrayStyle{M}}, B))
+    ax isa Tuple{Vararg{SOneTo}} || error("Dimension is not static. Please file a bug.")
+    return _broadcast(f, Size(map(length, ax)), argsizes, as...)
 end
 # copyto! overloads
 @inline Base.copyto!(dest, B::Broadcasted{<:StaticArrayStyle}) = _copyto!(dest, B)

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -24,6 +24,10 @@ function _precompile_()
     # Some expensive generators
     @assert precompile(Tuple{typeof(which(__broadcast,(Any,Size,Tuple{Vararg{Size}},Vararg{Any},)).generator.gen),Any,Any,Any,Any,Any,Any})
     @assert precompile(Tuple{typeof(which(_zeros,(Size,Type{<:StaticArray},)).generator.gen),Any,Any,Any,Type,Any})
-    @assert precompile(Tuple{typeof(which(combine_sizes,(Tuple{Vararg{Size}},)).generator.gen),Any,Any})
     @assert precompile(Tuple{typeof(which(_mapfoldl,(Any,Any,Colon,Any,Size,Vararg{StaticArray},)).generator.gen),Any,Any,Any,Any,Any,Any,Any,Any})
+
+    # broadcast_getindex
+    for m = 0:5, n = m:5 
+        @assert precompile(Tuple{typeof(broadcast_getindex),NTuple{m,Int},Int,CartesianIndex{n}})
+    end
 end

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -315,3 +315,23 @@ end
         end
     end
 end
+
+@testset "instantiate with axes updated" begin
+    f(a; ax = nothing) = Broadcast.Broadcasted{StaticArrays.StaticArrayStyle{ndims(a)}}(+,(a,),ax)
+    a = @SArray zeros(2,2,2)
+    ax = Base.OneTo(2), Base.OneTo(2), Base.OneTo(2)
+    @test @inferred(Broadcast.instantiate(f(a; ax))).axes isa NTuple{3,SOneTo}
+    ax = (ax..., Base.OneTo(2))
+    @test @inferred(Broadcast.instantiate(f(a; ax))).axes isa NTuple{4,Base.OneTo}
+    ax = setindex(ax, Base.OneTo(1), 4)
+    @test @inferred(Broadcast.instantiate(f(a; ax))).axes isa NTuple{4,Base.OneTo}
+    a = @SArray zeros(2,1,2)
+    ax = Base.OneTo(2), Base.OneTo(2), Base.OneTo(2)
+    @test @inferred(Broadcast.instantiate(f(a; ax))).axes isa Tuple{SOneTo,Base.OneTo,SOneTo}
+    @test_throws DimensionMismatch Broadcast.instantiate(f(a; ax = ax[1:2]))
+
+    a = @SArray zeros(2,2,1)
+    ax = Base.OneTo(2), Base.OneTo(2), Base.OneTo(2)
+    @test @inferred(Broadcast.instantiate(f(a; ax))).axes isa Tuple{SOneTo,SOneTo,Base.OneTo}
+    @test @inferred(Broadcast.instantiate(f(a; ax = ax[1:2]))).axes isa NTuple{2,SOneTo}
+end


### PR DESCRIPTION
This PR tries to perform `combine_size` during `Broadcast.instantiate`:
1. For `broadcast`, `combine_axes` will return a `Tuple{Vararg{SOneTo}}`, thus the output size has been static.
2. For `broadcast!`, the `dest`'s `axes` is marked as static (if possible). If there's no size-1 dim in `src`. The current generated kernal will be called.

With this change, we can reduce the compile time for first broadcast by about 1/4:
```julia
julia> a = @SArray zeros(3,3)
3×3 SMatrix{3, 3, Float64, 9} with indices SOneTo(3)×SOneTo(3):
 0.0  0.0  0.0
 0.0  0.0  0.0
 0.0  0.0  0.0

julia> @time a .+ a;
  0.234903 seconds (452.90 k allocations: 24.654 MiB, 99.75% compilation time) #  on master: 0.308612 seconds (513.89 k allocations: 27.912 MiB, 99.87% compilation time)
```