### PR TITLE
only precompile on Julia version less than v1.9

### DIFF
--- a/src/StaticArrays.jl
+++ b/src/StaticArrays.jl
@@ -133,7 +133,9 @@ include("flatten.jl")
 include("io.jl")
 include("pinv.jl")
 
-include("precompile.jl")
-_precompile_()
+@static if VERSION < v"1.9"
+    include("precompile.jl")
+    _precompile_()
+end
 
 end # module


### PR DESCRIPTION
In the post 1.9 era, we do not have to be prescriptive
about precompiles within the package. We can save some
overall loading time/meory use and allow down stream
packages to determine the precompilation sigantures.
