### PR TITLE
Fix norm of StaticArrays with non-finite elements

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StaticArrays"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "1.5.24"
+version = "1.5.25"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -231,7 +231,7 @@ end
 
     m = maxabs_nested(a[1])
     for j = 2:prod(size(a))
-        m = @fastmath max(m, maxabs_nested(a[j]))
+        m = max(m, maxabs_nested(a[j]))
     end
 
     return m
@@ -246,6 +246,7 @@ end
     return quote
         $(Expr(:meta, :inline))
         scale = maxabs_nested(a)
+        !isfinite(scale) && return scale
 
         iszero(scale) && return _init_zero(a)
         return @inbounds scale * sqrt($expr)

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -318,6 +318,23 @@ end
         @test norm(SA[SVector{0,Int}(),SVector{0,Int}()]) isa float(Int)
         @test norm(SA[SVector{0,Int}(),SVector{0,Int}()]) == norm([Int[], Int[]])
 
+        # norm of SVector with NaN and/or Inf elements -- issue #1135
+        @test isnan(norm(SA[0.0, NaN]))
+        @test isnan(norm(SA[NaN, 0.0]))
+        @test norm(SA[0.0, Inf]) == Inf
+        @test norm(SA[Inf, 0.0]) == Inf
+        @test norm(SA[0.0, -Inf]) == Inf
+        @test norm(SA[-Inf, 0.0]) == Inf
+        @test norm(SA[Inf, Inf]) == Inf
+        @test norm(SA[-Inf, -Inf]) == Inf
+        @test norm(SA[Inf, -Inf]) == Inf
+        @test norm(SA[-Inf, Inf]) == Inf
+        @test isnan(norm(SA[Inf, NaN]))
+        @test isnan(norm(SA[NaN, Inf]))
+        @test isnan(norm(SA[-Inf, NaN]))
+        @test isnan(norm(SA[NaN, -Inf]))
+        @test isapprox(SA[0.0, NaN], SA[0.0, NaN], nans=true)
+
         # no allocation for MArray -- issue #1126
 
         @inline function calc_particle_forces!(s, pos1, pos2)


### PR DESCRIPTION
Fixes #1135 by making the functionality introduced in #975 play nicer with arrays that contain `NaN` or `(±)Inf` elements. This removes an unexpected dependence of the return of `norm()` on the ordering of the elements in these cases, and also makes the results consistent with regular Julia arrays.

(Thanks to @rmkn85 for the help in tracing the cause of this one)

EDIT: fix typos