### PR TITLE
Remove faulty `isassigned` specialization

### DIFF
--- a/src/abstractarray.jl
+++ b/src/abstractarray.jl
@@ -27,12 +27,6 @@ function Base.summary(io::IO, a, inds::Tuple{SOneTo, Vararg{SOneTo}})
     Base.showarg(io, a, true)
 end
 
-# This seems to confuse Julia a bit in certain circumstances (specifically for trailing 1's)
-@inline function Base.isassigned(a::StaticArray, i::Integer...)
-    ii = LinearIndices(size(a))[i...]
-    1 <= ii <= length(a) ? true : false
-end
-
 Base.IndexStyle(::Type{T}) where {T<:StaticArray} = IndexLinear()
 
 # Default type search for similar_type

--- a/src/abstractarray.jl
+++ b/src/abstractarray.jl
@@ -28,7 +28,7 @@ function Base.summary(io::IO, a, inds::Tuple{SOneTo, Vararg{SOneTo}})
 end
 
 # This seems to confuse Julia a bit in certain circumstances (specifically for trailing 1's)
-@inline function Base.isassigned(a::StaticArray, i::Int...)
+@inline function Base.isassigned(a::StaticArray, i::Integer...)
     ii = LinearIndices(size(a))[i...]
     1 <= ii <= length(a) ? true : false
 end


### PR DESCRIPTION
```
 inserting isassigned(a::StaticArray, i::Int64...) in StaticArrays at C:\Users\mkitti\.julia\packages\StaticArrays\NOLon\src\abstractarray.jl:31 invalidated:
   backedges: 1: superseding isassigned(a::AbstractArray, i::Integer...) in Base at abstractarray.jl:563 with MethodInstance for isassigned(::AbstractMatrix, ::Int64, ::Int64) (4 children)
              2: superseding isassigned(a::AbstractArray, i::Integer...) in Base at abstractarray.jl:563 with MethodInstance for isassigned(::AbstractVecOrMat, ::Int64, ::Int64) (4 children)
   1 mt_cache
```

Yes it fixes an invalidating function, but it's probably just a good idea to follow Base's convention on this one regardless.