### PR TITLE
implement ConstructionBase interface

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,7 @@ uuid = "90137ffa-7385-5640-81b9-e52037218182"
 version = "1.5.6"
 
 [deps]
+ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
@@ -10,6 +11,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 julia = "1.6"
+ConstructionBase = "1"
 StaticArraysCore = "~1.3.0"
 
 [extras]

--- a/src/StaticArrays.jl
+++ b/src/StaticArrays.jl
@@ -10,6 +10,8 @@ import Base: getindex, setindex!, size, similar, vec, show, length, convert, pro
 
 import Statistics: mean
 
+import ConstructionBase: constructorof
+
 using Random
 import Random: rand, randn, randexp, rand!, randn!, randexp!
 using Core.Compiler: return_type
@@ -128,6 +130,7 @@ include("svd.jl")
 include("qr.jl")
 include("deque.jl")
 include("flatten.jl")
+include("constructorof.jl")
 include("io.jl")
 include("pinv.jl")
 

--- a/src/constructorof.jl
+++ b/src/constructorof.jl
@@ -1,0 +1,9 @@
+# keep the size when reconstructing arrays
+# eltype can be different
+constructorof(sa::Type{<:SArray{S}}) where {S} = SArray{S}
+constructorof(sa::Type{<:MArray{S}}) where {S} = MArray{S}
+
+# don't keep neither size nor eltype for vectors:
+# both are unambiguously determined by the values
+constructorof(::Type{<:SVector}) = SVector
+constructorof(::Type{<:MVector}) = MVector

--- a/test/constructorof.jl
+++ b/test/constructorof.jl
@@ -1,0 +1,25 @@
+using StaticArrays
+using Test
+using ConstructionBase: constructorof
+
+@testset "constructorof" begin
+    sa = @SVector [2, 4, 6, 8]
+    sa2 = constructorof(typeof(sa))((3.0, 5.0, 7.0, 9.0))
+    @test sa2 === @SVector [3.0, 5.0, 7.0, 9.0]
+
+    ma = @MMatrix [2.0 4.0; 6.0 8.0]
+    ma2 = constructorof(typeof(ma))((1, 2, 3, 4))
+    @test ma2 isa MArray{Tuple{2,2},Int,2,4}
+    @test all(ma2 .=== @MMatrix [1 3; 2 4])
+
+    for T in (SVector, MVector)
+        @test constructorof(T)((1, 2, 3))::T == T((1, 2, 3))
+        @test constructorof(T{3})((1, 2, 3))::T == T((1, 2, 3))
+        @test constructorof(T{3})((1, 2))::T == T((1, 2))
+        @test constructorof(T{3, Symbol})((1, 2, 3))::T == T((1, 2, 3))
+        @test constructorof(T{3, Symbol})((1, 2))::T == T((1, 2))
+        @test constructorof(T{3, X} where {X})((1, 2, 3))::T == T((1, 2, 3))
+        @test constructorof(T{3, X} where {X})((1, 2))::T == T((1, 2))
+        @test constructorof(T{X, Symbol} where {X})((1, 2, 3))::T == T((1, 2, 3))
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -78,6 +78,7 @@ if TEST_GROUP ∈ ["", "all", "group-B"]
     addtests("chol.jl") # hermitian_type(::Type{Any}) for block algorithm
     addtests("deque.jl")
     addtests("flatten.jl")
+    addtests("constructorof.jl")
     addtests("io.jl")
     addtests("svd.jl")
 end


### PR DESCRIPTION
Brief motivation: ConstructionBase is the foundational package for (re)constructing and modifying immutable and mutable objects, see https://github.com/JuliaObjects/ConstructionBase.jl.
`constructorof(T)(args)` is the main interface of that package, it works with lots of types by default. However, it needs to be overloaded when some type parameters cannot be determined purely from arguments passed to the constructor. Clearly, this is the case for `SArray`.
This PR implements that interface, making StaticArrays immediately compatible with all those packages and user codes that use ConstructionBase.

A similar PR was proposed 1.5 years ago: https://github.com/JuliaArrays/StaticArrays.jl/pull/901. See for more discussion and more details on the motivation.
Several things have changed since that PR that make me believe there are more reasons for this to be accepted now.

First, the implementation here is definitely cleaner and shorter than in #901. It just forwards `constructorof` to already existing S/MArray constructors, keeping only those type parameters that are necessary for reconstruction. So, it automatically supports all S/MArray constructor variations.
In partucular, this addresses a concern made for #901:
> In generic code I might want to change the size or element type - so I'm a little curious how you handle this in practice with constructorof?

Second, more and more packages are using ConstructionBase: already more than 1k in General (transitively) depend on it, and this number is growing. ConstructionBase has stayed stable and there are no plans for breaking changes or "feature creep". It's an extremely lightweight package with no dependencies and negligible load time.

@rafaqz @jw3126 @andyferris 