### PR TITLE
Adjoint and Projections

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,14 +3,15 @@ uuid = "90137ffa-7385-5640-81b9-e52037218182"
 version = "1.5.2"
 
 [deps]
+ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-julia = "1.6"
 StaticArraysCore = "1"
+julia = "1.6"
 
 [extras]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/Project.toml
+++ b/Project.toml
@@ -18,6 +18,8 @@ BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 
 [targets]
-test = ["InteractiveUtils", "Test", "BenchmarkTools", "OffsetArrays"]
+test = ["InteractiveUtils", "Test", "BenchmarkTools", "OffsetArrays", "Zygote", "ForwardDiff"]

--- a/src/StaticArrays.jl
+++ b/src/StaticArrays.jl
@@ -130,6 +130,7 @@ include("io.jl")
 include("pinv.jl")
 
 include("precompile.jl")
+include("chainrule.jl")
 _precompile_()
 
 end # module

--- a/src/StaticArrays.jl
+++ b/src/StaticArrays.jl
@@ -12,6 +12,7 @@ import Statistics: mean
 
 using Random
 import Random: rand, randn, randexp, rand!, randn!, randexp!
+using ChainRulesCore
 using Core.Compiler: return_type
 import Base: sqrt, exp, log, float, real
 using LinearAlgebra

--- a/src/chainrule.jl
+++ b/src/chainrule.jl
@@ -16,12 +16,6 @@ end
 
 ### Adjoint for SArray constructor
 
-ChainRulesCore.@non_differentiable (::Type{T} where {T<:SArray})(::UndefInitializer, args...)
-
-function ChainRulesCore.frule((_, ẋ), ::Type{T}, x::Tuple) where {T<:SArray}
-    return T(x), T(ẋ)
-end
-
 function ChainRulesCore.rrule(::Type{T}, x::Tuple) where {T<:SArray}
     project_x = ProjectTo(x)
     Array_pullback(ȳ) = (NoTangent(), project_x(ȳ))

--- a/src/chainrule.jl
+++ b/src/chainrule.jl
@@ -1,14 +1,10 @@
 ### Projecting a tuple to SMatrix leads to ChainRulesCore._projection_mismatch by default, so overloaded here
 function (project::ChainRulesCore.ProjectTo{<:Tangent{<:Tuple}})(dx::SArray)
-    # for d in 1:ndims(dx)
-    #     if size(dx, d) != get(length(project.elements), d, 1)
-    #         throw(ChainRulesCore._projection_mismatch(axes(project.elements), size(dx)))
-    #     end
-    # end
     dy = reshape(dx, axes(project.elements))  # allows for dx::OffsetArray
     dz = ntuple(i -> project.elements[i](dy[i]), length(project.elements))
     return ChainRulesCore.project_type(project)(dz...)
 end
+
 ### Project SArray to SArray
 function ChainRulesCore.ProjectTo(x::SArray{S,T}) where {S, T}
     return ChainRulesCore.ProjectTo{SArray}(; element=ChainRulesCore._eltype_projectto(T), axes=S)

--- a/src/chainrule.jl
+++ b/src/chainrule.jl
@@ -1,0 +1,39 @@
+#####
+##### constructors
+#####
+
+ChainRulesCore.@non_differentiable (::Type{T} where {T<:Union{SArray, SizedArray}})(::UndefInitializer, args...)
+
+function ChainRulesCore.frule((_, ẋ), ::Type{T}, x::Tuple) where {T<:Union{SArray, SizedArray}}
+    return T(x), T(ẋ)
+end
+
+function ChainRulesCore.rrule(::Type{T}, x::Tuple) where {T<:Union{SArray, SizedArray}}
+    project_x = ProjectTo(x)
+    Array_pullback(ȳ) = (NoTangent(), project_x(ȳ))
+    return T(x), Array_pullback
+end
+
+function (project::ChainRulesCore.ProjectTo{AbstractArray})(dx::AbstractArray{S,M}) where {S,M}
+    # First deal with shape. The rule is that we reshape to add or remove trivial dimensions
+    # like dx = ones(4,1), where x = ones(4), but throw an error on dx = ones(1,4) etc.
+    dy = if axes(dx) === project.axes
+        dx
+    else
+        for d in 1:max(M, length(project.axes))
+            if size(dx, d) != length(get(project.axes, d, 1))
+                throw(_projection_mismatch(project.axes, size(dx)))
+            end
+        end
+        reshape(dx, project.axes)
+    end
+    # Then deal with the elements. One projector if AbstractArray{<:Number},
+    # or one per element for arrays of anything else, including arrays of arrays:
+    dz = if hasproperty(project, :element)
+        T = project_type(project.element)
+        S <: T ? dy : map(project.element, dy)
+    else
+        map((f, y) -> f(y), project.elements, dy)
+    end
+    return dz
+end


### PR DESCRIPTION
Solves a few AD related issues:

- Adjoint of SArray constructor
- SArray projected to SizedArray in pullback due to [this](https://github.com/JuliaDiff/ChainRulesCore.jl/blob/00e17d236e3c09063c5b27a52c550c841d591fd5/src/projection.jl#L230) `reshape` during pullback
- SMatrix tuple dimensions don't match the matrix dimensions when the above is fixed in [this](https://github.com/JuliaDiff/ChainRulesCore.jl/blob/00e17d236e3c09063c5b27a52c550c841d591fd5/src/projection.jl#L368) projection

Example

```julia
using Zygote
using StaticArrays

u0 = @SVector [1.0f0, 1.0f0]
p = @SVector [1.5f0, 1.0f0, 3.0f0, 1.0f0]

function lotka(u, p)
    du1 = p[1]*u[1] - p[2]*u[1]*u[2]
    du2 = -p[3]*u[2] + p[4]*u[1]*u[2]
    @SVector [du1, du2]
    # @SMatrix [du1 du2 du1; du2 du1 du1]
end

function loss(p)
    u = lotka(u0, p)
    sum(1 .- u)
end

loss(p)

grad = Zygote.gradient(loss, p)
```
```
ERROR: Need an adjoint for constructor SVector{2, Float32}. Gradient is of type SizedVector{2, Float32, Vector{Float32}}
Stacktrace:
  [1] error(s::String)
    @ Base .\error.jl:33
  [2] (::Zygote.Jnew{SVector{2, Float32}, Nothing, false})(Δ::SizedVector{2, Float32, Vector{Float32}})
    @ Zygote C:\Users\user\.julia\packages\Zygote\D7j8v\src\lib\lib.jl:326
  [3] (::Zygote.var"#1928#back#222"{Zygote.Jnew{SVector{2, Float32}, Nothing, false}})(Δ::SizedVector{2, Float32, Vector{Float32}})
    @ Zygote C:\Users\user\.julia\packages\ZygoteRules\AIbCs\src\adjoint.jl:67
  [4] Pullback
    @ C:\Users\user\.julia\packages\StaticArraysCore\gkLqH\src\StaticArraysCore.jl:106 [inlined]
  [5] (::typeof(∂(SVector{2, Float32})))(Δ::SizedVector{2, Float32, Vector{Float32}})
    @ Zygote C:\Users\user\.julia\packages\Zygote\D7j8v\src\compiler\interface2.jl:0
  [6] Pullback
    @ C:\Users\user\.julia\dev\StaticArrays\src\convert.jl:163 [inlined]
  [7] Pullback
    @ c:\Users\user\.julia\dev\buffer.jl:668 [inlined]
  [8] (::typeof(∂(lotka)))(Δ::SizedVector{2, Float32, Vector{Float32}})
    @ Zygote C:\Users\user\.julia\packages\Zygote\D7j8v\src\compiler\interface2.jl:0
  [9] Pullback
    @ c:\Users\user\.julia\dev\buffer.jl:673 [inlined]
 [10] (::typeof(∂(loss)))(Δ::Float32)
    @ Zygote C:\Users\user\.julia\packages\Zygote\D7j8v\src\compiler\interface2.jl:0
 [11] (::Zygote.var"#60#61"{typeof(∂(loss))})(Δ::Float32)
    @ Zygote C:\Users\user\.julia\packages\Zygote\D7j8v\src\compiler\interface.jl:41
 [12] gradient(f::Function, args::SVector{4, Float32})
    @ Zygote C:\Users\user\.julia\packages\Zygote\D7j8v\src\compiler\interface.jl:76
 [13] top-level scope
    @ c:\Users\user\.julia\dev\buffer.jl:679
```