### PR TITLE
Relax recursion check in `construct_type`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StaticArrays"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "1.5.18"
+version = "1.5.19"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -86,7 +86,7 @@ const SizeEltypeAdaptable = Union{SArray, MArray, SHermitianCompact, SizedArray}
 function construct_type(::Type{SA}, x) where {SA<:SizeEltypeAdaptable}
     SA′ = adapt_eltype(adapt_size(SA, x), x)
     check_parameters(SA′)
-    (x isa Tuple && SA === SA′) || return SA′
+    (!need_rewrap(SA′, x) && x isa Tuple && SA === SA′) || return SA′
     error("Constructor for $SA is missing. Please file a bug.")
 end
 

--- a/test/SVector.jl
+++ b/test/SVector.jl
@@ -127,4 +127,10 @@
         f = [1,2,3]
         @test f == @SVector [f[i] for i in 1:3]
     end
+
+    @testset "issue 1118" begin
+        a = SVector{1}(1)
+        @test SVector{1, Tuple{SVector{1, Int}, SVector{1, Int}}}((a,a)) === SVector{1}((a,a))
+        @test SVector{1, NTuple}((a,a))[1] === (a,a)
+    end
 end


### PR DESCRIPTION
If `need_rewrap` returns `true`, then `x` would be re-wrapped before the next call.
Thus there's actually no stackoverflow risk in this case.
fix #1118.