### PR TITLE
Define `similar_type` and `StaticArrayStyle` in the core package.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 julia = "1.6"
-StaticArraysCore = "= 1.3.0"
+StaticArraysCore = "~1.3.0"
 
 [extras]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StaticArrays"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "1.5.5"
+version = "1.5.6"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -10,7 +10,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 julia = "1.6"
-StaticArraysCore = "~1.1"
+StaticArraysCore = "= 1.3.0"
 
 [extras]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/src/StaticArrays.jl
+++ b/src/StaticArrays.jl
@@ -28,10 +28,12 @@ using StaticArraysCore: StaticArraysCore, StaticArray, StaticScalar, StaticVecto
                         StaticMatrix, StaticVecOrMat, tuple_length, tuple_prod,
                         tuple_minimum, size_to_tuple, require_one_based_indexing
 using StaticArraysCore: FieldArray, FieldMatrix, FieldVector
+using StaticArraysCore: StaticArrayStyle
 import StaticArraysCore: SArray, SVector, SMatrix
 import StaticArraysCore: MArray, MVector, MMatrix
 import StaticArraysCore: SizedArray, SizedVector, SizedMatrix
 import StaticArraysCore: check_array_parameters, convert_ntuple
+import StaticArraysCore: similar_type
 
 # end of StaticArraysCore imports
 # StaticArraysCore exports

--- a/src/abstractarray.jl
+++ b/src/abstractarray.jl
@@ -36,28 +36,6 @@ end
 Base.IndexStyle(::Type{T}) where {T<:StaticArray} = IndexLinear()
 
 # Default type search for similar_type
-"""
-    similar_type(static_array)
-    similar_type(static_array, T)
-    similar_type(array, ::Size)
-    similar_type(array, T, ::Size)
-
-Returns a constructor for a statically-sized array similar to the input array
-(or type) `static_array`/`array`, optionally with different element type `T` or size
-`Size`. If the input `array` is not a `StaticArray` then the `Size` is mandatory.
-
-This differs from `similar()` in that the resulting array type may not be
-mutable (or define `setindex!()`), and therefore the returned type may need to
-be *constructed* with its data.
-
-Note that the (optional) size *must* be specified as a static `Size` object (so the compiler
-can infer the result statically).
-
-New types should define the signature `similar_type(::Type{A},::Type{T},::Size{S}) where {A<:MyType,T,S}`
-if they wish to overload the default behavior.
-"""
-function similar_type end
-
 similar_type(::SA) where {SA<:StaticArrayLike} = similar_type(SA,eltype(SA))
 similar_type(::Type{SA}) where {SA<:StaticArrayLike} = similar_type(SA,eltype(SA))
 

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -7,10 +7,7 @@ using Base.Broadcast: broadcast_shape, _broadcast_getindex, combine_axes
 import Base.Broadcast: BroadcastStyle, materialize!, instantiate
 import Base.Broadcast: _bcs1  # for SOneTo axis information
 using Base.Broadcast: _bcsm
-# Add a new BroadcastStyle for StaticArrays, derived from AbstractArrayStyle
-# A constructor that changes the style parameter N (array dimension) is also required
-struct StaticArrayStyle{N} <: AbstractArrayStyle{N} end
-StaticArrayStyle{M}(::Val{N}) where {M,N} = StaticArrayStyle{N}()
+
 BroadcastStyle(::Type{<:StaticArray{<:Tuple, <:Any, N}}) where {N} = StaticArrayStyle{N}()
 BroadcastStyle(::Type{<:Transpose{<:Any, <:StaticArray}}) = StaticArrayStyle{2}()
 BroadcastStyle(::Type{<:Adjoint{<:Any, <:StaticArray}}) = StaticArrayStyle{2}()


### PR DESCRIPTION
See https://github.com/JuliaArrays/StaticArraysCore.jl/pull/5
and https://github.com/JuliaArrays/StaticArraysCore.jl/pull/8