### PR TITLE
Mark typeintersect pure for Julia 1.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
       matrix:
         version:
           - '1.6'
+          - '~1.9.0-0'
           - '1'
           - 'nightly'
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StaticArrays"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "1.5.21"
+version = "1.5.22"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/arraymath.jl
+++ b/src/arraymath.jl
@@ -1,4 +1,4 @@
-@inline zeros(::Type{SA}) where {SA <: StaticArray{<:Tuple}} = zeros(Base.typeintersect(SA, AbstractArray{Float64}))
+@inline zeros(::Type{SA}) where {SA <: StaticArray{<:Tuple}} = zeros(typeintersect(SA, AbstractArray{Float64}))
 @inline zeros(::Type{SA}) where {SA <: StaticArray{<:Tuple, T}} where T = _zeros(Size(SA), SA)
 @generated function _zeros(::Size{s}, ::Type{SA}) where {s, SA <: StaticArray}
     T = eltype(SA)
@@ -16,7 +16,7 @@
     end
 end
 
-@inline ones(::Type{SA}) where {SA <: StaticArray{<:Tuple}} = ones(Base.typeintersect(SA, AbstractArray{Float64}))
+@inline ones(::Type{SA}) where {SA <: StaticArray{<:Tuple}} = ones(typeintersect(SA, AbstractArray{Float64}))
 @inline ones(::Type{SA}) where {SA <: StaticArray{<:Tuple, T}} where T = _ones(Size(SA), SA)
 @generated function _ones(::Size{s}, ::Type{SA}) where {s, SA <: StaticArray}
     T = eltype(SA)

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -112,7 +112,7 @@ function adapt_size(::Type{SA}, x) where {SA<:StaticArray}
             _no_precise_size(SA, x)
         end
     end
-    SA′ = Base.typeintersect(SA, StaticArrayNoEltype{SZ,tuple_length(SZ)})
+    SA′ = typeintersect(SA, StaticArrayNoEltype{SZ,tuple_length(SZ)})
     SA′ === Union{} && _no_precise_size(SA, x)
     return SA′
 end
@@ -139,7 +139,7 @@ function adapt_eltype(::Type{SA}, x) where {SA<:StaticArray}
     else
         eltype(x)
     end
-    return Base.typeintersect(SA, AbstractArray{T})
+    return typeintersect(SA, AbstractArray{T})
 end
 
 need_rewrap(::Type{<:StaticArray}, x) = false

--- a/src/util.jl
+++ b/src/util.jl
@@ -4,6 +4,12 @@ else
     const var"@_inline_meta" = Base.var"@inline"
 end
 
+# Julia 1.9 removed the `@pure` annotation in favor off Concrete-Eval
+# This behaves unfavorable with `julia --check-bounds=no`
+Base.@pure function typeintersect(@nospecialize(a),@nospecialize(b))
+    Base.typeintersect(a,b)
+end
+
 # For convenience
 TupleN{T,N} = NTuple{N,T}
 

--- a/src/util.jl
+++ b/src/util.jl
@@ -4,7 +4,7 @@ else
     const var"@_inline_meta" = Base.var"@inline"
 end
 
-# Julia 1.9 removed the `@pure` annotation in favor off Concrete-Eval
+# Julia 1.9 removed the `@pure` annotation in favor of Concrete-Eval
 # This behaves unfavorable with `julia --check-bounds=no`
 Base.@pure function typeintersect(@nospecialize(a),@nospecialize(b))
     Base.typeintersect(a,b)
@@ -19,7 +19,7 @@ TupleN{T,N} = NTuple{N,T}
 
 # Base gives up on tuples for promote_eltype... (TODO can we improve Base?)
 _TupleOf{T} = Tuple{T,Vararg{T}}
-promote_tuple_eltype(::Union{_TupleOf{T}, Type{<:_TupleOf{T}}}) where {T} = T 
+promote_tuple_eltype(::Union{_TupleOf{T}, Type{<:_TupleOf{T}}}) where {T} = T
 @generated function promote_tuple_eltype(::Union{T,Type{T}}) where T <: Tuple
     t = Union{}
     for i = 1:length(T.parameters)

--- a/test/check_bounds_no.jl
+++ b/test/check_bounds_no.jl
@@ -1,0 +1,16 @@
+module TestCheckBoundsNo
+
+using Test
+using StaticArrays
+
+# https://github.com/JuliaArrays/StaticArrays.jl/issues/1155
+@testset "Issue #1155" begin
+  u = @inferred(SVector(1, 2))
+  v = @inferred(SVector(3.0, 4.0))
+  a = 1.0
+  b = 2
+  result = @inferred(a * u + b * v)
+  @test result ≈ @inferred(SVector(7, 10))
+end
+
+end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -66,6 +66,13 @@ if TEST_GROUP ∈ ["", "all", "group-A"]
     addtests("inv.jl")
     addtests("pinv.jl")
     addtests("solve.jl")
+
+    # special logic required since we need to start a new
+    # Julia process for these tests
+    if isempty(enabled_tests) || "check_bounds_no" in enabled_tests
+        Random.seed!(42)
+        run(`$(Base.julia_cmd()) --check-bounds=no $(abspath("check_bounds_no.jl"))`)
+    end
 end
 
 if TEST_GROUP ∈ ["", "all", "group-B"]


### PR DESCRIPTION
Fixes the concrete issue in #1155.

Julia 1.9 favors concrete-eval over constant propagation.
Furthermore the effect system was powered up and [many `@pure` annotation were removed](https://github.com/JuliaLang/julia/pull/44776).

With `--check-bounds=no` [concrete-eval is disabled](https://github.com/JuliaLang/julia/blob/8419b5042690fda143f366d09e4b0ee3f275efc7/base/compiler/abstractinterpretation.jl#L804)
and we rely entirely on const-prop, which seems to struggle whithout the `@pure` annotation.

@aviatesk would it be feasible to consider the effects for directing const-prop? We have two situations
where the reliance on concrete-eval has shown itself to be problematic. GPU code with custom method-tables,
and `--check-bounds=no`. 

In Julia 1.10 [`@pure` is deprecated](https://github.com/JuliaLang/julia/pull/48682) and the testcase in #1155
fails again.

