### PR TITLE
Test on Julia v1.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         version:
           - '1.6'
-          - '~1.9.0-0'
+          - '~1.10.0-0'
           - '1'
           - 'nightly'
         os:


### PR DESCRIPTION
Since v1 points to v1.9 now, we don't need the explicit test anymore. This PR changes it to the unreleased versions of v1.10