### PR TITLE
Fix Base.elsize(<:Type{<:MArray})

### DIFF
--- a/src/MArray.jl
+++ b/src/MArray.jl
@@ -115,4 +115,4 @@ function Base.view(
     return SizedArray{new_size}(view_from_invoke)
 end
 
-Base.elsize(::Type{<:MArray{S,T}}) where {S,T} = sizeof(T)
+Base.elsize(::Type{<:MArray{<:Any, T}}) where T = Base.elsize(Vector{T})

--- a/test/MArray.jl
+++ b/test/MArray.jl
@@ -220,6 +220,20 @@
         v[] = 2
         @test v[] == 2
     end
+
+    @testset "non-power-of-2 element size" begin
+        primitive type Test24 24 end
+        Test24(n) = Base.trunc_int(Test24, n)
+        a = Test24.(1:4)
+        m = MVector{4}(a)
+        @test m == m[:] == m[1:4] == a
+        @test getindex.(Ref(m), 1:4) == a
+        @test GC.@preserve m unsafe_load.(pointer(m), 1:4) == a
+        @test GC.@preserve m unsafe_load.(pointer.(Ref(m), 1:4)) == a
+        b = Test24.(5:8)
+        setindex!.(Ref(m), b, 1:4)
+        @test m == b
+    end
 end
 
 @testset "some special case" begin


### PR DESCRIPTION
Currently, `Base.elsize(<:Type{<:MArray})` is not correct for eltypes for which `sizeof` is not a multiple of `Base.datatype_alignment`. This leads to `pointer(::MArray, ::Int)` giving incorrect addresses. For example:
```julia
julia> using StaticArrays

julia> primitive type Test24 24 end

julia> Test24(n) = Base.trunc_int(Test24, n);

julia> a = Test24.(1:4);

julia> m = MVector{4}(a)
4-element MVector{4, Test24} with indices SOneTo(4):
 Test24(0x000001)
 Test24(0x000002)
 Test24(0x000003)
 Test24(0x000004)

julia> GC.@preserve m unsafe_load.(pointer.(Ref(m), 1:4))
4-element Vector{Test24}:
 Test24(0x000001)
 Test24(0x0002be)
 Test24(0x030000)
 Test24(0x000000)
```

This PR fixes this by calling `Base.elsize` on the corresponding `Vector` type. (This issue was previously present in Base https://github.com/JuliaLang/julia/pull/33283.)