### PR TITLE
Code clean and reuse for `constructor`.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,8 @@ julia = "1.6"
 [extras]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["InteractiveUtils", "Test", "BenchmarkTools"]
+test = ["InteractiveUtils", "Test", "BenchmarkTools", "OffsetArrays"]

--- a/src/FieldArray.jl
+++ b/src/FieldArray.jl
@@ -110,11 +110,12 @@ array operations as in the example below.
 """
 abstract type FieldVector{N, T} <: FieldArray{Tuple{N}, T, 1} end
 
-@inline function (::Type{FA})(x::Tuple{Vararg{Any, N}}) where {N, FA <: FieldArray}
-    @boundscheck if length(FA) != length(x)
-        throw(DimensionMismatch("No precise constructor for $FA found. Length of input was $(length(x))."))
-    end
-    return FA(x...)
+@inline (::Type{FA})(x::Tuple) where {FA <: FieldArray} = construct_type(FA, x)(x...)
+
+function construct_type(::Type{FA}, x) where {FA <: FieldArray}
+    has_size(FA) || error("$FA has no static size!")
+    length_match_size(FA, x)
+    return adapt_eltype(FA, x)
 end
 
 @propagate_inbounds getindex(a::FieldArray, i::Int) = getfield(a, i)

--- a/src/MArray.jl
+++ b/src/MArray.jl
@@ -20,42 +20,23 @@ the compiler (the element type may optionally also be specified).
 mutable struct MArray{S <: Tuple, T, N, L} <: StaticArray{S, T, N}
     data::NTuple{L,T}
 
-    function MArray{S,T,N,L}(x::NTuple{L,T}) where {S,T,N,L}
+    function MArray{S,T,N,L}(x::NTuple{L,T}) where {S<:Tuple,T,N,L}
         check_array_parameters(S, T, Val{N}, Val{L})
         new{S,T,N,L}(x)
     end
 
-    function MArray{S,T,N,L}(x::NTuple{L,Any}) where {S,T,N,L}
+    function MArray{S,T,N,L}(x::NTuple{L,Any}) where {S<:Tuple,T,N,L}
         check_array_parameters(S, T, Val{N}, Val{L})
         new{S,T,N,L}(convert_ntuple(T, x))
     end
 
-    function MArray{S,T,N,L}(::UndefInitializer) where {S,T,N,L}
+    function MArray{S,T,N,L}(::UndefInitializer) where {S<:Tuple,T,N,L}
         check_array_parameters(S, T, Val{N}, Val{L})
         new{S,T,N,L}()
     end
 end
 
-@generated function (::Type{MArray{S,T,N}})(x::Tuple) where {S,T,N}
-    return quote
-        $(Expr(:meta, :inline))
-        MArray{S,T,N,$(tuple_prod(S))}(x)
-    end
-end
-
-@generated function (::Type{MArray{S,T}})(x::Tuple) where {S,T}
-    return quote
-        $(Expr(:meta, :inline))
-        MArray{S,T,$(tuple_length(S)),$(tuple_prod(S))}(x)
-    end
-end
-
-@generated function (::Type{MArray{S}})(x::T) where {S, T <: Tuple}
-    return quote
-        $(Expr(:meta, :inline))
-        MArray{S,promote_tuple_eltype(T),$(tuple_length(S)),$(tuple_prod(S))}(x)
-    end
-end
+@inline MArray{S,T,N}(x::Tuple) where {S<:Tuple,T,N} = MArray{S,T,N,tuple_prod(S)}(x)
 
 @generated function (::Type{MArray{S,T,N}})(::UndefInitializer) where {S,T,N}
     return quote
@@ -70,8 +51,6 @@ end
         MArray{S, T, $(tuple_length(S)), $(tuple_prod(S))}(undef)
     end
 end
-
-@inline MArray(a::StaticArray{S,T}) where {S<:Tuple,T} = MArray{S,T}(Tuple(a))
 
 ####################
 ## MArray methods ##

--- a/src/MMatrix.jl
+++ b/src/MMatrix.jl
@@ -17,42 +17,12 @@ unknown to the compiler (the element type may optionally also be specified).
 """
 const MMatrix{S1, S2, T, L} = MArray{Tuple{S1, S2}, T, 2, L}
 
-@generated function (::Type{MMatrix{S1}})(x::NTuple{L}) where {S1,L}
-    S2 = div(L, S1)
-    if S1*S2 != L
-        throw(DimensionMismatch("Incorrect matrix sizes. $S1 does not divide $L elements"))
-    end
-    return quote
-        $(Expr(:meta, :inline))
-        T = eltype(typeof(x))
-        MMatrix{S1, $S2, T, L}(x)
-    end
-end
-
-@generated function (::Type{MMatrix{S1,S2}})(x::NTuple{L}) where {S1,S2,L}
-    return quote
-        $(Expr(:meta, :inline))
-        T = eltype(typeof(x))
-        MMatrix{S1, S2, T, L}(x)
-    end
-end
-
-@generated function (::Type{MMatrix{S1,S2,T}})(x::NTuple{L}) where {S1,S2,T,L}
-    return quote
-        $(Expr(:meta, :inline))
-        MMatrix{S1, S2, T, L}(x)
-    end
-end
-
 @generated function (::Type{MMatrix{S1,S2,T}})(::UndefInitializer) where {S1,S2,T}
     return quote
         $(Expr(:meta, :inline))
         MMatrix{S1, S2, T, $(S1*S2)}(undef)
     end
 end
-
-@inline convert(::Type{MMatrix{S1,S2}}, a::StaticArray{<:Tuple, T}) where {S1,S2,T} = MMatrix{S1,S2,T}(Tuple(a))
-@inline MMatrix(a::StaticMatrix{N,M,T}) where {N,M,T} = MMatrix{N,M,T}(Tuple(a))
 
 # Some more advanced constructor-like functions
 @inline one(::Type{MMatrix{N}}) where {N} = one(MMatrix{N,N})

--- a/src/MVector.jl
+++ b/src/MVector.jl
@@ -16,11 +16,6 @@ compiler (the element type may optionally also be specified).
 """
 const MVector{S, T} = MArray{Tuple{S}, T, 1, S}
 
-@inline MVector(a::StaticVector{N,T}) where {N,T} = MVector{N,T}(a)
-@inline MVector(x::NTuple{S,Any}) where {S} = MVector{S}(x)
-@inline MVector{S}(x::NTuple{S,T}) where {S, T} = MVector{S, T}(x)
-@inline MVector{S}(x::NTuple{S,Any}) where {S} = MVector{S, promote_tuple_eltype(typeof(x))}(x)
-
 # Some more advanced constructor-like functions
 @inline zeros(::Type{MVector{N}}) where {N} = zeros(MVector{N,Float64})
 @inline ones(::Type{MVector{N}}) where {N} = ones(MVector{N,Float64})

--- a/src/SHermitianCompact.jl
+++ b/src/SHermitianCompact.jl
@@ -60,6 +60,7 @@ lowertriangletype(::Type{SHermitianCompact{N}}) where {N} = SVector{triangularnu
 end
 
 @generated function SHermitianCompact{N, T, L}(a::Tuple) where {N, T, L}
+    _check_hermitian_parameters(Val(N), Val(L))
     expr = Vector{Expr}(undef, L)
     i = 0
     for col = 1 : N, row = col : N
@@ -77,14 +78,12 @@ end
     SHermitianCompact{N, T, L}(a)
 end
 
-@inline SHermitianCompact{N}(a::Tuple) where {N} = SHermitianCompact{N, promote_tuple_eltype(a)}(a)
-@inline SHermitianCompact{N}(a::NTuple{M, T}) where {N, T, M} = SHermitianCompact{N, T}(a)
-@inline SHermitianCompact(a::StaticMatrix{N, N, T}) where {N, T} = SHermitianCompact{N, T}(a)
-
 @inline (::Type{SSC})(a::SHermitianCompact) where {SSC <: SHermitianCompact} = SSC(a.lowertriangle)
-@inline (::Type{SSC})(a::SSC) where {SSC <: SHermitianCompact} = a
 
 @inline (::Type{SSC})(a::AbstractVector) where {SSC <: SHermitianCompact} = SSC(convert(lowertriangletype(SSC), a))
+
+# disambiguation
+@inline (::Type{SSC})(a::StaticArray{<:Tuple,<:Any,1}) where {SSC <: SHermitianCompact} = SSC(convert(SVector, a))
 
 @generated function _hermitian_compact_indices(::Val{N}) where N
     # Returns a Tuple{Pair{Int, Bool}} I such that for linear index i,

--- a/src/SMatrix.jl
+++ b/src/SMatrix.jl
@@ -16,60 +16,12 @@ unknown to the compiler (the element type may optionally also be specified).
 """
 const SMatrix{S1, S2, T, L} = SArray{Tuple{S1, S2}, T, 2, L}
 
-@generated function SMatrix{S1}(x::NTuple{L,Any}) where {S1,L}
-    S2 = div(L, S1)
-    if S1*S2 != L
-        throw(DimensionMismatch("Incorrect matrix sizes. $S1 does not divide $L elements"))
-    end
-
-    return quote
-        $(Expr(:meta, :inline))
-        T = promote_tuple_eltype(typeof(x))
-        SMatrix{S1, $S2, T, L}(x)
-    end
-end
-
-@generated function SMatrix{S1,S2}(x::NTuple{L,Any}) where {S1,S2,L}
-    return quote
-        $(Expr(:meta, :inline))
-        T = promote_tuple_eltype(typeof(x))
-        SMatrix{S1, S2, T, L}(x)
-    end
-end
-SMatrixNoType{S1, S2, L, T} = SMatrix{S1, S2, T, L}
-@generated function SMatrixNoType{S1, S2, L}(x::NTuple{L,Any}) where {S1,S2,L}
-    return quote
-        $(Expr(:meta, :inline))
-        T = promote_tuple_eltype(typeof(x))
-        SMatrix{S1, S2, T, L}(x)
-    end
-end
-
-@generated function SMatrix{S1,S2,T}(x::NTuple{L,Any}) where {S1,S2,T,L}
-    return quote
-        $(Expr(:meta, :inline))
-        SMatrix{S1, S2, T, L}(x)
-    end
-end
-
-@inline SMatrix{M, N, T}(gen::Base.Generator) where {M, N, T} =
-    sacollect(SMatrix{M, N, T}, gen)
-@inline SMatrix{M, N}(gen::Base.Generator) where {M, N} =
-    sacollect(SMatrix{M, N}, gen)
-
-@inline convert(::Type{SMatrix{S1,S2}}, a::StaticArray{<:Tuple, T}) where {S1,S2,T} = SMatrix{S1,S2,T}(Tuple(a))
-@inline SMatrix(a::StaticMatrix{S1, S2, T}) where {S1, S2, T} = SMatrix{S1, S2, T}(Tuple(a))
-
 # Some more advanced constructor-like functions
 @inline one(::Type{SMatrix{N}}) where {N} = one(SMatrix{N,N})
 
 #####################
 ## SMatrix methods ##
 #####################
-
-@propagate_inbounds function getindex(v::SMatrix, i::Int)
-    v.data[i]
-end
 
 function check_matrix_size(x::Tuple, T = :S)
     if length(x) > 2

--- a/src/SVector.jl
+++ b/src/SVector.jl
@@ -15,19 +15,6 @@ compiler (the element type may optionally also be specified).
 """
 const SVector{S, T} = SArray{Tuple{S}, T, 1, S}
 
-@inline SVector(a::StaticVector{N,T}) where {N,T} = SVector{N,T}(a)
-@inline SVector(x::NTuple{S,Any}) where {S} = SVector{S}(x)
-@inline SVector{S}(x::NTuple{S,T}) where {S, T} = SVector{S,T}(x)
-@inline SVector{S}(x::T) where {S, T <: Tuple} = SVector{S,promote_tuple_eltype(T)}(x)
-
-@inline SVector{N, T}(gen::Base.Generator) where {N, T} =
-    sacollect(SVector{N, T}, gen)
-@inline SVector{N}(gen::Base.Generator) where {N} =
-    sacollect(SVector{N}, gen)
-
-# conversion from AbstractVector / AbstractArray (better inference than default)
-#@inline convert{S,T}(::Type{SVector{S}}, a::AbstractArray{T}) = SVector{S,T}((a...))
-
 # Some more advanced constructor-like functions
 @inline zeros(::Type{SVector{N}}) where {N} = zeros(SVector{N,Float64})
 @inline ones(::Type{SVector{N}}) where {N} = ones(SVector{N,Float64})

--- a/src/Scalar.jl
+++ b/src/Scalar.jl
@@ -6,13 +6,11 @@ Construct a statically-sized 0-dimensional array that contains a single element,
 """
 const Scalar{T} = SArray{Tuple{},T,0,1}
 
-@inline Scalar(x::Tuple{T}) where {T} = Scalar{T}(x[1])
 @inline Scalar(a::AbstractArray) = Scalar{typeof(a)}((a,))
+@inline Scalar(a::StaticArray) = Scalar{typeof(a)}((a,)) # disambiguation
+
 @inline Scalar(a::AbstractScalar) = Scalar{eltype(a)}((a[],)) # Do we want this to convert or wrap?
-@inline function convert(::Type{SA}, a::AbstractArray) where {SA <: Scalar}
-    return SA((a[],))
-end
-@inline convert(::Type{SA}, sa::SA) where {SA <: Scalar} = sa
+@inline Scalar(a::StaticScalar) = Scalar{eltype(a)}((a[],)) # disambiguation
 
 @propagate_inbounds function getindex(v::Scalar, i::Int)
     @boundscheck if i != 1

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -18,7 +18,6 @@ end
 @pure has_size1(::Type{<:StaticMatrix{M}}) where {M} = @isdefined M
 @pure has_size1(::Type{<:StaticMatrix}) = false
 _size1(::Type{<:StaticMatrix{M}}) where {M} = M
-StaticSquareMatrix{N,T} = StaticMatrix{N,N,T}
 @generated function _sqrt(::Length{L}) where {L}
     N = round(Int, sqrt(L))
     N^2 == L || throw(DimensionMismatch("Input's length must be perfect square"))
@@ -73,7 +72,7 @@ function adapt_size(::Type{SA}, x) where {SA<:StaticArray}
             M = len ÷ N
             M * N == len || throw(DimensionMismatch("Incorrect matrix sizes. $len does not divide $N elements"))
             SZ = Tuple{N, M}
-        elseif SA <: StaticSquareMatrix
+        elseif SA <: StaticMatrix{N,N} where {N}
             N = _sqrt(Length(len))
             SZ = Tuple{N, N}
         elseif x isa StaticArray

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -1,3 +1,132 @@
+# A help wrapper to distinguish `SA(x...)` and `SA((x...，))`
+struct Args{T<:Tuple}
+    args::T
+end
+Length(x::Args) = Length(length(x.args))
+const BadArgs = Args{<:Tuple{Tuple{<:Tuple}}}
+
+# Some help functions.
+@pure has_ndims(::Type{<:StaticArray{<:Tuple,<:Any,N}}) where {N} = @isdefined N
+@pure has_ndims(::Type{<:StaticArray}) = false
+if VERSION < v"1.7"
+    Base.ndims(::Type{<:StaticArray{<:Tuple,<:Any,N}}) where {N} = N
+end
+@pure has_eltype(::Type{<:StaticArray{<:Tuple,T}}) where {T} = @isdefined T
+@pure has_eltype(::Type{<:StaticArray}) = false
+@pure has_size(::Type{<:StaticArray{S}}) where {S<:Tuple} = @isdefined S
+@pure has_size(::Type{<:StaticArray}) = false
+@pure has_size1(::Type{<:StaticMatrix{M}}) where {M} = @isdefined M
+@pure has_size1(::Type{<:StaticMatrix}) = false
+_size1(::Type{<:StaticMatrix{M}}) where {M} = M
+StaticSquareMatrix{N,T} = StaticMatrix{N,N,T}
+@generated function _sqrt(::Length{L}) where {L}
+    N = round(Int, sqrt(L))
+    N^2 == L || throw(DimensionMismatch("Input's length must be perfect square"))
+    return :($N)
+end
+
+const FirstClass = Union{SArray, MArray, SHermitianCompact, SizedArray}
+
+"""
+    construct_type(::Type{<:StaticArray}, x)
+
+Returns a constructor for a statically-sized array based on `x`'s size and eltype.
+The first argument is returned by default.
+"""
+function construct_type(::Type{SA}, x) where {SA<:StaticArray}
+    x isa BadArgs || return SA
+    _no_precise_size(SA, x.args[1][1])
+end
+
+# Here we define `construct_type(SA, x)` for `SArray`, `MArray`, `SHermitianCompact`, `SizedArray`
+# Different `x` has different rules, to summarize:
+# 1. Tuple
+#    We try to fill `SA` with elements in `x` if `SA` is static-sized.
+#    If `SA <: StaticVector`, the output `Length` is derived based on `length(x)`.
+#    If `SA <: StaticMatrix{M}`, the output `Size` is derived based on `length(x)÷M`.
+#    If `SA <: StaticMatrix{M,M} where M`, the output `Size` is derived based on `sqrt(length(x))`.
+#    If `length(SA) == 1 && length（x） > 1`, then we tries to fill `SA` with `x` itself. (rewrapping)
+# 2. Args (`SA(x...)`)
+#    Similar to `Tuple`, but rewrapping is not allowed.
+# 3. StaticArray
+#    Treat `x` as `Tuple` whenever possible. If failed, then try to inherit `x`'s `Size`.
+# 4. AbstractArray
+#    `x` is used to provide eltype. Thus `SA` must be static sized.
+function construct_type(::Type{SA}, x) where {SA<:FirstClass}
+    SA′ = adapt_eltype_size(SA, x)
+    check_parameters(SA′)
+    x isa Tuple && SA === SA′ && error("Constructor for $SA is missing. Please file a bug.")
+    return SA′
+end
+
+adapt_eltype_size(SA, x) = adapt_eltype(adapt_size(SA, x), x)
+function adapt_size(::Type{SA}, x) where {SA<:StaticArray}
+    if has_size(SA) && length_match_size(SA, x)
+        SZ = Tuple{size(SA)...}
+    else
+        len = x isa Tuple ? length(x) : Int(Length(x))
+        len isa Int || _no_precise_size(SA, x)
+        if SA <: StaticVector
+            SZ = Tuple{len}
+        elseif SA <: StaticMatrix && has_size1(SA)
+            N = _size1(SA)
+            M = len ÷ N
+            M * N == len || throw(DimensionMismatch("Incorrect matrix sizes. $len does not divide $N elements"))
+            SZ = Tuple{N, M}
+        elseif SA <: StaticSquareMatrix
+            N = _sqrt(Length(len))
+            SZ = Tuple{N, N}
+        elseif x isa StaticArray
+            SZ = Tuple{size(x)...}
+        else
+            _no_precise_size(SA, x)
+        end
+    end
+    SA′ = Base.typeintersect(SA, StaticArrayNoEltype{SZ,tuple_length(SZ)})
+    SA′ === Union{} && _no_precise_size(SA, x)
+    return SA′
+end
+
+function length_match_size(::Type{SA}, x) where {SA<:StaticArray}
+    if has_ndims(SA)
+        SZ, N = size(SA), ndims(SA)
+        length(SZ) == N || throw(ArgumentError("Size $(Tuple{SZ...}) mismatches dimension $N."))
+    end
+    _length_match_size(length(SA), x) || _no_precise_size(SA, x)
+end
+_length_match_size(l::Int, x::Union{Tuple,StaticArray}) = l == 1 || l == length(x)
+_length_match_size(l::Int, x::Args) = l == length(x.args)
+_length_match_size(::Int, _) = true
+
+function adapt_eltype(::Type{SA}, x) where {SA<:StaticArray}
+    has_eltype(SA) && return SA
+    T = if need_rewrap(SA, x)
+        typeof(x)
+    elseif x isa Tuple
+        promote_tuple_eltype(x)
+    elseif x isa Args
+        promote_tuple_eltype(x.args)
+    else
+        eltype(x)
+    end
+    return Base.typeintersect(SA, AbstractArray{T})
+end
+
+need_rewrap(::Type{<:StaticArray}, x) = false
+function need_rewrap(::Type{SA}, x::Union{Tuple,StaticArray}) where {SA <: StaticArray}
+    has_size(SA) && length(SA) == 1 && length(x) > 1
+end
+
+check_parameters(::Type{<:FirstClass}) = nothing
+check_parameters(::Type{SArray{S,T,N,L}}) where {S<:Tuple,T,N,L} = check_array_parameters(S,T,Val{N},Val{L})
+check_parameters(::Type{MArray{S,T,N,L}}) where {S<:Tuple,T,N,L} = check_array_parameters(S,T,Val{N},Val{L})
+check_parameters(::Type{SHermitianCompact{N,T,L}}) where {N,T,L} = _check_hermitian_parameters(Val(N), Val(L))
+
+_no_precise_size(SA, x::Args) = _no_precise_size(SA, x.args)
+_no_precise_size(SA, x::Tuple) = throw(DimensionMismatch("No precise constructor for $SA found. Length of input was $(length(x))."))
+_no_precise_size(SA, x::StaticArray) = throw(DimensionMismatch("No precise constructor for $SA found. Size of input was $(size(x))."))
+_no_precise_size(SA, x) = throw(DimensionMismatch("No precise constructor for $SA found. Input is not static sized."))
+
 (::Type{SA})(x::Tuple{Tuple{Tuple{<:Tuple}}}) where {SA <: StaticArray} =
     throw(DimensionMismatch("No precise constructor for $SA found. Length of input was $(length(x[1][1][1]))."))
 

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -1,7 +1,7 @@
 """
     Args
 
-A help wrapper to distinguish `SA(x...)` and `SA((x...，))`
+A help wrapper to distinguish `SA(x...)` and `SA((x...,))`
 """
 struct Args{T<:Tuple}
     args::T

--- a/src/util.jl
+++ b/src/util.jl
@@ -19,6 +19,8 @@ TupleN{T,N} = NTuple{N,T}
 end
 
 # Base gives up on tuples for promote_eltype... (TODO can we improve Base?)
+_NTuple{T} = Tuple{T,Vararg{T}}
+promote_tuple_eltype(::Union{_NTuple{T}, Type{<:_NTuple{T}}}) where {T} = T 
 @generated function promote_tuple_eltype(::Union{T,Type{T}}) where T <: Tuple
     t = Union{}
     for i = 1:length(T.parameters)

--- a/src/util.jl
+++ b/src/util.jl
@@ -19,8 +19,8 @@ TupleN{T,N} = NTuple{N,T}
 end
 
 # Base gives up on tuples for promote_eltype... (TODO can we improve Base?)
-_NTuple{T} = Tuple{T,Vararg{T}}
-promote_tuple_eltype(::Union{_NTuple{T}, Type{<:_NTuple{T}}}) where {T} = T 
+_TupleOf{T} = Tuple{T,Vararg{T}}
+promote_tuple_eltype(::Union{_TupleOf{T}, Type{<:_TupleOf{T}}}) where {T} = T 
 @generated function promote_tuple_eltype(::Union{T,Type{T}}) where T <: Tuple
     t = Union{}
     for i = 1:length(T.parameters)

--- a/test/FieldMatrix.jl
+++ b/test/FieldMatrix.jl
@@ -85,6 +85,10 @@
         @test @inferred(similar_type(Tensor2x2{Float64}, Float32)) == Tensor2x2{Float32}
         @test @inferred(similar_type(Tensor2x2{Float64}, Size(3,3))) == SMatrix{3,3,Float64,9}
         @test @inferred(similar_type(Tensor2x2{Float64}, Float32, Size(4,4))) == SMatrix{4,4,Float32,16}
+
+        # eltype promotion
+        @test Tuple(@inferred(Tensor2x2(1., 2, 3, 4f0))) === (1.,2.,3.,4.)
+        @test Tuple(@inferred(Tensor2x2{Int}(1., 2, 3, 4f0))) === (1,2,3,4)
     end
 
     @testset "FieldMatrix with Tuple fields" begin

--- a/test/FieldVector.jl
+++ b/test/FieldVector.jl
@@ -43,6 +43,17 @@
 
         # Issue 342
         @test_throws DimensionMismatch("No precise constructor for Point3D found. Length of input was 4.") Point3D(1,2,3,4)
+
+        eval(quote
+            struct Point2DT{T} <: FieldVector{2, T}
+                x::T
+                y::T
+            end
+        end)
+
+        # eltype promotion
+        @test Point2DT(1., 2) === Point2DT(1.0, 2.0) && Tuple(Point2DT(1.0, 2.0)) === (1.0, 2.0)
+        @test Point2DT{Int}(1., 2) === Point2DT(1, 2) && Tuple(Point2DT(1, 2)) === (1, 2)
     end
 
     @testset "Mutable Point2D" begin
@@ -77,6 +88,12 @@
         @test @inferred(similar_type(Point2D{Float64}, Float32)) == Point2D{Float32}
         @test @inferred(similar_type(Point2D{Float64}, Size(4))) == SVector{4,Float64}
         @test @inferred(similar_type(Point2D{Float64}, Float32, Size(4))) == SVector{4,Float32}
+
+        # eltype promotion
+        @test Point2D(1f0, 2) isa Point2D{Float32}
+        @test Point2D{Int}(1f0, 2) isa Point2D{Int}
+        p = Point2D(0, 0.0)
+        @test p[1] === p[2] === 0.0
     end
 
     @testset "FieldVector with Tuple fields" begin

--- a/test/MArray.jl
+++ b/test/MArray.jl
@@ -19,6 +19,8 @@
     end
 
     @testset "Outer constructors and macro" begin
+        @test_throws Exception MArray(1,2,3,4) # unknown constructor
+
         @test MArray{Tuple{1},Int,1}((1,)).data === (1,)
         @test MArray{Tuple{1},Int}((1,)).data === (1,)
         @test MArray{Tuple{1}}((1,)).data === (1,)
@@ -218,4 +220,20 @@
         v[] = 2
         @test v[] == 2
     end
+end
+
+@testset "some special case" begin
+    @test_throws Exception MVector{1}(1, 2)
+    @test (@inferred(MVector{1}((1, 2)))::MVector{1,NTuple{2,Int}}).data === ((1,2),)
+    @test (@inferred(MVector{2}((1, 2)))::MVector{2,Int}).data === (1,2)
+    @test (@inferred(MVector(1, 2))::MVector{2,Int}).data === (1,2)
+    @test (@inferred(MVector((1, 2)))::MVector{2,Int}).data === (1,2)
+
+    @test_throws Exception MMatrix{1,1}(1, 2)
+    @test (@inferred(MMatrix{1,1}((1, 2)))::MMatrix{1,1,NTuple{2,Int}}).data === ((1,2),)
+    @test (@inferred(MMatrix{1,2}((1, 2)))::MMatrix{1,2,Int}).data === (1,2)
+    @test (@inferred(MMatrix{1}((1, 2)))::MMatrix{1,2,Int}).data === (1,2)
+    @test (@inferred(MMatrix{1}(1, 2))::MMatrix{1,2,Int}).data === (1,2)
+    @test (@inferred(MMatrix{2}((1, 2)))::MMatrix{2,1,Int}).data === (1,2)
+    @test (@inferred(MMatrix{2}(1, 2))::MMatrix{2,1,Int}).data === (1,2)
 end

--- a/test/MMatrix.jl
+++ b/test/MMatrix.jl
@@ -18,6 +18,8 @@
     end
 
     @testset "Outer constructors and macro" begin
+        @test_throws Exception MMatrix(1,2,3,4) # unknown constructor
+
         @test MMatrix{1,1,Int}((1,)).data === (1,)
         @test MMatrix{1,1}((1,)).data === (1,)
         @test MMatrix{1}((1,)).data === (1,)
@@ -53,6 +55,7 @@
         test_expand_error(:(@MMatrix [1; 2; 3; 4]...))
         test_expand_error(:(@MMatrix a))
 
+        @test ((@MMatrix [1 2.;3 4])::MMatrix{2, 2, Float64}).data === (1., 3., 2., 4.) #issue #911
         @test ((@MMatrix zeros(2,2))::MMatrix{2, 2, Float64}).data === (0.0, 0.0, 0.0, 0.0)
         @test ((@MMatrix fill(3.4, 2,2))::MMatrix{2, 2, Float64}).data === (3.4, 3.4, 3.4, 3.4)
         @test ((@MMatrix ones(2,2))::MMatrix{2, 2, Float64}).data === (1.0, 1.0, 1.0, 1.0)

--- a/test/MVector.jl
+++ b/test/MVector.jl
@@ -54,10 +54,6 @@
         if VERSION >= v"1.7.0"
             @test ((@MVector Float64[1;2;3;;;])::MVector{3}).data === (1.0, 2.0, 3.0)
             @test ((@MVector [1;2;3;;;])::MVector{3}).data === (1, 2, 3)
-            # @test ((@MVector [;])::MVector{0}).data === ()
-            @eval @test_broken ((@MVector $(Expr(:ncat, 1)))::MVector{0}).data === ()
-            # test_expand_error(:(@MVector [;;]))
-            @eval test_expand_error(:(@MVector $(Expr(:ncat, 2))))
         end
     end
 

--- a/test/SArray.jl
+++ b/test/SArray.jl
@@ -17,6 +17,8 @@
     end
 
     @testset "Outer constructors and macro" begin
+        @test_throws Exception SArray(1,2,3,4) # unknown constructor
+
         @test SArray{Tuple{1},Int,1}((1,)).data === (1,)
         @test SArray{Tuple{1},Int}((1,)).data === (1,)
         @test SArray{Tuple{1}}((1,)).data === (1,)
@@ -206,4 +208,22 @@
         @test @inferred(promote_type(SVector{2,Int}, SVector{2,Float64})) === SVector{2,Float64}
         @test @inferred(promote_type(SMatrix{2,3,Float32,6}, SMatrix{2,3,Complex{Float64},6})) === SMatrix{2,3,Complex{Float64},6}
     end
+end
+
+@testset "some special case" begin
+    @test_throws Exception (SArray{Tuple{2,M,N}} where {M,N})(SArray{Tuple{3,2,1}}(1,2,3,4,5,6))
+
+    @test_throws Exception SVector{1}(1, 2)
+    @test (@inferred(SVector{1}((1, 2)))::SVector{1,NTuple{2,Int}}).data === ((1,2),)
+    @test (@inferred(SVector{2}((1, 2)))::SVector{2,Int}).data === (1,2)
+    @test (@inferred(SVector(1, 2))::SVector{2,Int}).data === (1,2)
+    @test (@inferred(SVector((1, 2)))::SVector{2,Int}).data === (1,2)
+
+    @test_throws Exception SMatrix{1,1}(1, 2)
+    @test (@inferred(SMatrix{1,1}((1, 2)))::SMatrix{1,1,NTuple{2,Int}}).data === ((1,2),)
+    @test (@inferred(SMatrix{1,2}((1, 2)))::SMatrix{1,2,Int}).data === (1,2)
+    @test (@inferred(SMatrix{1}((1, 2)))::SMatrix{1,2,Int}).data === (1,2)
+    @test (@inferred(SMatrix{1}(1, 2))::SMatrix{1,2,Int}).data === (1,2)
+    @test (@inferred(SMatrix{2}((1, 2)))::SMatrix{2,1,Int}).data === (1,2)
+    @test (@inferred(SMatrix{2}(1, 2))::SMatrix{2,1,Int}).data === (1,2)
 end

--- a/test/SHermitianCompact.jl
+++ b/test/SHermitianCompact.jl
@@ -58,6 +58,11 @@ fill3(x) = fill(3, x)
     end
 
     @testset "Outer Constructors" begin
+        @test @inferred(SHermitianCompact(MVector(1,2,3))) === SHermitianCompact(SVector(1,2,3))
+        @test_throws Exception SHermitianCompact(1,2,3)
+        @test_throws Exception SHermitianCompact(1,2,3,4,5)
+        @test @inferred(SHermitianCompact(1,2,3,4)) === SHermitianCompact(SVector(1,2,4))
+
         for (N, L) in ((3, 6), (4, 10), (6, 21))
             for T in (Int32, Int64)
                 @eval begin

--- a/test/SMatrix.jl
+++ b/test/SMatrix.jl
@@ -17,6 +17,8 @@
     end
 
     @testset "Outer constructors and macro" begin
+        @test_throws Exception SMatrix(1,2,3,4) # unknown constructor
+
         @test SMatrix{1,1,Int}((1,)).data === (1,)
         @test SMatrix{1,1}((1,)).data === (1,)
         @test SMatrix{1}((1,)).data === (1,)

--- a/test/Scalar.jl
+++ b/test/Scalar.jl
@@ -11,4 +11,10 @@
     @test Scalar(a)[] == 2
     s = Scalar(a)
     @test convert(typeof(s), s) === s
+    @test Scalar(SVector(1,2,3))[] === SVector(1,2,3)
+    @test Scalar(MArray{Tuple{}}(1)) === Scalar(1)
+end
+
+@testset "issue #809" begin
+    @test_throws DimensionMismatch Scalar(1, 2)
 end

--- a/test/SizedArray.jl
+++ b/test/SizedArray.jl
@@ -19,6 +19,7 @@
     end
 
     @testset "Outer Constructors" begin
+        @test_throws DimensionMismatch SizedArray([3, 4])
         @test SizedArray{Tuple{2},Int,1}([3, 4]).data == [3, 4]
         @test SizedArray{Tuple{2},Int,1,1}([3, 4]).data == [3, 4]
 
@@ -252,3 +253,21 @@ struct OVector <: AbstractVector{Int} end
 Base.length(::OVector) = 10
 Base.axes(::OVector) = (0:9,)
 @test_throws ArgumentError SizedVector{10}(OVector())
+
+@testset "some special case" begin
+    @test_throws Exception SizedVector{1}(1, 2)
+    @test (@inferred(SizedVector{1}((1, 2)))::SizedVector{1,NTuple{2,Int}}) == [(1, 2)]
+    @test (@inferred(SizedVector{2}((1, 2)))::SizedVector{2,Int}) == [1, 2]
+    @test (@inferred(SizedVector(1, 2))::SizedVector{2,Int}) == [1, 2]
+    @test (@inferred(SizedVector((1, 2)))::SizedVector{2,Int}) == [1, 2]
+
+    @test_throws Exception SizedMatrix{1,1}(1, 2)
+    @test (@inferred(SizedMatrix{1,1}((1, 2)))::SizedMatrix{1,1,NTuple{2,Int}}) == fill((1, 2),1,1)
+    @test (@inferred(SizedMatrix{1,2}((1, 2)))::SizedMatrix{1,2,Int}) == reshape(1:2, 1, 2)
+    @test (@inferred(SizedMatrix{1}((1, 2)))::SizedMatrix{1,2,Int}) == reshape(1:2, 1, 2)
+    @test (@inferred(SizedMatrix{1}(1, 2))::SizedMatrix{1,2,Int}) == reshape(1:2, 1, 2)
+    @test (@inferred(SizedMatrix{2}((1, 2)))::SizedMatrix{2,1,Int}) == reshape(1:2, 2, 1)
+    @test (@inferred(SizedMatrix{2}(1, 2))::SizedMatrix{2,1,Int}) == reshape(1:2, 2, 1)
+
+
+end

--- a/test/SizedArray.jl
+++ b/test/SizedArray.jl
@@ -31,6 +31,7 @@
         @test @inferred(SizedArray{Tuple{2,2}}([1 2;3 4]))::SizedArray{Tuple{2,2},Int,2,2} == [1 2; 3 4]
         # From Array, reshaped
         @test @inferred(SizedArray{Tuple{2,2}}([1,2,3,4]))::SizedArray{Tuple{2,2},Int,2,1} == [1 3; 2 4]
+        @test SizedArray{Tuple{4}}([1 2; 3 4]) == vec([1 2; 3 4])
         @test_throws DimensionMismatch SizedArray{Tuple{1,4}}([1 2; 3 4])
         # Uninitialized
         @test @inferred(SizedArray{Tuple{2,2},Int,2,2,Matrix{Int}}(undef)) isa SizedArray{Tuple{2,2},Int,2,2,Matrix{Int}}
@@ -76,6 +77,9 @@
         # Reshaping
         @test @inferred(SizedMatrix{2,2}([1,2,3,4]))::SizedArray{Tuple{2,2},Int,2,1} == [1 3; 2 4]
         @test @inferred(SizedMatrix{2,2}((1,2,3,4)))::SizedArray{Tuple{2,2},Int,2,2} == [1 3; 2 4]
+        @test @inferred(SizedMatrix{2,2,Int}(SVector(1,2,3,4)))::SizedMatrix{2,2,Int,2} == [1 3; 2 4]
+        @test @inferred(SizedMatrix{2,2,Int,1}(SVector(1,2,3,4)))::SizedMatrix{2,2,Int,1} == [1 3; 2 4]
+        @test @inferred(SizedMatrix{2,2,Int,1,SVector{4,Int}}(SVector(1,2,3,4)))::SizedMatrix{2,2,Int,1} == [1 3; 2 4]
         # Back to Matrix
         @test Matrix(SizedMatrix{2,2}([1 2;3 4])) == [1 2; 3 4]
         @test convert(Matrix, SizedMatrix{2,2}([1 2;3 4])) == [1 2; 3 4]
@@ -268,6 +272,4 @@ Base.axes(::OVector) = (0:9,)
     @test (@inferred(SizedMatrix{1}(1, 2))::SizedMatrix{1,2,Int}) == reshape(1:2, 1, 2)
     @test (@inferred(SizedMatrix{2}((1, 2)))::SizedMatrix{2,1,Int}) == reshape(1:2, 2, 1)
     @test (@inferred(SizedMatrix{2}(1, 2))::SizedMatrix{2,1,Int}) == reshape(1:2, 2, 1)
-
-
 end

--- a/test/SizedArray.jl
+++ b/test/SizedArray.jl
@@ -30,7 +30,7 @@
         @test @inferred(SizedArray{Tuple{2,2}}([1 2;3 4]))::SizedArray{Tuple{2,2},Int,2,2} == [1 2; 3 4]
         # From Array, reshaped
         @test @inferred(SizedArray{Tuple{2,2}}([1,2,3,4]))::SizedArray{Tuple{2,2},Int,2,1} == [1 3; 2 4]
-        @test_throws DimensionMismatch SizedArray{Tuple{4}}([1 2; 3 4])
+        @test_throws DimensionMismatch SizedArray{Tuple{1,4}}([1 2; 3 4])
         # Uninitialized
         @test @inferred(SizedArray{Tuple{2,2},Int,2,2,Matrix{Int}}(undef)) isa SizedArray{Tuple{2,2},Int,2,2,Matrix{Int}}
         @test @inferred(SizedArray{Tuple{2,2},Int,2,2}(undef)) isa SizedArray{Tuple{2,2},Int,2,2,Matrix{Int}}

--- a/test/ambiguities.jl
+++ b/test/ambiguities.jl
@@ -1,7 +1,7 @@
 # Allow no new ambiguities (see #18), unless you fix some old ones first!
 
-const allowable_ambiguities = VERSION ≥ v"1.7" ? 60 :
-                              VERSION ≥ v"1.6" ? 61 : error("version must be ≥1.6")
+const allowable_ambiguities = VERSION ≥ v"1.7" ? 10 :
+                              VERSION ≥ v"1.6" ? 11 : error("version must be ≥1.6")
 
 # TODO: Revisit and fix. See
 #   https://github.com/JuliaLang/julia/pull/36962

--- a/test/convert.jl
+++ b/test/convert.jl
@@ -42,3 +42,18 @@ end
     mInt = SA[Int16(1) Int16(2) Int16(3); Int16(4) Int16(5) Int16(6)] # SMatrix{3,2,Int16}
     @test float(typeof(mInt)) === SMatrix{2, 3, float(Int16), 6}
 end
+
+@testset "convert with missing/wrong size" begin
+    @test convert(SVector, MVector(1,2,3)) === SVector(1,2,3)
+    @test convert(SMatrix{3}, MVector(1,2,3)) === SMatrix{3,1}(1,2,3)
+    @test_throws Exception convert(SVector{1}, MVector(1,2,3)) 
+end
+
+struct BugStaticVector <: StaticVector{2,Int} end
+@testset "Unknow StaticArray" begin
+    # Make sure the new `construct_type` cause no regression.
+    @test_throws DimensionMismatch BugStaticVector(1,2,3)
+    f(x) = StaticArrays.construct_type(BugStaticVector, StaticArrays.Args(x))
+    @test_inlined f((1,2,3,4))
+end
+

--- a/test/convert.jl
+++ b/test/convert.jl
@@ -57,3 +57,12 @@ struct BugStaticVector <: StaticVector{2,Int} end
     @test_inlined f((1,2,3,4))
 end
 
+using OffsetArrays
+@testset "constructor/convert from OffsetArray" begin
+    a = OffsetArray([-1 1;0 2], -1, -1)
+    b = OffsetArray([-1,0,1,2], -1)
+    c = OffsetArray(-1:2, -1)
+    d = Base.IdentityUnitRange(-1:2)
+    @test SVector{4}(a) === SVector{4}(b) === SVector{4}(c) === SVector{4}(d) == [-1,0,1,2]
+    @test SMatrix{2,2}(a) === SMatrix{2,2}(b) === SMatrix{2,2}(c) === SMatrix{2,2}(d) == [-1 1;0 2]
+end

--- a/test/empty_array_syntax.jl
+++ b/test/empty_array_syntax.jl
@@ -1,7 +1,7 @@
 @testset "[;;;;;]" begin
-    @test_broken ((@SVector [;])::SVector{0}).data === ()
+    @test ((@SVector [;])::SVector{0}).data === ()
     test_expand_error(:(@SVector [;;]))
-    @test_broken ((@MVector [;])::MVector{0}).data === ()
+    @test ((@MVector [;])::MVector{0}).data === ()
     test_expand_error(:(@MVector [;;]))
 
     @test ((@SMatrix [;;])::SMatrix{0,0}).data === ()


### PR DESCRIPTION
Seperated from #1009.

This PR aims to unify the implement of `StaticArray`'s constructor with a new method `construct_type`.
It returns a `concrete` constructor based on `src <: Union{Tupe, StaticArray, AbstractArray}` and the target type `SA` (if possible).
e.g.
```julia
julia> StaticArrays.construct_type(SMatrix{2},(1,2,3,4))
SMatrix{2, 2, Int64} (alias for SArray{Tuple{2, 2}, Int64, 2})

julia> StaticArrays.construct_type(SMatrix{2},(1.,2,3,4))
SMatrix{2, 2, Float64} (alias for SArray{Tuple{2, 2}, Float64, 2})

julia> StaticArrays.construct_type(SMatrix,(1.,2,3,4)) # the output's size is not static.
ERROR: DimensionMismatch: No precise constructor for SMatrix found. Length of input was 4.
```
Thus, we only need to mannually define the constructor with precise `size`, `eltype` and `ndims`.
Unneeded dispatch has been removed.
Edit1: Since 3rd party `StaticArray` might prefer previous design, the default `construct_type` returns the input `SA` directly to keep compatibility.
Edit2:  `construct_type` for `FieldArray` has been implemented. Now `FieldArray`'s default constructor support eltype promotion.
```julia
julia> struct Point2D{T} <: FieldVector{2,T}
           x::T
           y::T
       end

julia> Point2D(1,1.0)
2-element Point2D{Float64} with indices SOneTo(2):
 1.0
 1.0
```

This PR also restrict the input wrapping within constructor.
If multiple arguments are provided, all of them should be treated as the result's elements, and re-wrapping is not allowed anymore.
For example
```julia
julia> Scalar(1, 2)
ERROR: DimensionMismatch: No precise constructor for Scalar found. Length of input was 2.
julia> Scalar((1, 2))
Scalar{Tuple{Int64, Int64}}(((1, 2),))
julia> SVector{1}(1, 2)
ERROR: DimensionMismatch: No precise constructor for SVector{1} found. Length of input was 2.
julia> SVector{1}((1, 2))
1-element SVector{1, Tuple{Int64, Int64}} with indices SOneTo(1):
 (1, 2)
```
Close #809. 
Close #911. (fix constructor missing)