### PR TITLE
make `@SVector` and `@SMatrix` calls default to `Float64` to match Base

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StaticArrays"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "1.5.25"
+version = "1.5.26"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/SMatrix.jl
+++ b/src/SMatrix.jl
@@ -71,7 +71,7 @@ function static_matrix_gen(::Type{SM}, @nospecialize(ex), mod::Module) where {SM
         f = ex.args[1]
         if f === :zeros || f === :ones || f === :rand || f === :randn || f === :randexp
             if length(ex.args) == 3
-                return :($f($SM{$(escall(ex.args[2:3])...)}))
+                return :($f($SM{$(escall(ex.args[2:3])...), Float64})) # default to Float64 like Base
             elseif length(ex.args) == 4
                 return :($f($SM{$(escall(ex.args[[3,4,2]])...)}))
             else

--- a/src/SVector.jl
+++ b/src/SVector.jl
@@ -76,7 +76,7 @@ function static_vector_gen(::Type{SV}, @nospecialize(ex), mod::Module) where {SV
         f = ex.args[1]
         if f === :zeros || f === :ones || f === :rand || f === :randn || f === :randexp
             if length(ex.args) == 2
-                return :($f($SV{$(esc(ex.args[2]))}))
+                return :($f($SV{$(esc(ex.args[2])), Float64})) # default to Float64 like Base
             elseif length(ex.args) == 3
                 return :($f($SV{$(escall(ex.args[3:-1:2])...)}))
             else


### PR DESCRIPTION
This makes calls to `zeros`, `ones`, `rand`, and friend default to `Float64`
similar to Base. This can be a source of type instability when used
in the single argument version, and it is not transparent as to why.
Making `Float64` the default eliminates this source of error for the user.

Closes: https://github.com/JuliaArrays/StaticArrays.jl/issues/1164
