### PR TITLE
Avoid runtime static parameters inference during dynamic dispatch of `SVector{k}`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StaticArrays"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "1.5.22"
+version = "1.5.23"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StaticArrays"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "1.5.21"
+version = "1.5.22"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -166,7 +166,7 @@ end
     SA′ = construct_type(SA, sa)
     need_rewrap(SA′, sa) ? SA′((sa,)) : SA′(Tuple(sa))
 end
-@propagate_inbounds (::Type{SA})(a::AbstractArray) where {SA <: StaticArray} = convert(SA, a)
+@propagate_inbounds (T::Type{<:StaticArray})(a::AbstractArray) = convert(T, a)
 
 # this covers most conversions and "statically-sized reshapes"
 @inline function convert(::Type{SA}, sa::StaticArray{S}) where {SA<:StaticArray,S<:Tuple}


### PR DESCRIPTION
Fixes #1148 by implementing @N5N3 's suggestion.