### PR TITLE
Define Base.show for SArray and MArray.

### DIFF
--- a/src/MArray.jl
+++ b/src/MArray.jl
@@ -36,6 +36,12 @@ mutable struct MArray{S <: Tuple, T, N, L} <: StaticArray{S, T, N}
     end
 end
 
+function Base.show(io::IO, a::MArray{S,T}) where {S,T}
+    print(io, 'M')
+    _show_shape_size_type(io, size(a), T)
+    print(io, Tuple(a))
+end
+
 @generated function (::Type{MArray{S,T,N}})(x::Tuple) where {S,T,N}
     return quote
         $(Expr(:meta, :inline))

--- a/src/SArray.jl
+++ b/src/SArray.jl
@@ -29,6 +29,12 @@ struct SArray{S <: Tuple, T, N, L} <: StaticArray{S, T, N}
     end
 end
 
+function Base.show(io::IO, a::SArray{S,T}) where {S,T}
+    print(io, 'S')
+    _show_shape_size_type(io, size(a), T)
+    print(io, Tuple(a))
+end
+
 @generated function (::Type{SArray{S, T, N}})(x::Tuple) where {S <: Tuple, T, N}
     return quote
         @_inline_meta

--- a/src/util.jl
+++ b/src/util.jl
@@ -112,3 +112,27 @@ Base.@propagate_inbounds function invperm(p::StaticVector)
      similar_type(p)(ip)
 end
 
+"""
+    _show_shape_size_type(io, S)
+
+Utility function for printing SArray and MArray types. Caller should print the `'S'` or the
+`'M'`, then this function prints the shape name, an opening curly brace, and the size
+parameters, the type parameter, and the closing curly brace in the format that can be used
+to construct the type.
+
+NOTE: does not special-case 0-dimensional arrays ([`Scalar`](@ref)).
+"""
+function _show_shape_size_type(io::IO, S::Tuple, ::Type{T}) where T
+    _show_shape_size(io, S)
+    print(io, ",", T, "}")
+end
+
+_show_shape_size(io::IO, S::NTuple{1}) = print(io, "Vector{$(S[1])")
+
+_show_shape_size(io::IO, S::NTuple{2}) = print(io, "Matrix{$(S[1]),$(S[2])")
+
+function _show_shape_size(io::IO, S::Tuple)
+    print(io, "Array{Tuple{")
+    join(io, S, ',')
+    print(io, "}")
+end

--- a/test/MArray.jl
+++ b/test/MArray.jl
@@ -218,4 +218,15 @@
         v[] = 2
         @test v[] == 2
     end
+
+    @testset "repr and show roundtrip" begin
+        z = MArray{Tuple{}}(1.0)
+        v = MVector{8}(float.(1:8))
+        m = MMatrix{2,4}(v)
+        a = MArray{Tuple{2,2,2}}(v)
+        for x in (z, v, m, a)
+            z = eval(Meta.parse(repr(x)))
+            @test z isa MArray && x == z && size(x) == size(z) && eltype(x) == eltype(z)
+        end
+    end
 end

--- a/test/SArray.jl
+++ b/test/SArray.jl
@@ -206,4 +206,14 @@
         @test @inferred(promote_type(SVector{2,Int}, SVector{2,Float64})) === SVector{2,Float64}
         @test @inferred(promote_type(SMatrix{2,3,Float32,6}, SMatrix{2,3,Complex{Float64},6})) === SMatrix{2,3,Complex{Float64},6}
     end
+
+    @testset "repr and show roundtrip" begin
+        z = SArray{Tuple{}}(1.0)
+        v = SVector{8}(float.(1:8))
+        m = SMatrix{2,4}(v)
+        a = SArray{Tuple{2,2,2}}(v)
+        for x in (z, v, m, a)
+            @test eval(Meta.parse(repr(x))) ≡ x
+        end
+    end
 end


### PR DESCRIPTION
This allows `SArray` and `MArray` to be printed (`show`, `repr`, etc) and read back into an object of the same type.

Fixes #692.