### PR TITLE
improve error message of `setindex!`

### DIFF
--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -1,6 +1,6 @@
 # Default error messages to help users with new types and to avoid subsequent stack overflows
 getindex(a::StaticArray, i::Int) = error("getindex(::$(typeof(a)), ::Int) is not defined.")
-setindex!(a::StaticArray, value, i::Int) = error("setindex!(::$(typeof(a)), value, ::Int) is not defined.")
+setindex!(a::StaticArray, value, i::Int) = error("setindex!(::$(typeof(a)), value, ::Int) is not defined.\n Hint: Use `MArray` to create a mutable static array")
 
 #######################################
 ## Multidimensional scalar indexing  ##

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -1,6 +1,6 @@
 # Default error messages to help users with new types and to avoid subsequent stack overflows
 getindex(a::StaticArray, i::Int) = error("getindex(::$(typeof(a)), ::Int) is not defined.")
-setindex!(a::StaticArray, value, i::Int) = error("setindex!(::$(typeof(a)), value, ::Int) is not defined.\n Hint: Use `MArray` to create a mutable static array")
+setindex!(a::StaticArray, value, i::Int) = error("setindex!(::$(typeof(a)), value, ::Int) is not defined.\n Hint: Use `MArray` or `SizedArray` to create a mutable static array")
 
 #######################################
 ## Multidimensional scalar indexing  ##


### PR DESCRIPTION
This pull request closes #1065 by throwing a better error when attempting to mutate a `StaticArray`

```julia
julia> SVector(1, 2, 3)[1] = 2
ERROR: setindex!(::SVector{3, Int64}, value, ::Int) is not defined.
 Hint: Use `MArray` to create a mutable static array
```

Note: Julia has an [experimental error hints](https://docs.julialang.org/en/v1/base/base/#Base.Experimental.register_error_hint) but I didn't use them because they're still experimental (and it seemed like too much stuff for a simple error message). 