### PR TITLE
Rewrite 4x4 det as product of 2x2 minors for improved performance

### DIFF
--- a/src/det.jl
+++ b/src/det.jl
@@ -18,21 +18,17 @@ end
     return bilinear_vecdot(x0, cross(x1, x2))
 end
 
-@inline function _det(::Size{(4,4)}, A::StaticMatrix)
-    @inbounds return (
-        A[13] * A[10]  * A[7]  * A[4]  - A[9] * A[14] * A[7]  * A[4]   -
-        A[13] * A[6]   * A[11] * A[4]  + A[5] * A[14] * A[11] * A[4]   +
-        A[9]  * A[6]   * A[15] * A[4]  - A[5] * A[10] * A[15] * A[4]   -
-        A[13] * A[10]  * A[3]  * A[8]  + A[9] * A[14] * A[3]  * A[8]   +
-        A[13] * A[2]   * A[11] * A[8]  - A[1] * A[14] * A[11] * A[8]   -
-        A[9]  * A[2]   * A[15] * A[8]  + A[1] * A[10] * A[15] * A[8]   +
-        A[13] * A[6]   * A[3]  * A[12] - A[5] * A[14] * A[3]  * A[12]  -
-        A[13] * A[2]   * A[7]  * A[12] + A[1] * A[14] * A[7]  * A[12]  +
-        A[5]  * A[2]   * A[15] * A[12] - A[1] * A[6]  * A[15] * A[12]  -
-        A[9]  * A[6]   * A[3]  * A[16] + A[5] * A[10] * A[3]  * A[16]  +
-        A[9]  * A[2]   * A[7]  * A[16] - A[1] * A[10] * A[7]  * A[16]  -
-        A[5]  * A[2]   * A[11] * A[16] + A[1] * A[6]  * A[11] * A[16])
+@inline function _prod2x2minors(A, a,b,c,d)
+ #   @assert all(Base.isbetween.(1, (a,b,c,d),4))
+     @inbounds return (A[a]*A[b+4] - A[b]*A[a+4])*(A[c+8]*A[d+12] - A[c+12]*A[d+8])
+ #    @inbounds return muladd(A[a], A[b+4], -A[b]*A[a+4])*muladd(A[c+8],A[d+12], -A[c+12]*A[d+8])
 end
+
+@inline function _det(::Size{(4,4)}, A::StaticMatrix)
+    @inbounds return (_prod2x2minors(A,1,2,3,4) - _prod2x2minors(A,1,3,2,4) + _prod2x2minors(A,1,4,2,3) 
+                     +_prod2x2minors(A,2,3,1,4) - _prod2x2minors(A,2,4,1,3) + _prod2x2minors(A,3,4,1,2))
+end
+
 
 @inline function _parity(p)    # inefficient compared to computing cycle lengths, but non-allocating
     s = 0

--- a/src/det.jl
+++ b/src/det.jl
@@ -19,9 +19,7 @@ end
 end
 
 @inline function _prod2x2minors(A, a,b,c,d)
- #   @assert all(Base.isbetween.(1, (a,b,c,d),4))
      @inbounds return (A[a]*A[b+4] - A[b]*A[a+4])*(A[c+8]*A[d+12] - A[c+12]*A[d+8])
- #    @inbounds return muladd(A[a], A[b+4], -A[b]*A[a+4])*muladd(A[c+8],A[d+12], -A[c+12]*A[d+8])
 end
 
 @inline function _det(::Size{(4,4)}, A::StaticMatrix)


### PR DESCRIPTION
The SMatrix{4,4} `det` code (added in #260) performs 72 multiplications and 23 addition/subtractions.  Rewriting as products of 2x2 minors reduces to 30 multiplications and 17 additions/subtractions.  Benchmarking (below) shows performance improvement from 11ns to <5ns, commensurate with the decrease in operations.

I see that in pull request #597 @ryanelandt (with the approval of @andyferris) implicitly rewrote `inv` using 2x2 minors.  Thus, my pull request just extends the performance improvement to `det`.  

-------
```julia
julia> using BenchmarkTools, Random, LinearAlgebra                                                        
                                                                                                          
julia> using StaticArrays                                                                                 
[ Info: Precompiling StaticArrays [90137ffa-7385-5640-81b9-e52037218182]                                  
                                                                                                          
julia> function bmold()                                                                                   
       N=4                                                                                                
       Random.seed!(1234)                                                                                 
       SA = @SMatrix rand(N,N)                                                                            
       A = Array(SA)                                                                                      
       @assert(det(SA) ≈ det(A))                                                                          
       @benchmark StaticArrays._olddet($(Size(SA)), $(SA))                                                
       end                                                                                                
bmold (generic function with 1 method)                                                                    
                                                                                                          
julia> function bm()                                                                                      
       N=4                                                                                                
       Random.seed!(1234)                                                                                 
       SA = @SMatrix rand(N,N)                                                                            
       A = Array(SA)                                                                                      
       @assert(det(SA) ≈ det(A))                                                                          
       @benchmark StaticArrays._det($(Size(SA)), $(SA))                                                   
       end                                                                                                
bm (generic function with 1 method)                                                                       
```                                                                                                    
                                                                                                       
`julia> bmold()`                                                                                           
BenchmarkTools.Trial: 10000 samples with 999 evaluations.                                                 
 Range (min … max):  10.975 ns … 47.887 ns  ┊ GC (min … max): 0.00% … 0.00%                               
 Time  (median):     11.259 ns              ┊ GC (median):    0.00%                                       
 Time  (mean ± σ):   11.398 ns ±  1.592 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%                               
 Memory estimate: 0 bytes, allocs estimate: 0.                                                            
                                                                                                          
`julia> bm()`                                                                                          
BenchmarkTools.Trial: 10000 samples with 1000 evaluations.                                                
 Range (min … max):  4.582 ns … 34.553 ns  ┊ GC (min … max): 0.00% … 0.00%                                
 Time  (median):     4.707 ns              ┊ GC (median):    0.00%                                        
 Time  (mean ± σ):   4.770 ns ±  0.865 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%                                
 Memory estimate: 0 bytes, allocs estimate: 0.                                                            
                                                                                                          