### PR TITLE
remove redundant `transpose`/`adjoint` methods for `Lower/UpperTriangular`

### DIFF
--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -1,21 +1,5 @@
 const StaticULT{TA} = Union{UpperTriangular{TA,<:StaticMatrix},LowerTriangular{TA,<:StaticMatrix},UnitUpperTriangular{TA,<:StaticMatrix},UnitLowerTriangular{TA,<:StaticMatrix}}
 
-@inline transpose(A::LowerTriangular{<:Any,<:StaticMatrix}) =
-    UpperTriangular(transpose(A.data))
-@inline adjoint(A::LowerTriangular{<:Any,<:StaticMatrix}) =
-    UpperTriangular(adjoint(A.data))
-@inline transpose(A::UnitLowerTriangular{<:Any,<:StaticMatrix}) =
-    UnitUpperTriangular(transpose(A.data))
-@inline adjoint(A::UnitLowerTriangular{<:Any,<:StaticMatrix}) =
-    UnitUpperTriangular(adjoint(A.data))
-@inline transpose(A::UpperTriangular{<:Any,<:StaticMatrix}) =
-    LowerTriangular(transpose(A.data))
-@inline adjoint(A::UpperTriangular{<:Any,<:StaticMatrix}) =
-    LowerTriangular(adjoint(A.data))
-@inline transpose(A::UnitUpperTriangular{<:Any,<:StaticMatrix}) =
-    UnitLowerTriangular(transpose(A.data))
-@inline adjoint(A::UnitUpperTriangular{<:Any,<:StaticMatrix}) =
-    UnitLowerTriangular(adjoint(A.data))
 @inline Base.:*(A::Adjoint{<:Any,<:StaticVector}, B::StaticULT{<:Any}) =
     adjoint(adjoint(B) * adjoint(A))
 @inline Base.:*(A::Transpose{<:Any,<:StaticVector}, B::StaticULT{<:Any}) =


### PR DESCRIPTION
@dkarrasch pointed out that these methods [have existed in Base](https://github.com/JuliaLang/julia/blob/7eb358e79967efb9a07b53f592c329139da7706a/stdlib/LinearAlgebra/src/triangular.jl#L399-L406C75) since at least v1.6, so there's no reason for them to be duplicated here (and StaticArrays assumes v1.6 already).