### PR TITLE
Make fallback similar methods less specific in axes

### DIFF
--- a/src/abstractarray.jl
+++ b/src/abstractarray.jl
@@ -139,12 +139,8 @@ similar(::Type{A},::Type{T},s::Size{S}) where {A<:Array,T,S} = sizedarray_simila
 # by simply converting them to either a tuple of Ints or a Size, re-dispatching to either one
 # of the above methods (in the case of Size) or a base fallback (in the case of Ints).
 const HeterogeneousBaseShape = Union{Integer, Base.OneTo}
-const HeterogeneousShape = Union{Integer, Base.OneTo, SOneTo}
-const HeterogeneousShapeTuple = Union{
-    Tuple{SOneTo, Vararg{HeterogeneousShape}},
-    Tuple{HeterogeneousBaseShape, SOneTo, Vararg{HeterogeneousShape}},
-    Tuple{HeterogeneousBaseShape, HeterogeneousBaseShape, SOneTo, Vararg{HeterogeneousShape}}
-}
+const HeterogeneousShape = Union{HeterogeneousBaseShape, SOneTo}
+const HeterogeneousShapeTuple = Tuple{Vararg{HeterogeneousShape}}
 
 similar(A::AbstractArray, ::Type{T}, shape::HeterogeneousShapeTuple) where {T} = similar(A, T, homogenize_shape(shape))
 similar(::Type{A}, shape::HeterogeneousShapeTuple) where {A<:AbstractArray} = similar(A, homogenize_shape(shape))

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -99,7 +99,7 @@ using StaticArrays, Test, LinearAlgebra
             for (ax, sz) in (((SOneTo(2), Base.OneTo(3)), (2,3)),
                                 ((2, SOneTo(2), Base.OneTo(3)), (2,2,3)))
                 for A in (similar(c, Float64, ax), similar(c, Float64, ax...))
-                    @test A isa Matrix{Float64}
+                    @test A isa Array{Float64, length(sz)}
                     @test size(A) == sz
                 end
             end

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -107,6 +107,8 @@ using StaticArrays, Test, LinearAlgebra
             @test similar(c, ()) isa Array{Int,0}
             @test similar(c, Float64, ()) isa Array{Float64,0}
 
+            @test size(similar(zeros(), (1,1,1,SOneTo(1)))) == (1,1,1,1)
+
             # ensure that the more specific Base method works
             @test similar(1:2, ()) isa AbstractArray{Int,0}
         end


### PR DESCRIPTION
The idea of this PR is to make the fallback `similar` method less specific in the axes, to make it easier for packages to extend `similar` for custom array types without encountering ambiguities.

The way the fallback `similar` method is defined currently makes it tricky for custom array types to extend `similar` without running into ambiguities. For example, an array type defined as:
```julia
julia> struct CustomArray{T} <: AbstractVector{T}
                       sz :: Int
                   end

julia> Base.size(C::CustomArray) = (C.sz,)

julia> Base.getindex(C::CustomArray{T}, i::Int) where {T} = T(i)

julia> Base.similar(C::CustomArray, ::Type{T}, ax::Tuple{Vararg{Int}}) where {T} =
                       Array{T}(undef, ax)

julia> function Base.similar(C::CustomArray, ::Type{T}, ax::Tuple{Vararg{Union{Int, SOneTo, Base.OneTo{Int}}}}) where {T}
                       sz = last.(ax)
                       Array{T}(undef, sz)
                   end

julia> c = CustomArray{Int}(4)
4-element CustomArray{Int64}:
 1
 2
 3
 4
```
faces the error
```julia
julia> similar(c, Float64, (SOneTo(2), Base.OneTo(3)))
ERROR: MethodError: similar(::CustomArray{Int64}, ::Type{Float64}, ::Tuple{SOneTo{2}, Base.OneTo{Int64}}) is ambiguous.

Candidates:
  similar(A::AbstractArray, ::Type{T}, shape::Union{Tuple{SOneTo, Vararg{Union{Integer, Base.OneTo, SOneTo}}}, Tuple{Union{Integer, Base.OneTo}, SOneTo, Vararg{Union{Integer, Base.OneTo, SOneTo}}}, Tuple{Union{Integer, Base.OneTo}, Union{Integer, Base.OneTo}, SOneTo, Vararg{Union{Integer, Base.OneTo, SOneTo}}}}) where T
    @ StaticArrays ~/.julia/packages/StaticArrays/80e5O/src/abstractarray.jl:149
  similar(C::CustomArray, ::Type{T}, ax::Tuple{Vararg{Union{Base.OneTo{Int64}, Int64, SOneTo}}}) where T
    @ Main REPL[6]:1

Possible fix, define
  similar(::CustomArray, ::Type{T}, ::Union{Tuple{SOneTo, Vararg{Union{Base.OneTo{Int64}, Int64, SOneTo}}}, Tuple{Union{Base.OneTo{Int64}, Int64}, SOneTo, Vararg{Union{Base.OneTo{Int64}, Int64, SOneTo}}}, Tuple{Union{Base.OneTo{Int64}, Int64}, Union{Base.OneTo{Int64}, Int64}, SOneTo, Vararg{Union{Base.OneTo{Int64}, Int64, SOneTo}}}}) where T

Stacktrace:
 [1] top-level scope
   @ REPL[8]:1
```
After this PR,
```julia
julia> similar(c, Float64, (SOneTo(2), Base.OneTo(3)))
2×3 Matrix{Float64}:
 0.0          6.9398e-310  6.9398e-310
 6.9398e-310  0.0          6.9398e-310
```
This definition of `similar` feels a bit icky, as
```julia
julia> Tuple{} <: StaticArrays.HeterogeneousShapeTuple
true
```
however,
```julia
julia> Tuple{} <: Tuple{Vararg{Int}} <: StaticArrays.HeterogeneousShapeTuple
true
```
and `Base` defines `similar` for `Tuple{Vararg{Int}}`, which is strictly more specific. This makes `similar(::AbstractArray, ::Tuple{})` call the `Base` method.

This PR also makes something like this work:
```julia
julia> similar(zeros(), (1,1,1,SOneTo(1)))
1×1×1×1 Array{Float64, 4}:
[:, :, 1, 1] =
 1.0e-323
```
where the `SOneTo` isn't present in the first three arguments.