### PR TITLE
Reduce ambiguities

### DIFF
--- a/test/FieldMatrix.jl
+++ b/test/FieldMatrix.jl
@@ -98,6 +98,9 @@
         eval(quote
             struct TupleField2 <: FieldMatrix{1, 1, NTuple{2, Int}}
                 x::NTuple{2, Int}
+                function TupleField2(x::NTuple{2,Int})
+                    new(x)
+                end
             end
         end)
 

--- a/test/FieldVector.jl
+++ b/test/FieldVector.jl
@@ -103,6 +103,9 @@
         eval(quote
             struct TupleField <: FieldVector{1, NTuple{2, Int}}
                 x::NTuple{2, Int}
+                function TupleField(x::NTuple{2,Int})
+                    new(x)
+                end
             end
         end)
 

--- a/test/ambiguities.jl
+++ b/test/ambiguities.jl
@@ -1,7 +1,7 @@
 # Allow no new ambiguities (see #18), unless you fix some old ones first!
 
-const allowable_ambiguities = VERSION ≥ v"1.7" ? 10 :
-                              VERSION ≥ v"1.6" ? 11 : error("version must be ≥1.6")
+const allowable_ambiguities = VERSION ≥ v"1.7" ? 0 :
+                              VERSION ≥ v"1.6" ? 1 : error("version must be ≥1.6")
 
 # TODO: Revisit and fix. See
 #   https://github.com/JuliaLang/julia/pull/36962


### PR DESCRIPTION
This PR reduces ambiguities `detect_ambiguities(StaticArrays)`. Note that the most of ambiguities were introduced in `test/FieldMatrix.jl` and `test/FieldVector.jl`.

We have the following two options, but this PR will minimize the changes for now.

* Drop `test/ambiguities.jl` and introduce Aqua.jl
* Duplicate `addtests("ambiguities.jl")` into `group-B` in `runtests.jl` and make sure no more ambiguities were not introduced during the test.