### PR TITLE
Relax diagonal type in matrix-multiply

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StaticArrays"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "1.5.10"
+version = "1.5.11"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/matrix_multiply_add.jl
+++ b/src/matrix_multiply_add.jl
@@ -28,7 +28,7 @@ const StaticMatMulLike{s1, s2, T} = Union{
     UnitUpperTriangular{T, <:StaticMatrix{s1, s2, T}},
     Adjoint{T, <:StaticMatrix{s1, s2, T}},
     Transpose{T, <:StaticMatrix{s1, s2, T}},
-    SDiagonal{s1, T}}
+    Diagonal{T, <:StaticVector{s1, T}}}
 
 """
     gen_by_access(expr_gen, a::Type{<:AbstractArray}, asym = :wrapped_a)
@@ -81,7 +81,7 @@ end
 function gen_by_access(expr_gen, a::Type{<:Adjoint{<:Any, <:StaticVecOrMat}}, asym = :wrapped_a)
     return expr_gen(:adjoint)
 end
-function gen_by_access(expr_gen, a::Type{<:SDiagonal}, asym = :wrapped_a)
+function gen_by_access(expr_gen, a::Type{<:Diagonal{<:Any, <:StaticVector}}, asym = :wrapped_a)
     return expr_gen(:diagonal)
 end
 """
@@ -166,7 +166,7 @@ function gen_by_access(expr_gen, a::Type{<:Adjoint{<:Any, <:StaticMatrix}}, b::T
         end)
     end
 end
-function gen_by_access(expr_gen, a::Type{<:SDiagonal}, b::Type)
+function gen_by_access(expr_gen, a::Type{<:Diagonal{<:Any, <:StaticVector}}, b::Type)
     return quote
         return $(gen_by_access(b, :wrapped_b) do access_b
             expr_gen(:diagonal, access_b)

--- a/test/matrix_multiply_add.jl
+++ b/test/matrix_multiply_add.jl
@@ -122,7 +122,7 @@ function test_multiply_add(N1,N2,ArrayType=MArray)
     mul!(C,a,b',1.,1.)
     @test C ≈ 3a*b'
 
-    b = @benchmark mul!($C,$a,$b') samples=10 evals=10
+    b = @benchmark mul!($C,$a,$(b')) samples=10 evals=10
     @test minimum(b).allocs <= expected_transpose_allocs
     # @test_noalloc mul!(C, a, b')  # records 16 bytes
 


### PR DESCRIPTION
This allows `*(A::SizedMatrix{6, 12, Float64, 2, Matrix{Float64}}, D::Diagonal{Float64, MVector{12, Float64}})` to yield a `SizedMatrix` instead of a plain `Matrix`.