### PR TITLE
Handle Statistics dep as Pkg extension

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,12 +1,18 @@
 name = "StaticArrays"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "1.5.26"
+version = "1.5.27"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
+[weakdeps]
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
+[extensions]
+StaticArraysStatisticsExt = "Statistics"
 
 [compat]
 julia = "1.6"

--- a/Project.toml
+++ b/Project.toml
@@ -26,4 +26,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [targets]
-test = ["InteractiveUtils", "Test", "BenchmarkTools", "OffsetArrays", "Unitful"]
+test = ["InteractiveUtils", "Test", "BenchmarkTools", "OffsetArrays", "Statistics", "Unitful"]

--- a/Project.toml
+++ b/Project.toml
@@ -22,6 +22,7 @@ StaticArraysCore = "~1.4.0"
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StaticArrays"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "1.5.27"
+version = "1.6.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/ext/StaticArraysStatisticsExt.jl
+++ b/ext/StaticArraysStatisticsExt.jl
@@ -3,6 +3,7 @@ module StaticArraysStatisticsExt
 import Statistics: mean
 
 using StaticArrays
+using StaticArrays: _InitialValue, _reduce, _mapreduce
 
 _mean_denom(a, ::Colon) = length(a)
 _mean_denom(a, dims::Int) = size(a, dims)

--- a/ext/StaticArraysStatisticsExt.jl
+++ b/ext/StaticArraysStatisticsExt.jl
@@ -8,7 +8,6 @@ using StaticArrays: _InitialValue, _reduce, _mapreduce
 _mean_denom(a, ::Colon) = length(a)
 _mean_denom(a, dims::Int) = size(a, dims)
 _mean_denom(a, ::Val{D}) where {D} = size(a, D)
-_mean_denom(a, ::Type{Val{D}}) where {D} = size(a, D)
 
 @inline mean(a::StaticArray; dims=:) = _reduce(+, a, dims) / _mean_denom(a, dims)
 @inline mean(f::Function, a::StaticArray; dims=:) = _mapreduce(f, +, dims, _InitialValue(), Size(a), a) / _mean_denom(a, dims)

--- a/ext/StaticArraysStatisticsExt.jl
+++ b/ext/StaticArraysStatisticsExt.jl
@@ -1,0 +1,15 @@
+module StaticArraysStatisticsExt
+
+import Statistics: mean
+
+using StaticArrays
+
+_mean_denom(a, ::Colon) = length(a)
+_mean_denom(a, dims::Int) = size(a, dims)
+_mean_denom(a, ::Val{D}) where {D} = size(a, D)
+_mean_denom(a, ::Type{Val{D}}) where {D} = size(a, D)
+
+@inline mean(a::StaticArray; dims=:) = _reduce(+, a, dims) / _mean_denom(a, dims)
+@inline mean(f::Function, a::StaticArray; dims=:) = _mapreduce(f, +, dims, _InitialValue(), Size(a), a) / _mean_denom(a, dims)
+
+end # module

--- a/src/StaticArrays.jl
+++ b/src/StaticArrays.jl
@@ -133,6 +133,10 @@ include("flatten.jl")
 include("io.jl")
 include("pinv.jl")
 
+@static if !isdefined(Base, :get_extension) # VERSION < v"1.9-"
+    include("../ext/StaticArraysStatisticsExt.jl")
+end
+
 include("precompile.jl")
 _precompile_()
 

--- a/src/StaticArrays.jl
+++ b/src/StaticArrays.jl
@@ -8,8 +8,6 @@ import Base: getindex, setindex!, size, similar, vec, show, length, convert, pro
              iszero, sum, prod, count, any, all, minimum, maximum, extrema,
              copy, read, read!, write, reverse
 
-import Statistics: mean
-
 using Random
 import Random: rand, randn, randexp, rand!, randn!, randexp!
 using Core.Compiler: return_type

--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -301,14 +301,6 @@ reduce(::typeof(hcat), A::StaticArray{<:Tuple,<:StaticVecOrMatLike}) =
 
 @inline Base.in(x, a::StaticArray) = _mapreduce(==(x), |, :, false, Size(a), a)
 
-_mean_denom(a, dims::Colon) = length(a)
-_mean_denom(a, dims::Int) = size(a, dims)
-_mean_denom(a, ::Val{D}) where {D} = size(a, D)
-_mean_denom(a, ::Type{Val{D}}) where {D} = size(a, D)
-
-@inline mean(a::StaticArray; dims=:) = _reduce(+, a, dims) / _mean_denom(a, dims)
-@inline mean(f::Function, a::StaticArray; dims=:) = _mapreduce(f, +, dims, _InitialValue(), Size(a), a) / _mean_denom(a, dims)
-
 @inline minimum(a::StaticArray; dims=:) = _reduce(min, a, dims) # base has mapreduce(identity, scalarmin, a)
 @inline minimum(f::Function, a::StaticArray; dims=:) = _mapreduce(f, min, dims, _InitialValue(), Size(a), a)
 

--- a/test/svd.jl
+++ b/test/svd.jl
@@ -78,7 +78,11 @@ using StaticArrays, Test, LinearAlgebra
         # This only seems to work on v"1.5" due to unknown compiler improvements; seems
         # to have stopped working again on v"1.6" and later?
         svd_full_false(A) = svd(A, full=false)
-        @test_broken @inferred(svd_full_false(m_sing2)).S ≈ svd(Matrix(m_sing2)).S
+        if VERSION < v"1.10-"
+            @test svd_full_false(m_sing2).S ≈ svd(Matrix(m_sing2)).S
+        else
+            @test @inferred(svd_full_false(m_sing2)).S ≈ svd(Matrix(m_sing2)).S
+        end
 
         @testinf svd(mc_sing) \ v ≈ svd(Matrix(mc_sing)) \ Vector(v)
         @testinf svd(mc_sing) \ vc ≈ svd(Matrix(mc_sing)) \ Vector(vc)


### PR DESCRIPTION
I think this is a no-brainer. It doesn't cost anything in terms of functionality, but reduces package load time significantly on Julia v1.9+. One could still decide later on to remove this or solve this via fallbacks etc., see #1171.