### PR TITLE
Fix `adjoint` and `transpose` for 0×0 matrix

### DIFF
--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -69,15 +69,12 @@ end
 @inline transpose(a::Adjoint{<:Any,<:Union{StaticVector,StaticMatrix}}) = conj(a.parent)
 @inline transpose(a::Adjoint{<:Real,<:Union{StaticVector,StaticMatrix}}) = a.parent
 
-@generated function _transpose(::Size{S}, m::StaticMatrix) where {S}
-    Snew = (S[2], S[1])
-
-    exprs = [:(transpose(m[$(LinearIndices(S)[j1, j2])])) for j2 = 1:S[2], j1 = 1:S[1]]
-
+@generated function _transpose(::Size{S}, m::StaticMatrix{n1, n2, T}) where {n1, n2, S, T}
+    exprs = [:(transpose(m[$(LinearIndices(S)[j1, j2])])) for j2 in 1:n2, j1 in 1:n1]
     return quote
         $(Expr(:meta, :inline))
         elements = tuple($(exprs...))
-        @inbounds return similar_type($m, eltype(elements), Size($Snew))(elements)
+        @inbounds return similar_type($m, Base.promote_op(transpose, T), Size($(n2,n1)))(elements)
     end
 end
 
@@ -86,15 +83,12 @@ end
 @inline adjoint(a::Transpose{<:Real,<:Union{StaticVector,StaticMatrix}}) = a.parent
 @inline adjoint(a::Adjoint{<:Any,<:Union{StaticVector,StaticMatrix}}) = a.parent
 
-@generated function _adjoint(::Size{S}, m::StaticMatrix) where {S}
-    Snew = (S[2], S[1])
-
-    exprs = [:(adjoint(m[$(LinearIndices(S)[j1, j2])])) for j2 = 1:S[2], j1 = 1:S[1]]
-
+@generated function _adjoint(::Size{S}, m::StaticMatrix{n1, n2, T}) where {n1, n2, S, T}
+    exprs = [:(adjoint(m[$(LinearIndices(S)[j1, j2])])) for j2 in 1:n2, j1 in 1:n1]
     return quote
         $(Expr(:meta, :inline))
         elements = tuple($(exprs...))
-        @inbounds return similar_type($m, eltype(elements), Size($Snew))(elements)
+        @inbounds return similar_type($m, Base.promote_op(adjoint, T), Size($(n2,n1)))(elements)
     end
 end
 

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -225,6 +225,14 @@ StaticArrays.similar_type(::Union{RotMat2,Type{RotMat2}}) = SMatrix{2,2,Float64,
         # Recursive adjoint/transpose correctly handles eltype (#708)
         @test (@inferred(adjoint(SMatrix{2,2}(fill([1,2], 2,2)))))::SMatrix == SMatrix{2,2}(fill(adjoint([1,2]), 2,2))
         @test (@inferred(transpose(SMatrix{2,2}(fill([1,2], 2,2)))))::SMatrix == SMatrix{2,2}(fill(transpose([1,2]), 2,2))
+
+        # 0×0 matrix
+        for T in (SMatrix{0,0,Float64}, MMatrix{0,0,Float64}, SizedMatrix{0,0,Float64})
+            m = T()
+            @test adjoint(m)::T == transpose(m)::T == m
+        end
+        @test adjoint(SMatrix{0,0,Vector{Int}}()) isa SMatrix{0,0,Adjoint{Int,Vector{Int}}}
+        @test transpose(SMatrix{0,0,Vector{Int}}()) isa SMatrix{0,0,Transpose{Int,Vector{Int}}}
     end
 
     @testset "normalization" begin


### PR DESCRIPTION
This PR fixes https://github.com/JuliaArrays/StaticArrays.jl/issues/1066.

**Before this PR**
```julia
julia> using StaticArrays

julia> n = SMatrix{0,0,Float64}()
0×0 SMatrix{0, 0, Float64, 0} with indices SOneTo(0)×SOneTo(0)

julia> adjoint(n)
0×0 SMatrix{0, 0, Union{}, 0} with indices SOneTo(0)×SOneTo(0)

julia> transpose(n)
0×0 SMatrix{0, 0, Union{}, 0} with indices SOneTo(0)×SOneTo(0)

julia> n/n
ERROR: MethodError: one(::Type{Union{}}) is ambiguous. Candidates:
  one(::Union{Type{T}, T}) where T<:AbstractString in Base at strings/basic.jl:262
  one(::Union{Type{P}, P}) where P<:Dates.Period in Dates at /home/hyrodium/julia/julia-1.7.3/share/julia/stdlib/v1.7/Dates/src/periods.jl:54
  one(::Type{SM}) where SM<:(Union{LinearAlgebra.Adjoint{T, <:Union{StaticArray{Tuple{var"#s2"}, T, 1} where var"#s2", StaticArray{Tuple{var"#s3", var"#s4"}, T, 2} where {var"#s3", var"#s4"}}}, LinearAlgebra.Diagonal{T, <:StaticArray{Tuple{var"#s13"}, T, 1} where var"#s13"}, LinearAlgebra.Hermitian{T, <:StaticArray{Tuple{var"#s10", var"#s11"}, T, 2} where {var"#s10", var"#s11"}}, LinearAlgebra.LowerTriangular{T, <:StaticArray{Tuple{var"#s18", var"#s19"}, T, 2} where {var"#s18", var"#s19"}}, LinearAlgebra.Symmetric{T, <:StaticArray{Tuple{var"#s7", var"#s8"}, T, 2} where {var"#s7", var"#s8"}}, LinearAlgebra.Transpose{T, <:Union{StaticArray{Tuple{var"#s2"}, T, 1} where var"#s2", StaticArray{Tuple{var"#s3", var"#s4"}, T, 2} where {var"#s3", var"#s4"}}}, LinearAlgebra.UnitLowerTriangular{T, <:StaticArray{Tuple{var"#s24", var"#s25"}, T, 2} where {var"#s24", var"#s25"}}, LinearAlgebra.UnitUpperTriangular{T, <:StaticArray{Tuple{var"#s21", var"#s22"}, T, 2} where {var"#s21", var"#s22"}}, LinearAlgebra.UpperTriangular{T, <:StaticArray{Tuple{var"#s15", var"#s16"}, T, 2} where {var"#s15", var"#s16"}}, StaticArray{Tuple{var"#s1", var"#s3"}, T, 2} where {var"#s1", var"#s3"}} where T) in StaticArrays at /home/hyrodium/.julia/dev/StaticArrays/src/linalg.jl:108
  one(::Type{<:AbstractIrrational}) in Base at irrationals.jl:154
  one(::Type{T}) where T<:Number in Base at number.jl:334
Possible fix, define
  one(::Type{Union{}})
Stacktrace:
  [1] __lu(A::SMatrix{0, 0, Union{}, 0}, #unused#::Val{true})
    @ StaticArrays ~/.julia/dev/StaticArrays/src/lu.jl:112
  [2] macro expansion
    @ ~/.julia/dev/StaticArrays/src/lu.jl:85 [inlined]
  [3] _lu(A::SMatrix{0, 0, Union{}, 0}, pivot::Val{true}, check::Bool)
    @ StaticArrays ~/.julia/dev/StaticArrays/src/lu.jl:77
  [4] lu(A::SMatrix{0, 0, Union{}, 0}, pivot::Val{true}; check::Bool)
    @ StaticArrays ~/.julia/dev/StaticArrays/src/lu.jl:50
  [5] lu(A::SMatrix{0, 0, Union{}, 0}; check::Bool)
    @ StaticArrays ~/.julia/dev/StaticArrays/src/lu.jl:54
  [6] lu(A::SMatrix{0, 0, Union{}, 0})
    @ StaticArrays ~/.julia/dev/StaticArrays/src/lu.jl:54
  [7] macro expansion
    @ ~/.julia/dev/StaticArrays/src/solve.jl:55 [inlined]
  [8] _solve
    @ ~/.julia/dev/StaticArrays/src/solve.jl:45 [inlined]
  [9] \
    @ ~/.julia/dev/StaticArrays/src/solve.jl:1 [inlined]
 [10] /(A::SMatrix{0, 0, Float64, 0}, B::SMatrix{0, 0, Float64, 0})
    @ LinearAlgebra ~/julia/julia-1.7.3/share/julia/stdlib/v1.7/LinearAlgebra/src/generic.jl:1152
 [11] top-level scope
    @ REPL[5]:1

julia> n\n
0×0 SMatrix{0, 0, Float64, 0} with indices SOneTo(0)×SOneTo(0)
```

**After this PR**
```julia
julia> using StaticArrays

julia> n = SMatrix{0,0,Float64}()
0×0 SMatrix{0, 0, Float64, 0} with indices SOneTo(0)×SOneTo(0)

julia> adjoint(n)
0×0 SMatrix{0, 0, Float64, 0} with indices SOneTo(0)×SOneTo(0)

julia> transpose(n)
0×0 SMatrix{0, 0, Float64, 0} with indices SOneTo(0)×SOneTo(0)

julia> n/n
0×0 SMatrix{0, 0, Float64, 0} with indices SOneTo(0)×SOneTo(0)

julia> n\n
0×0 SMatrix{0, 0, Float64, 0} with indices SOneTo(0)×SOneTo(0)
```