### PR TITLE
Specialize reduced_indices for Tuple{Vararg{SOneTo}}

### DIFF
--- a/src/SOneTo.jl
+++ b/src/SOneTo.jl
@@ -74,3 +74,7 @@ end
 
 Base.promote_rule(a::Type{Base.OneTo{T}}, ::Type{SOneTo{n}}) where {T,n} =
     Base.OneTo{promote_type(T, Int)}
+
+function Base.reduced_indices(inds::Tuple{SOneTo,Vararg{SOneTo}}, d::Int)
+    Base.reduced_indices(map(Base.OneTo, inds), d)
+end

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -234,6 +234,15 @@ using StaticArrays, Test, LinearAlgebra
             @test (@inferred f(v, i)) == length(v[i])
         end
     end
+
+    @testset "reduced_indices" begin
+        s = SArray{Tuple{2,2,2},Int,3,8}((1,2,3,4,5,6,7,8))
+        a = Array(s)
+        for i in 1:ndims(s)
+            rs = @inferred Base.reduced_indices(axes(s), i)
+            @test rs == Base.reduced_indices(axes(a), i)
+        end
+    end
 end
 
 @testset "permutedims" begin


### PR DESCRIPTION
Based on https://github.com/JuliaArrays/StaticArrays.jl/issues/881#issuecomment-812822965, this partially addresses the issue of reduction on wrappers of `StaticArray`s.

Currently,
```julia
julia> s = SArray{Tuple{2,2,2},Int,3,8}((1,2,3,4,5,6,7,8))
2×2×2 SArray{Tuple{2, 2, 2}, Int64, 3, 8} with indices SOneTo(2)×SOneTo(2)×SOneTo(2):
[:, :, 1] =
 1  3
 2  4

[:, :, 2] =
 5  7
 6  8

julia> ss = StructArray{Complex{Int}}((s,s))
2×2×2 StructArray(::SArray{Tuple{2, 2, 2}, Int64, 3, 8}, ::SArray{Tuple{2, 2, 2}, Int64, 3, 8}) with eltype Complex{Int64} with indices SOneTo(2)×SOneTo(2)×SOneTo(2):
[:, :, 1] =
 1+1im  3+3im
 2+2im  4+4im

[:, :, 2] =
 5+5im  7+7im
 6+6im  8+8im

julia> sum(ss, dims=1)
ERROR: ArgumentError: No method is implemented for reducing index range of type SOneTo{2}. Please implement
reduced_index for this index type or report this as an issue.
```

After this PR:
```julia
julia> sum(ss, dims=1)
1×2×2 Array{Complex{Int64}, 3}:
[:, :, 1] =
 3+3im  7+7im

[:, :, 2] =
 11+11im  15+15im

julia> sum(ss, dims=1) == sum(Array(ss), dims=1)
true
```

I'm unsure if there's a way to retain the size information in a type-stable manner, but I guess returning an `Array` is better than throwing an error.