### PR TITLE
Avoid possible stackoverflow in FieldArray's constructor

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StaticArrays"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "1.5.6"
+version = "1.5.7"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/FieldArray.jl
+++ b/src/FieldArray.jl
@@ -5,8 +5,12 @@ function construct_type(::Type{FA}, x) where {FA <: FieldArray}
     has_size(FA) || error("$FA has no static size!")
     length_match_size(FA, x)
     FA′ = adapt_eltype(FA, x)
-    FA′ === FA && x isa Args && error("the constructor for $FA is missing!")
+    FA′ === FA && x isa Args && _missing_fa_constructor(FA, typeof(x.args))
     return FA′
+end
+@noinline function _missing_fa_constructor(@nospecialize(FA), @nospecialize(AT))
+    Ts = join(("::$T" for T in fieldtypes(AT)), ", ")
+    error("The constructor for $FA($Ts) is missing!")
 end
 
 @propagate_inbounds getindex(a::FieldArray, i::Int) = getfield(a, i)

--- a/src/FieldArray.jl
+++ b/src/FieldArray.jl
@@ -4,7 +4,9 @@
 function construct_type(::Type{FA}, x) where {FA <: FieldArray}
     has_size(FA) || error("$FA has no static size!")
     length_match_size(FA, x)
-    return adapt_eltype(FA, x)
+    FA′ = adapt_eltype(FA, x)
+    FA′ === FA && x isa Args && error("the constructor for $FA is missing!")
+    return FA′
 end
 
 @propagate_inbounds getindex(a::FieldArray, i::Int) = getfield(a, i)

--- a/test/FieldVector.jl
+++ b/test/FieldVector.jl
@@ -130,4 +130,14 @@
         @test @inferred(similar_type(FVT{Float64}, Size(3))) == SVector{3,Float64}
         @test @inferred(similar_type(FVT{Float64}, Float32, Size(3))) == SVector{3,Float32}
     end
+
+    @testset "FieldVector with constructor missing" begin
+        struct Position1088{T} <: FieldVector{3, T}
+            x::T
+            y::T
+            z::T
+            Position1088(x::T, y::T, z::T) where {T} = new{T}(x, y, z)
+        end
+        @test_throws ErrorException("the constructor for Position1088{Float64} is missing!") Position1088((1.,2.,3.))
+    end
 end

--- a/test/FieldVector.jl
+++ b/test/FieldVector.jl
@@ -138,6 +138,6 @@
             z::T
             Position1088(x::T, y::T, z::T) where {T} = new{T}(x, y, z)
         end
-        @test_throws ErrorException("the constructor for Position1088{Float64} is missing!") Position1088((1.,2.,3.))
+        @test_throws ErrorException("The constructor for Position1088{Float64}(::Float64, ::Float64, ::Float64) is missing!") Position1088((1.,2.,3.))
     end
 end


### PR DESCRIPTION
Stackoverflow is always bad as a error message. This PR tries to make it more informative.
Test added. 