### PR TITLE
Fix copy of a complicated `SizedArray`

### DIFF
--- a/src/abstractarray.jl
+++ b/src/abstractarray.jl
@@ -212,7 +212,7 @@ Base.rdims(out::Tuple{Any}, inds::Tuple{SOneTo, Vararg{SOneTo}}) = (SOneTo(Base.
 @inline vec(a::StaticArray) = reshape(a, Size(prod(Size(typeof(a)))))
 
 @inline copy(a::StaticArray) = typeof(a)(Tuple(a))
-@inline copy(a::SizedArray) = typeof(a)(copy(a.data))
+@inline copy(a::SizedArray{S,T}) where {S,T} = SizedArray{S,T}(copy(a.data))
 
 @inline reverse(v::StaticArray) = typeof(v)(_reverse(v))
 

--- a/test/SizedArray.jl
+++ b/test/SizedArray.jl
@@ -125,6 +125,9 @@
         sa2 = SizedArray{Tuple{2, 2}, Int}([1, 2, 3, 4])
         @test (@inferred vec(sa2)) isa SizedVector{4, Int}
         @test vec(sa2).data === vec(sa2.data)
+
+        M = @MMatrix [1 2; 3 4]
+        @test copy(vec(M)) isa SizedVector{4, Int}
     end
 
     @testset "aliasing" begin


### PR DESCRIPTION
I've noticed that the following code didn't work:
```julia
M = @MMatrix [1 2; 3 4]
copy(vec(M))
```
and this change fixes it.