### PR TITLE
Fix more methods with zero-element array

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StaticArrays"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "1.5.12"
+version = "1.5.13"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/arraymath.jl
+++ b/src/arraymath.jl
@@ -40,7 +40,11 @@ end
 
 @inline fill(val, ::SA) where {SA <: StaticArray} = _fill(val, Size(SA), SA)
 @inline fill(val, ::Type{SA}) where {SA <: StaticArray} = _fill(val, Size(SA), SA)
-@generated function _fill(val::T, ::Size{s}, ::Type{SA}) where {T, s, SA <: StaticArray}
+@generated function _fill(val, ::Size{s}, ::Type{SA}) where {s, SA <: StaticArray}
+    T = eltype(SA)
+    if T == Any
+        T = typeof(val)
+    end
     v = [:val for i = 1:prod(s)]
     if SA <: SArray
         SA = SArray{Tuple{s...}, T, length(s), prod(s)}

--- a/src/arraymath.jl
+++ b/src/arraymath.jl
@@ -40,10 +40,10 @@ end
 
 @inline fill(val, ::SA) where {SA <: StaticArray} = _fill(val, Size(SA), SA)
 @inline fill(val, ::Type{SA}) where {SA <: StaticArray} = _fill(val, Size(SA), SA)
-@generated function _fill(val, ::Size{s}, ::Type{SA}) where {s, SA <: StaticArray}
+@generated function _fill(val::U, ::Size{s}, ::Type{SA}) where {U, s, SA <: StaticArray}
     T = eltype(SA)
     if T == Any
-        T = typeof(val)
+        T = U
     end
     v = [:val for i = 1:prod(s)]
     if SA <: SArray

--- a/src/arraymath.jl
+++ b/src/arraymath.jl
@@ -5,6 +5,13 @@
         T = Float64
     end
     v = [:(zero($T)) for i = 1:prod(s)]
+    if SA <: SArray
+        SA = SArray{Tuple{s...}, T, length(s), prod(s)}
+    elseif SA <: MArray
+        SA = MArray{Tuple{s...}, T, length(s), prod(s)}
+    elseif SA <: SizedArray
+        SA = SizedArray{Tuple{s...}, T, length(s)}
+    end
     return quote
         @_inline_meta
         $SA(tuple($(v...)))
@@ -18,6 +25,13 @@ end
         T = Float64
     end
     v = [:(one($T)) for i = 1:prod(s)]
+    if SA <: SArray
+        SA = SArray{Tuple{s...}, T, length(s), prod(s)}
+    elseif SA <: MArray
+        SA = MArray{Tuple{s...}, T, length(s), prod(s)}
+    elseif SA <: SizedArray
+        SA = SizedArray{Tuple{s...}, T, length(s)}
+    end
     return quote
         @_inline_meta
         $SA(tuple($(v...)))
@@ -26,8 +40,15 @@ end
 
 @inline fill(val, ::SA) where {SA <: StaticArray} = _fill(val, Size(SA), SA)
 @inline fill(val, ::Type{SA}) where {SA <: StaticArray} = _fill(val, Size(SA), SA)
-@generated function _fill(val, ::Size{s}, ::Type{SA}) where {s, SA <: StaticArray}
+@generated function _fill(val::T, ::Size{s}, ::Type{SA}) where {T, s, SA <: StaticArray}
     v = [:val for i = 1:prod(s)]
+    if SA <: SArray
+        SA = SArray{Tuple{s...}, T, length(s), prod(s)}
+    elseif SA <: MArray
+        SA = MArray{Tuple{s...}, T, length(s), prod(s)}
+    elseif SA <: SizedArray
+        SA = SizedArray{Tuple{s...}, T, length(s)}
+    end
     return quote
         @_inline_meta
         $SA(tuple($(v...)))

--- a/test/arraymath.jl
+++ b/test/arraymath.jl
@@ -69,6 +69,11 @@ import StaticArrays.arithmetic_closure
             @test all(m .== 3.)
             m = @inferred(fill(3., T{0, 5, Float64}))
             @test m isa T{0, 5, Float64}
+            m = @inferred(fill(3, T{4, 16, Float64}))
+            @test m isa T{4, 16, Float64}
+            @test all(m .== 3.)
+            m = @inferred(fill(3, T{0, 5, Float64}))
+            @test m isa T{0, 5, Float64}
         end
     end
 

--- a/test/arraymath.jl
+++ b/test/arraymath.jl
@@ -7,6 +7,10 @@ import StaticArrays.arithmetic_closure
         @test @inferred(zeros(SVector{3,Int})) === @SVector [0, 0, 0]
         @test @inferred(ones(SVector{3,Float64})) === @SVector [1.0, 1.0, 1.0]
         @test @inferred(ones(SVector{3,Int})) === @SVector [1, 1, 1]
+        @test @inferred(zeros(SVector{0,Float64})) === @SVector Float64[]
+        @test @inferred(zeros(SVector{0,Int})) === @SVector Int[]
+        @test @inferred(ones(SVector{0,Float64})) === @SVector Float64[]
+        @test @inferred(ones(SVector{0,Int})) === @SVector Int[]
 
         @test @inferred(zeros(SVector{3})) === @SVector [0.0, 0.0, 0.0]
         @test @inferred(zeros(SMatrix{2,2})) === @SMatrix [0.0 0.0; 0.0 0.0]
@@ -35,15 +39,22 @@ import StaticArrays.arithmetic_closure
     @testset "zero()" begin
         @test @inferred(zero(SVector{3, Float64})) === @SVector [0.0, 0.0, 0.0]
         @test @inferred(zero(SVector{3, Int})) === @SVector [0, 0, 0]
+        @test @inferred(zero(SVector{0, Float64})) === @SVector Float64[]
+        @test @inferred(zero(SVector{0, Int})) === @SVector Int[]
     end
 
     @testset "fill()" begin
         @test all(@inferred(fill(3., SMatrix{4, 16, Float64})) .== 3.)
         @test @allocated(fill(0., SMatrix{1, 16, Float64})) == 0 # #81
+        @test all(@inferred(fill(3., SMatrix{0, 5, Float64})) .== 3.)
+        @test @allocated(fill(0., SMatrix{1, 5, Float64})) == 0 # #81
     end
 
     @testset "fill!()" begin
         m = MMatrix{4,16,Float64}(undef)
+        fill!(m, 3)
+        @test all(m .== 3.)
+        m = MMatrix{0,5,Float64}(undef)
         fill!(m, 3)
         @test all(m .== 3.)
     end

--- a/test/arraymath.jl
+++ b/test/arraymath.jl
@@ -60,8 +60,8 @@ import StaticArrays.arithmetic_closure
     end
 
     @testset "fill()" begin
-        @test @allocated(fill(0., T{1, 16, Float64})) == 0 # #81
-        @test @allocated(fill(0., T{0, 5, Float64})) == 0
+        @test @allocated(fill(0., SMatrix{1, 16, Float64})) == 0 # #81
+        @test @allocated(fill(0., SMatrix{0, 5, Float64})) == 0
 
         for T in (SMatrix, MMatrix, SizedMatrix)
             m = @inferred(fill(3., T{4, 16, Float64}))

--- a/test/arraymath.jl
+++ b/test/arraymath.jl
@@ -36,6 +36,29 @@ import StaticArrays.arithmetic_closure
         @test bigones[1] !== bigones[2]
     end
 
+    @testset "ones()" begin
+        for T in (SVector, MVector, SizedVector)
+            m = @inferred ones(T{3, Float64})
+            @test m == [1.0, 1.0, 1.0]
+            @test m isa T{3, Float64}
+            m = @inferred ones(T{3, Int})
+            @test m == [1, 1, 1]
+            @test m isa T{3, Int}
+            m = @inferred ones(T{3})
+            @test m == [1.0, 1.0, 1.0]
+            @test m isa T{3}
+            m = @inferred ones(T{0, Float64})
+            @test m == Float64[]
+            @test m isa T{0, Float64}
+            m = @inferred ones(T{0, Int})
+            @test m == Int[]
+            @test m isa T{0, Int}
+            m = @inferred ones(T{0})
+            @test m == Float64[]
+            @test m isa T{0}
+        end
+    end
+
     @testset "zero()" begin
         for T in (SVector, MVector, SizedVector)
             m = @inferred zero(T{3, Float64})

--- a/test/arraymath.jl
+++ b/test/arraymath.jl
@@ -44,10 +44,16 @@ import StaticArrays.arithmetic_closure
     end
 
     @testset "fill()" begin
-        @test all(@inferred(fill(3., SMatrix{4, 16, Float64})) .== 3.)
-        @test @allocated(fill(0., SMatrix{1, 16, Float64})) == 0 # #81
-        @test all(@inferred(fill(3., SMatrix{0, 5, Float64})) .== 3.)
-        @test @allocated(fill(0., SMatrix{1, 5, Float64})) == 0 # #81
+        @test @allocated(fill(0., T{1, 16, Float64})) == 0 # #81
+        @test @allocated(fill(0., T{0, 5, Float64})) == 0
+
+        for T in (SMatrix, MMatrix, SizedMatrix)
+            m = @inferred(fill(3., T{4, 16, Float64}))
+            @test m isa T{4, 16, Float64}
+            @test all(m .== 3.)
+            m = @inferred(fill(3., T{0, 5, Float64}))
+            @test m isa T{0, 5, Float64}
+        end
     end
 
     @testset "fill!()" begin

--- a/test/arraymath.jl
+++ b/test/arraymath.jl
@@ -37,10 +37,26 @@ import StaticArrays.arithmetic_closure
     end
 
     @testset "zero()" begin
-        @test @inferred(zero(SVector{3, Float64})) === @SVector [0.0, 0.0, 0.0]
-        @test @inferred(zero(SVector{3, Int})) === @SVector [0, 0, 0]
-        @test @inferred(zero(SVector{0, Float64})) === @SVector Float64[]
-        @test @inferred(zero(SVector{0, Int})) === @SVector Int[]
+        for T in (SVector, MVector, SizedVector)
+            m = @inferred zero(T{3, Float64})
+            @test m == [0.0, 0.0, 0.0]
+            @test m isa T{3, Float64}
+            m = @inferred zero(T{3, Int})
+            @test m == [0, 0, 0]
+            @test m isa T{3, Int}
+            m = @inferred zero(T{3})
+            @test m == [0.0, 0.0, 0.0]
+            @test m isa T{3}
+            m = @inferred zero(T{0, Float64})
+            @test m == Float64[]
+            @test m isa T{0, Float64}
+            m = @inferred zero(T{0, Int})
+            @test m == Int[]
+            @test m isa T{0, Int}
+            m = @inferred zero(T{0})
+            @test m == Float64[]
+            @test m isa T{0}
+        end
     end
 
     @testset "fill()" begin


### PR DESCRIPTION
Follow up #1122. Fixes https://github.com/JuliaArrays/StaticArrays.jl/issues/1121.

**Before this PR**

```julia
julia> using StaticArrays

julia> @SMatrix fill(3,2,0)
2×0 SMatrix{2, 0, Union{}, 0} with indices SOneTo(2)×SOneTo(0)

julia> @SMatrix ones(0,2)
0×2 SMatrix{0, 2, Union{}, 0} with indices SOneTo(0)×SOneTo(2)

julia> @SMatrix zeros(0,2)
0×2 SMatrix{0, 2, Union{}, 0} with indices SOneTo(0)×SOneTo(2)
```

**After this PR**

```julia
julia> using StaticArrays

julia> @SMatrix fill(3,2,0)
2×0 SMatrix{2, 0, Int64, 0} with indices SOneTo(2)×SOneTo(0)

julia> @SMatrix ones(0,2)
0×2 SMatrix{0, 2, Float64, 0} with indices SOneTo(0)×SOneTo(2)

julia> @SMatrix zeros(0,2)
0×2 SMatrix{0, 2, Float64, 0} with indices SOneTo(0)×SOneTo(2)
```

