### PR TITLE
Fix qr test failure on nightly

### DIFF
--- a/test/qr.jl
+++ b/test/qr.jl
@@ -48,7 +48,7 @@ Random.seed!(42)
         test_qr(arr)
     end
     # some special cases
-    for arr in [
+    for arr in (
                    (@MMatrix randn(3,2)),
                    (@MMatrix randn(2,3)),
                    (@SMatrix([0 1 2; 0 2 3; 0 3 4; 0 4 5])),
@@ -56,7 +56,7 @@ Random.seed!(42)
                    (@SMatrix([1//2 1//1])),
                    (@SMatrix randn(17,18)),    # fallback to LAPACK
                    (@SMatrix randn(18,17))
-               ]
+                )
         test_qr(arr)
     end
 


### PR DESCRIPTION
Failure example is [here](https://github.com/JuliaArrays/StaticArrays.jl/runs/5522395851?check_suite_focus=true) and occurs because of a change to the element type of heterogeneous vectors of arrays (cf. https://github.com/JuliaLang/julia/issues/44586).

The change here just makes the tests loop over a tuple rather than an array (to make sure the element type is unchanged).