### PR TITLE
nits from JET

### DIFF
--- a/src/SVector.jl
+++ b/src/SVector.jl
@@ -39,10 +39,13 @@ function static_vector_gen(::Type{SV}, @nospecialize(ex), mod::Module) where {SV
         len = check_vector_length(size(args))
         return :($SV{$len}($tuple($(escall(args)...))))
     elseif head === :comprehension
-        if length(ex.args) != 1 || !isa(ex.args[1], Expr) || ex.args[1].head != :generator
+        if length(ex.args) != 1
             error("Expected generator in comprehension, e.g. [f(i) for i = 1:3]")
         end
         ex = ex.args[1]
+        if !isa(ex, Expr) || (ex::Expr).head != :generator
+            error("Expected generator in comprehension, e.g. [f(i) for i = 1:3]")
+        end
         if length(ex.args) != 2
             error("Use a one-dimensional comprehension for @$SV")
         end
@@ -55,11 +58,14 @@ function static_vector_gen(::Type{SV}, @nospecialize(ex), mod::Module) where {SV
             end
         end
     elseif head === :typed_comprehension
-        if length(ex.args) != 2 || !isa(ex.args[2], Expr) || ex.args[2].head != :generator
+        if length(ex.args) != 2
             error("Expected generator in typed comprehension, e.g. Float64[f(i) for i = 1:3]")
         end
         T = esc(ex.args[1])
         ex = ex.args[2]
+        if !isa(ex, Expr) || (ex::Expr).head != :generator
+            error("Expected generator in typed comprehension, e.g. Float64[f(i) for i = 1:3]")
+        end
         if length(ex.args) != 2
             error("Use a one-dimensional comprehension for @$SV")
         end

--- a/src/matrix_multiply.jl
+++ b/src/matrix_multiply.jl
@@ -128,7 +128,6 @@ for TWR in [Adjoint, Transpose, Symmetric, Hermitian, LowerTriangular, UpperTria
 end
 
 @generated function _mul(Sa::Size{sa}, Sb::Size{sb}, a::StaticMatMulLike{<:Any, <:Any, Ta}, b::StaticMatMulLike{<:Any, <:Any, Tb}) where {sa, sb, Ta, Tb}
-    S = Size(sa[1], sb[2])
     # Heuristic choice for amount of codegen
     a_tri_mul = a <: LinearAlgebra.AbstractTriangular ? 4 : 1
     b_tri_mul = b <: LinearAlgebra.AbstractTriangular ? 4 : 1

--- a/test/SArray.jl
+++ b/test/SArray.jl
@@ -91,6 +91,10 @@
         test_expand_error(:(@SArray fill()))
         test_expand_error(:(@SArray [1; 2; 3; 4]...))
 
+        # (typed-)comprehension LoadError for `ex.args[1].head != :generator`
+        test_expand_error(:(@SArray [i+j for i in 1:2 for j in 1:2]))
+        test_expand_error(:(@SArray Int[i+j for i in 1:2 for j in 1:2]))
+
         @test ((@SArray fill(1))::SArray{Tuple{},Int}).data === (1,)
         @test ((@SArray ones())::SArray{Tuple{},Float64}).data === (1.,)
 


### PR DESCRIPTION
Some minor nits found with JET.

The point of changes in `src/SVector.jl` and `src/SArray.jl` is that the if-statement otherwise cannot know that the call to `.head` is meaningful (it still thinks that `ex.args[1] isa Any`). This change just splits it up and type-asserts so the knowledge that `ex isa Expr` can propagate. The code duplication is a little annoying, but I couldn't think of a good way to avoid it.

Since it's a macro it doesn't really matter - but I figured it might be nice anyway in order to reduce noise in reports by JET in the future.