### PR TITLE
small nits from JET report

### DIFF
--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -316,8 +316,8 @@ _mean_denom(a, ::Type{Val{D}}) where {D} = size(a, D)
 @inline maximum(f::Function, a::StaticArray; dims=:) = _mapreduce(f, max, dims, _InitialValue(), Size(a), a)
 
 # Diff is slightly different
-@inline diff(a::StaticArray; dims) = _diff(Size(a), a, dims)
-@inline diff(a::StaticVector) = diff(a;dims=Val(1))
+@inline diff(a::StaticArray; dims=Val(1)) = _diff(Size(a), a, dims)
+@inline diff(a::StaticVector) = diff(a; dims=Val(1))
 
 @inline function _diff(sz::Size{S}, a::StaticArray, D::Int) where {S}
     _diff(sz,a,Val(D))

--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -316,8 +316,8 @@ _mean_denom(a, ::Type{Val{D}}) where {D} = size(a, D)
 @inline maximum(f::Function, a::StaticArray; dims=:) = _mapreduce(f, max, dims, _InitialValue(), Size(a), a)
 
 # Diff is slightly different
-@inline diff(a::StaticArray; dims=Val(1)) = _diff(Size(a), a, dims)
-@inline diff(a::StaticVector) = diff(a; dims=Val(1))
+@inline diff(a::StaticArray; dims) = _diff(Size(a), a, dims)
+@inline diff(a::StaticVector) = diff(a;dims=Val(1))
 
 @inline function _diff(sz::Size{S}, a::StaticArray, D::Int) where {S}
     _diff(sz,a,Val(D))

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -65,9 +65,6 @@ Base.LinearIndices(::Size{S}) where {S} = LinearIndices(S)
 @pure Base.:(==)(::Length{L}, l::Int) where {L} = L == l
 @pure Base.:(==)(l::Int, ::Length{L}) where {L} = l == L
 
-# unroll_tuple also works with `Length`
-@propagate_inbounds unroll_tuple(f, ::Length{L}) where {L} = unroll_tuple(f, Val{L})
-
 """
     sizematch(::Size, ::Size)
     sizematch(::Tuple, ::Tuple)


### PR DESCRIPTION
A few nits from JET.jl: mostly just to reduce noise in future reports.

In `/src/mapreduce.jl` the issue is a missing default for a kwarg, in `/src/traits.jl` the issue is that `Val{L}` is not instantiated (i.e., ought to have been `Val{L}()`) and beyond that that there isn't even a `unroll_tuple(::Any, ::Val)` method to call.