### PR TITLE
Fix zero(SVector{3,Any}) etc. with multiple dispatch

### DIFF
--- a/src/MVector.jl
+++ b/src/MVector.jl
@@ -1,7 +1,3 @@
-# Some more advanced constructor-like functions
-@inline zeros(::Type{MVector{N}}) where {N} = zeros(MVector{N,Float64})
-@inline ones(::Type{MVector{N}}) where {N} = ones(MVector{N,Float64})
-
 #####################
 ## MVector methods ##
 #####################

--- a/src/SVector.jl
+++ b/src/SVector.jl
@@ -1,8 +1,3 @@
-
-# Some more advanced constructor-like functions
-@inline zeros(::Type{SVector{N}}) where {N} = zeros(SVector{N,Float64})
-@inline ones(::Type{SVector{N}}) where {N} = ones(SVector{N,Float64})
-
 #####################
 ## SVector methods ##
 #####################

--- a/src/arraymath.jl
+++ b/src/arraymath.jl
@@ -1,4 +1,4 @@
-@inline zeros(::Type{SA}) where {SA <: StaticArray{<:Tuple}} = zeros(SA{Float64})
+@inline zeros(::Type{SA}) where {SA <: StaticArray{<:Tuple}} = zeros(Base.typeintersect(SA, AbstractArray{Float64}))
 @inline zeros(::Type{SA}) where {SA <: StaticArray{<:Tuple, T}} where T = _zeros(Size(SA), SA)
 @generated function _zeros(::Size{s}, ::Type{SA}) where {s, SA <: StaticArray}
     T = eltype(SA)
@@ -16,7 +16,7 @@
     end
 end
 
-@inline ones(::Type{SA}) where {SA <: StaticArray{<:Tuple}} = ones(SA{Float64})
+@inline ones(::Type{SA}) where {SA <: StaticArray{<:Tuple}} = ones(Base.typeintersect(SA, AbstractArray{Float64}))
 @inline ones(::Type{SA}) where {SA <: StaticArray{<:Tuple, T}} where T = _ones(Size(SA), SA)
 @generated function _ones(::Size{s}, ::Type{SA}) where {s, SA <: StaticArray}
     T = eltype(SA)

--- a/src/arraymath.jl
+++ b/src/arraymath.jl
@@ -35,7 +35,7 @@ end
 end
 
 @inline fill(val, ::SA) where {SA <: StaticArray{<:Tuple}} = _fill(val, Size(SA), SA)
-@inline fill(val::U, ::Type{SA}) where {SA <: StaticArray} where U = fill(val, SA{U})
+@inline fill(val::U, ::Type{SA}) where {SA <: StaticArray} where U = fill(val, Base.typeintersect(SA, AbstractArray{U}))
 @inline fill(val, ::Type{SA}) where {SA <: StaticArray{<:Tuple, T}} where T = _fill(val, Size(SA), SA)
 @generated function _fill(val, ::Size{s}, ::Type{SA}) where {s, SA <: StaticArray}
     T = eltype(SA)

--- a/src/arraymath.jl
+++ b/src/arraymath.jl
@@ -1,9 +1,7 @@
-@inline zeros(::Type{SA}) where {SA <: StaticArray} = _zeros(Size(SA), SA)
+@inline zeros(::Type{SA}) where {SA <: StaticArray{<:Tuple}} = zeros(SA{Float64})
+@inline zeros(::Type{SA}) where {SA <: StaticArray{<:Tuple, T}} where T = _zeros(Size(SA), SA)
 @generated function _zeros(::Size{s}, ::Type{SA}) where {s, SA <: StaticArray}
     T = eltype(SA)
-    if T == Any
-        T = Float64
-    end
     v = [:(zero($T)) for i = 1:prod(s)]
     if SA <: SArray
         SA = SArray{Tuple{s...}, T, length(s), prod(s)}
@@ -18,12 +16,10 @@
     end
 end
 
-@inline ones(::Type{SA}) where {SA <: StaticArray} = _ones(Size(SA), SA)
+@inline ones(::Type{SA}) where {SA <: StaticArray{<:Tuple}} = ones(SA{Float64})
+@inline ones(::Type{SA}) where {SA <: StaticArray{<:Tuple, T}} where T = _ones(Size(SA), SA)
 @generated function _ones(::Size{s}, ::Type{SA}) where {s, SA <: StaticArray}
     T = eltype(SA)
-    if T == Any
-        T = Float64
-    end
     v = [:(one($T)) for i = 1:prod(s)]
     if SA <: SArray
         SA = SArray{Tuple{s...}, T, length(s), prod(s)}
@@ -38,13 +34,11 @@ end
     end
 end
 
-@inline fill(val, ::SA) where {SA <: StaticArray} = _fill(val, Size(SA), SA)
-@inline fill(val, ::Type{SA}) where {SA <: StaticArray} = _fill(val, Size(SA), SA)
-@generated function _fill(val::U, ::Size{s}, ::Type{SA}) where {U, s, SA <: StaticArray}
+@inline fill(val, ::SA) where {SA <: StaticArray{<:Tuple}} = _fill(val, Size(SA), SA)
+@inline fill(val::U, ::Type{SA}) where {SA <: StaticArray} where U = fill(val, SA{U})
+@inline fill(val, ::Type{SA}) where {SA <: StaticArray{<:Tuple, T}} where T = _fill(val, Size(SA), SA)
+@generated function _fill(val, ::Size{s}, ::Type{SA}) where {s, SA <: StaticArray}
     T = eltype(SA)
-    if T == Any
-        T = U
-    end
     v = [:val for i = 1:prod(s)]
     if SA <: SArray
         SA = SArray{Tuple{s...}, T, length(s), prod(s)}

--- a/test/arraymath.jl
+++ b/test/arraymath.jl
@@ -104,17 +104,42 @@ import StaticArrays.arithmetic_closure
         @test @allocated(fill(0., SMatrix{1, 16, Float64})) == 0 # #81
         @test @allocated(fill(0., SMatrix{0, 5, Float64})) == 0
 
-        for T in (SMatrix, MMatrix, SizedMatrix)
-            m = @inferred(fill(3., T{4, 16, Float64}))
-            @test m isa T{4, 16, Float64}
-            @test all(m .== 3.)
-            m = @inferred(fill(3., T{0, 5, Float64}))
-            @test m isa T{0, 5, Float64}
-            m = @inferred(fill(3, T{4, 16, Float64}))
-            @test m isa T{4, 16, Float64}
-            @test all(m .== 3.)
-            m = @inferred(fill(3, T{0, 5, Float64}))
-            @test m isa T{0, 5, Float64}
+        for SA in (SMatrix, MMatrix, SizedMatrix)
+            for T in (Float64, Int, Any)
+                # Float64 -> T
+                m = @inferred(fill(3.0, SA{4, 16, T}))
+                @test m isa SA{4, 16, T}
+                @test all(m .== 3)
+                # Float64 -> T (zero-element)
+                m = @inferred(fill(3.0, SA{0, 5, T}))
+                @test m isa SA{0, 5, T}
+                @test all(m .== 3)
+                # Int -> T
+                m = @inferred(fill(3, SA{4, 16, T}))
+                @test m isa SA{4, 16, T}
+                @test all(m .== 3)
+                # Int -> T (zero-element)
+                m = @inferred(fill(3, SA{0, 5, T}))
+                @test m isa SA{0, 5, T}
+                @test all(m .== 3)
+            end
+
+            # Float64 -> Unspecified
+            m = @inferred(fill(3.0, SA{4, 16}))
+            @test m isa SA{4, 16, Float64}
+            @test all(m .== 3)
+            # Float64 -> Unspecified (zero-element)
+            m = @inferred(fill(3.0, SA{0, 5}))
+            @test m isa SA{0, 5, Float64}
+            @test all(m .== 3)
+            # Int -> Unspecified
+            m = @inferred(fill(3, SA{4, 16}))
+            @test m isa SA{4, 16, Int}
+            @test all(m .== 3)
+            # Int -> Unspecified (zero-element)
+            m = @inferred(fill(3, SA{0, 5}))
+            @test m isa SA{0, 5, Int}
+            @test all(m .== 3)
         end
     end
 

--- a/test/arraymath.jl
+++ b/test/arraymath.jl
@@ -38,47 +38,65 @@ import StaticArrays.arithmetic_closure
 
     @testset "ones()" begin
         for T in (SVector, MVector, SizedVector)
+            # Float64
             m = @inferred ones(T{3, Float64})
             @test m == [1.0, 1.0, 1.0]
             @test m isa T{3, Float64}
+            # Int
             m = @inferred ones(T{3, Int})
             @test m == [1, 1, 1]
             @test m isa T{3, Int}
+            # Unspecified
             m = @inferred ones(T{3})
             @test m == [1.0, 1.0, 1.0]
             @test m isa T{3}
+            # Float64
             m = @inferred ones(T{0, Float64})
             @test m == Float64[]
             @test m isa T{0, Float64}
+            # Int
             m = @inferred ones(T{0, Int})
             @test m == Int[]
             @test m isa T{0, Int}
+            # Unspecified
             m = @inferred ones(T{0})
             @test m == Float64[]
             @test m isa T{0}
+            # Any
+            @test_throws MethodError ones(T{3, Any})
+            @test ones(T{0, Any}) isa T{0, Any}
         end
     end
 
     @testset "zero()" begin
         for T in (SVector, MVector, SizedVector)
+            # Float64
             m = @inferred zero(T{3, Float64})
             @test m == [0.0, 0.0, 0.0]
             @test m isa T{3, Float64}
+            # Int
             m = @inferred zero(T{3, Int})
             @test m == [0, 0, 0]
             @test m isa T{3, Int}
+            # Unspecified
             m = @inferred zero(T{3})
             @test m == [0.0, 0.0, 0.0]
             @test m isa T{3}
+            # Float64 (zero-element)
             m = @inferred zero(T{0, Float64})
             @test m == Float64[]
             @test m isa T{0, Float64}
+            # Int (zero-element)
             m = @inferred zero(T{0, Int})
             @test m == Int[]
             @test m isa T{0, Int}
+            # Unspecified (zero-element)
             m = @inferred zero(T{0})
             @test m == Float64[]
             @test m isa T{0}
+            # Any
+            @test_throws MethodError zeros(T{3, Any})
+            @test zeros(T{0, Any}) isa T{0, Any}
         end
     end
 

--- a/test/arraymath.jl
+++ b/test/arraymath.jl
@@ -37,66 +37,66 @@ import StaticArrays.arithmetic_closure
     end
 
     @testset "ones()" begin
-        for T in (SVector, MVector, SizedVector)
+        for SA in (SVector, MVector, SizedVector)
             # Float64
-            m = @inferred ones(T{3, Float64})
+            m = @inferred ones(SA{3, Float64})
             @test m == [1.0, 1.0, 1.0]
-            @test m isa T{3, Float64}
+            @test m isa SA{3, Float64}
             # Int
-            m = @inferred ones(T{3, Int})
+            m = @inferred ones(SA{3, Int})
             @test m == [1, 1, 1]
-            @test m isa T{3, Int}
+            @test m isa SA{3, Int}
             # Unspecified
-            m = @inferred ones(T{3})
+            m = @inferred ones(SA{3})
             @test m == [1.0, 1.0, 1.0]
-            @test m isa T{3}
+            @test m isa SA{3}
             # Float64
-            m = @inferred ones(T{0, Float64})
+            m = @inferred ones(SA{0, Float64})
             @test m == Float64[]
-            @test m isa T{0, Float64}
+            @test m isa SA{0, Float64}
             # Int
-            m = @inferred ones(T{0, Int})
+            m = @inferred ones(SA{0, Int})
             @test m == Int[]
-            @test m isa T{0, Int}
+            @test m isa SA{0, Int}
             # Unspecified
-            m = @inferred ones(T{0})
+            m = @inferred ones(SA{0})
             @test m == Float64[]
-            @test m isa T{0}
+            @test m isa SA{0}
             # Any
-            @test_throws MethodError ones(T{3, Any})
-            @test ones(T{0, Any}) isa T{0, Any}
+            @test_throws MethodError ones(SA{3, Any})
+            @test ones(SA{0, Any}) isa SA{0, Any}
         end
     end
 
     @testset "zero()" begin
-        for T in (SVector, MVector, SizedVector)
+        for SA in (SVector, MVector, SizedVector)
             # Float64
-            m = @inferred zero(T{3, Float64})
+            m = @inferred zero(SA{3, Float64})
             @test m == [0.0, 0.0, 0.0]
-            @test m isa T{3, Float64}
+            @test m isa SA{3, Float64}
             # Int
-            m = @inferred zero(T{3, Int})
+            m = @inferred zero(SA{3, Int})
             @test m == [0, 0, 0]
-            @test m isa T{3, Int}
+            @test m isa SA{3, Int}
             # Unspecified
-            m = @inferred zero(T{3})
+            m = @inferred zero(SA{3})
             @test m == [0.0, 0.0, 0.0]
-            @test m isa T{3}
+            @test m isa SA{3}
             # Float64 (zero-element)
-            m = @inferred zero(T{0, Float64})
+            m = @inferred zero(SA{0, Float64})
             @test m == Float64[]
-            @test m isa T{0, Float64}
+            @test m isa SA{0, Float64}
             # Int (zero-element)
-            m = @inferred zero(T{0, Int})
+            m = @inferred zero(SA{0, Int})
             @test m == Int[]
-            @test m isa T{0, Int}
+            @test m isa SA{0, Int}
             # Unspecified (zero-element)
-            m = @inferred zero(T{0})
+            m = @inferred zero(SA{0})
             @test m == Float64[]
-            @test m isa T{0}
+            @test m isa SA{0}
             # Any
-            @test_throws MethodError zeros(T{3, Any})
-            @test zeros(T{0, Any}) isa T{0, Any}
+            @test_throws MethodError zeros(SA{3, Any})
+            @test zeros(SA{0, Any}) isa SA{0, Any}
         end
     end
 
@@ -162,21 +162,21 @@ import StaticArrays.arithmetic_closure
         m = rand(1:1, SVector{3})
         @test rand(m) == 1
 
-        for T in (SVector, MVector, SizedVector)
-            v1 = rand(T{3})
-            @test v1 isa T{3, Float64}
+        for SA in (SVector, MVector, SizedVector)
+            v1 = rand(SA{3})
+            @test v1 isa SA{3, Float64}
             @test all(0 .< v1 .< 1)
 
-            v2 = rand(T{0})
-            @test v2 isa T{0, Float64}
+            v2 = rand(SA{0})
+            @test v2 isa SA{0, Float64}
             @test all(0 .< v2 .< 1)
 
-            v3 = rand(T{3, Float32})
-            @test v3 isa T{3, Float32}
+            v3 = rand(SA{3, Float32})
+            @test v3 isa SA{3, Float32}
             @test all(0 .< v3 .< 1)
 
-            v4 = rand(T{0, Float32})
-            @test v4 isa T{0, Float32}
+            v4 = rand(SA{0, Float32})
+            @test v4 isa SA{0, Float32}
             @test all(0 .< v4 .< 1)
         end
     end
@@ -191,105 +191,105 @@ import StaticArrays.arithmetic_closure
         check = ((m .>= 1) .& (m .<= 2))
         @test all(check)
 
-        for T in (MVector, SizedVector)
-            v1 = rand(T{3})
+        for SA in (MVector, SizedVector)
+            v1 = rand(SA{3})
             rand!(v1)
-            @test v1 isa T{3, Float64}
+            @test v1 isa SA{3, Float64}
             @test all(0 .< v1 .< 1)
 
-            v2 = rand(T{0})
+            v2 = rand(SA{0})
             rand!(v2)
-            @test v2 isa T{0, Float64}
+            @test v2 isa SA{0, Float64}
             @test all(0 .< v2 .< 1)
 
-            v3 = rand(T{3, Float32})
+            v3 = rand(SA{3, Float32})
             rand!(v3)
-            @test v3 isa T{3, Float32}
+            @test v3 isa SA{3, Float32}
             @test all(0 .< v3 .< 1)
 
-            v4 = rand(T{0, Float32})
+            v4 = rand(SA{0, Float32})
             rand!(v4)
-            @test v4 isa T{0, Float32}
+            @test v4 isa SA{0, Float32}
             @test all(0 .< v4 .< 1)
         end
     end
 
     @testset "randn()" begin
-        for T in (SVector, MVector, SizedVector)
-            v1 = randn(T{3})
-            @test v1 isa T{3, Float64}
+        for SA in (SVector, MVector, SizedVector)
+            v1 = randn(SA{3})
+            @test v1 isa SA{3, Float64}
 
-            v2 = randn(T{0})
-            @test v2 isa T{0, Float64}
+            v2 = randn(SA{0})
+            @test v2 isa SA{0, Float64}
 
-            v3 = randn(T{3, Float32})
-            @test v3 isa T{3, Float32}
+            v3 = randn(SA{3, Float32})
+            @test v3 isa SA{3, Float32}
 
-            v4 = randn(T{0, Float32})
-            @test v4 isa T{0, Float32}
+            v4 = randn(SA{0, Float32})
+            @test v4 isa SA{0, Float32}
         end
     end
 
     @testset "randn!()" begin
-        for T in (MVector, SizedVector)
-            v1 = randn(T{3})
+        for SA in (MVector, SizedVector)
+            v1 = randn(SA{3})
             randn!(v1)
-            @test v1 isa T{3, Float64}
+            @test v1 isa SA{3, Float64}
 
-            v2 = randn(T{0})
+            v2 = randn(SA{0})
             randn!(v2)
-            @test v2 isa T{0, Float64}
+            @test v2 isa SA{0, Float64}
 
-            v3 = randn(T{3, Float32})
+            v3 = randn(SA{3, Float32})
             randn!(v3)
-            @test v3 isa T{3, Float32}
+            @test v3 isa SA{3, Float32}
 
-            v4 = randn(T{0, Float32})
+            v4 = randn(SA{0, Float32})
             randn!(v4)
-            @test v4 isa T{0, Float32}
+            @test v4 isa SA{0, Float32}
         end
     end
 
     @testset "randexp()" begin
-        for T in (SVector, MVector, SizedVector)
-            v1 = randexp(T{3})
-            @test v1 isa T{3, Float64}
+        for SA in (SVector, MVector, SizedVector)
+            v1 = randexp(SA{3})
+            @test v1 isa SA{3, Float64}
             @test all(0 .< v1)
 
-            v2 = randexp(T{0})
-            @test v2 isa T{0, Float64}
+            v2 = randexp(SA{0})
+            @test v2 isa SA{0, Float64}
             @test all(0 .< v2)
 
-            v3 = randexp(T{3, Float32})
-            @test v3 isa T{3, Float32}
+            v3 = randexp(SA{3, Float32})
+            @test v3 isa SA{3, Float32}
             @test all(0 .< v3)
 
-            v4 = randexp(T{0, Float32})
-            @test v4 isa T{0, Float32}
+            v4 = randexp(SA{0, Float32})
+            @test v4 isa SA{0, Float32}
             @test all(0 .< v4)
         end
     end
 
     @testset "randexp!()" begin
-        for T in (MVector, SizedVector)
-            v1 = randexp(T{3})
+        for SA in (MVector, SizedVector)
+            v1 = randexp(SA{3})
             randexp!(v1)
-            @test v1 isa T{3, Float64}
+            @test v1 isa SA{3, Float64}
             @test all(0 .< v1)
 
-            v2 = randexp(T{0})
+            v2 = randexp(SA{0})
             randexp!(v2)
-            @test v2 isa T{0, Float64}
+            @test v2 isa SA{0, Float64}
             @test all(0 .< v2)
 
-            v3 = randexp(T{3, Float32})
+            v3 = randexp(SA{3, Float32})
             randexp!(v3)
-            @test v3 isa T{3, Float32}
+            @test v3 isa SA{3, Float32}
             @test all(0 .< v3)
 
-            v4 = randexp(T{0, Float32})
+            v4 = randexp(SA{0, Float32})
             randexp!(v4)
-            @test v4 isa T{0, Float32}
+            @test v4 isa SA{0, Float32}
             @test all(0 .< v4)
         end
     end


### PR DESCRIPTION
This PR fixes the output values commented on https://github.com/JuliaArrays/StaticArrays.jl/pull/1122#issuecomment-1429146870.

**StaticArrays.jl v1.5.12**

```julia
julia> zero(MVector{3,Any})::MVector{3,Any}
3-element MVector{3, Any} with indices SOneTo(3):
 0.0
 0.0
 0.0
```

**StaticArrays.jl v1.5.13**

```julia
julia> zero(MVector{3,Any})::MVector{3,Float64} # Float64 !== Any
3-element MVector{3, Float64} with indices SOneTo(3):
 0.0
 0.0
 0.0
```

**After this PR**

```julia
julia> using StaticArrays

julia> zero(MVector{3,Any})::MVector{3,Float64}
ERROR: MethodError: no method matching zero(::Type{Any})
```

I think the return value on v1.5.13 is problematic, but I'm not sure the return value on v1.5.12 is correct because `zero(Any)` throws an error.