### PR TITLE
fix vector indexing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StaticArrays"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "1.5.19"
+version = "1.5.20"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -59,7 +59,7 @@ end
         else
             ind_expr = :($ind_expr + $stride * (inds[$i] - 1))
         end
-        stride *= S[i]
+        stride *= Size(S)[i]
     end
     return quote
         @_propagate_inbounds_meta

--- a/test/matrix_multiply.jl
+++ b/test/matrix_multiply.jl
@@ -436,5 +436,7 @@ mul_wrappers = [
         outvec2f = Vector{Float64}(undef, 2)
         mul!(outvec2f, mf, vf2)
         @test outvec2f ≈ [10.0, 22.0]
+
+        @test mul!(@MArray([0.0]), Diagonal([1]), @MArray([2.0])) == @MArray([2.0])
     end
 end


### PR DESCRIPTION
This fixes `mul!(@MArray([0.0]), Diagonal([1]), @MArray([-14691.819508873506]))` in line with the same change in getindex.