### PR TITLE
Allow mutation of non-isbits eltypes

### DIFF
--- a/src/MArray.jl
+++ b/src/MArray.jl
@@ -36,9 +36,9 @@ end
     else
         # This one is unsafe (#27)
         # unsafe_store!(Base.unsafe_convert(Ptr{Ptr{Nothing}}, pointer_from_objref(v.data)), pointer_from_objref(val), i)
-        error("setindex!() with non-isbitstype eltype is not supported by StaticArrays. Consider using SizedArray.")
+        # error("setindex!() with non-isbitstype eltype is not supported by StaticArrays. Consider using SizedArray.")
+        setfield!(v, :data, Base.setindex(getfield(v, :data), val, i))
     end
-
     return v
 end
 

--- a/src/MArray.jl
+++ b/src/MArray.jl
@@ -27,7 +27,7 @@ end
     getfield(v,:data)[i]
 end
 
-@propagate_inbounds function setindex!(v::MArray, val, i::Int)
+@propagate_inbounds function setindex!(v::MArray, val, i::Int) 
     @boundscheck checkbounds(v,i)
     T = eltype(v)
 
@@ -37,7 +37,7 @@ end
         # This one is unsafe (#27)
         # unsafe_store!(Base.unsafe_convert(Ptr{Ptr{Nothing}}, pointer_from_objref(v.data)), pointer_from_objref(val), i)
         # error("setindex!() with non-isbitstype eltype is not supported by StaticArrays. Consider using SizedArray.")
-        setfield!(v, :data, Base.setindex(getfield(v, :data), val, i))
+        setfield!(v, :data, Base.setindex(getfield(v, :data), convert(eltype(v), val), i))
     end
     return v
 end

--- a/test/MArray.jl
+++ b/test/MArray.jl
@@ -209,8 +209,10 @@
         @test_throws BoundsError setindex!(mm, 4, 82)
 
         # setindex with non-elbits type
-        m = MArray{Tuple{2,2,2}, String}(undef)
-        @test_throws ErrorException setindex!(m, "a", 1, 1, 1)
+        m = MArray{Tuple{2,2,2}, String}(("b" for _ ∈ 1:2^3))
+        @test setindex!(m, "a", 1, 1, 1) == MArray{Tuple{2,2,2}, String}(("a", ("b" for _ ∈ 1:2^3-1)...,))
+        @test m[1,1,1] == "a"
+        @test m[1,1,2] == "b"
     end
 
     @testset "promotion" begin


### PR DESCRIPTION
For large `MArray`s, this'll be slower than if we had a proper `MutableTuple`, but it does work and it won't screw up the garbage collector or do anything unsafe like the previous version did. 