### PR TITLE
Use `nameof` instead of Type.name.name

### DIFF
--- a/perf/benchmark3.jl
+++ b/perf/benchmark3.jl
@@ -19,21 +19,21 @@ for T ∈ [Int64, Float64]
         mutables = [rand(T,N), rand(MVector{N,T}), SizedVector{N}(rand(T,N))]
         instances = vcat(immutables, mutables)
 
-        namelengths = [length(string(typeof(v).name.name)) for v ∈ instances]
+        namelengths = [length(string(nameof(typeof(v)))) for v ∈ instances]
         maxnamelength = maximum(namelengths)
 
         for v ∈ instances
             result = mean(@benchmark plus($(copy(v)), $(copy(v))))
-            padding = maxnamelength - length(string(typeof(v).name.name))
-            println(typeof(v).name.name, ":", " " ^ padding, " v3 = v1 + v2 takes ", prettytime(time(result)), ", ", prettymemory(memory(result)), " (GC ", prettytime(gctime(result)) , ")")
+            padding = maxnamelength - length(string(nameof(typeof(v))))
+            println(nameof(typeof(v)), ":", " " ^ padding, " v3 = v1 + v2 takes ", prettytime(time(result)), ", ", prettymemory(memory(result)), " (GC ", prettytime(gctime(result)) , ")")
         end
 
         println()
 
         for v ∈ mutables
             result = mean(@benchmark plus!($(copy(v)), $(copy(v)), $(copy(v))))
-            padding = maxnamelength - length(string(typeof(v).name.name))
-            println(typeof(v).name.name, ":", " " ^ padding, " v3 .= +.(v1, v2) takes ", prettytime(time(result)), ", ", prettymemory(memory(result)), " (GC ", prettytime(gctime(result)) , ")")
+            padding = maxnamelength - length(string(nameof(typeof(v))))
+            println(nameof(typeof(v)), ":", " " ^ padding, " v3 .= +.(v1, v2) takes ", prettytime(time(result)), ", ", prettymemory(memory(result)), " (GC ", prettytime(gctime(result)) , ")")
         end
 
         println()
@@ -48,21 +48,21 @@ for T ∈ [Int64, Float64]
         mutables = [rand(T,N,N), rand(MMatrix{N,N,T}), SizedMatrix{N,N}(rand(T,N,N))]
         instances = vcat(immutables, mutables)
 
-        namelengths = [length(string(typeof(v).name.name)) for v ∈ instances]
+        namelengths = [length(string(nameof(typeof(v)))) for v ∈ instances]
         maxnamelength = maximum(namelengths)
 
         for m ∈ instances
             result = mean(@benchmark mul($(copy(m)), $(copy(m))))
-            padding = maxnamelength - length(string(typeof(m).name.name))
-            println(typeof(m).name.name, ":", " " ^ padding, " m3 = m1 * m2 takes ", prettytime(time(result)), ", ", prettymemory(memory(result)), " (GC ", prettytime(gctime(result)) , ")")
+            padding = maxnamelength - length(string(nameof(typeof(m))))
+            println(nameof(typeof(m)), ":", " " ^ padding, " m3 = m1 * m2 takes ", prettytime(time(result)), ", ", prettymemory(memory(result)), " (GC ", prettytime(gctime(result)) , ")")
         end
 
         println()
 
         for m ∈ mutables
             result = mean(@benchmark mul!($(copy(m)), $(copy(m)), $(copy(m))))
-            padding = maxnamelength - length(string(typeof(m).name.name))
-            println(typeof(m).name.name, ":", " " ^ padding, " A_mul_B!(m3, m1, m2) takes ", prettytime(time(result)), ", ", prettymemory(memory(result)), " (GC ", prettytime(gctime(result)) , ")")
+            padding = maxnamelength - length(string(nameof(typeof(m))))
+            println(nameof(typeof(m)), ":", " " ^ padding, " A_mul_B!(m3, m1, m2) takes ", prettytime(time(result)), ", ", prettymemory(memory(result)), " (GC ", prettytime(gctime(result)) , ")")
         end
 
         println()


### PR DESCRIPTION
`nameof` does the same thing, and is public. The changes are only to `perf/benchmark3.jl`, and there's no change to code in this PR.