### PR TITLE
Avoid allocation when computing norm of MVector

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StaticArrays"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "1.5.15"
+version = "1.5.16"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -226,7 +226,7 @@ _inner_eltype(x::Number) = typeof(x)
 end
 
 @inline maxabs_nested(a::Number) = abs(a)
-function maxabs_nested(a::AbstractArray)
+@inline function maxabs_nested(a::AbstractArray)
     prod(size(a)) == 0 && (return _init_zero(a))
 
     m = maxabs_nested(a[1])

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -236,9 +236,7 @@ end
         @test @inferred(add_bc!(MMatrix(SA[10 20; 30 40]), (1,2))) ::MMatrix{2,2,Int} == SA[11 21; 32 42]
 
         # Tuples of SA
-        @test SA[1,2,3] .* (SA[1,0],) === SVector{3,SVector{2,Int}}(((1,0), (2,0), (3,0)))
-        # Unfortunately this case of nested broadcasting is not inferred
-        @test_broken @inferred(SA[1,2,3] .* (SA[1,0],))
+        @test (@inferred SA[1,2,3] .* (SA[1,0],)) === SVector{3,SVector{2,Int}}(((1,0), (2,0), (3,0)))
     end
 
     @testset "SDiagonal" begin


### PR DESCRIPTION
This is one way to fix #1126, another would be to convert any static array to `SArray` before the norm is calculated. I don't have a strong preference one way or another.