### PR TITLE
Improve type inference for adjoint/transpose of nested matrices

### DIFF
--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -62,6 +62,10 @@ end
 #--------------------------------------------------
 # Matrix algebra
 
+# _adjointtype returns the eltype of the container when computing the adjoint/transpose
+# of a static array. Using this method instead of calling `Base.promote_op` directly
+# helps with type-inference, particularly for nested static arrays,
+# where the adjoint is applied recursively.
 @inline _adjointtype(f, ::Type{T}) where {T} = Base.promote_op(f, T)
 for S in (:SMatrix, :MMatrix)
     @eval @inline _adjointtype(f, ::Type{$S{M,N,T,L}}) where {M,N,T,L} = $S{N,M,_adjointtype(f, T),L}

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -62,6 +62,11 @@ end
 #--------------------------------------------------
 # Matrix algebra
 
+@inline _adjointtype(f, ::Type{T}) where {T} = Base.promote_op(f, T)
+for S in (:SMatrix, :MMatrix)
+    @eval @inline _adjointtype(f, ::Type{$S{M,N,T,L}}) where {M,N,T,L} = $S{N,M,_adjointtype(f, T),L}
+end
+
 # Transpose, etc
 @inline transpose(m::StaticMatrix) = _transpose(Size(m), m)
 # note: transpose of StaticVector is a Transpose, handled by Base
@@ -74,7 +79,7 @@ end
     return quote
         $(Expr(:meta, :inline))
         elements = tuple($(exprs...))
-        @inbounds return similar_type($m, Base.promote_op(transpose, T), Size($(n2,n1)))(elements)
+        @inbounds return similar_type($m, _adjointtype(transpose, T), Size($(n2,n1)))(elements)
     end
 end
 
@@ -88,7 +93,7 @@ end
     return quote
         $(Expr(:meta, :inline))
         elements = tuple($(exprs...))
-        @inbounds return similar_type($m, Base.promote_op(adjoint, T), Size($(n2,n1)))(elements)
+        @inbounds return similar_type($m, _adjointtype(adjoint, T), Size($(n2,n1)))(elements)
     end
 end
 

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -237,6 +237,15 @@ end
         end
         @test adjoint(SMatrix{0,0,Vector{Int}}()) isa SMatrix{0,0,Adjoint{Int,Vector{Int}}}
         @test transpose(SMatrix{0,0,Vector{Int}}()) isa SMatrix{0,0,Transpose{Int,Vector{Int}}}
+
+        @testset "inference for nested matrices" begin
+            A = reshape([reshape([complex(i,2i)*j for i in 1:2], 1, 2) for j in 1:6], 3, 2)
+            for TA in (SMatrix, MMatrix), TB in (SMatrix, MMatrix)
+                S = TA{3,2}(TB{1,2}.(A)) # static matrix of static matrices
+                @test @inferred(transpose(S)) == transpose(A)
+                @test @inferred(adjoint(S)) == adjoint(A)
+            end
+        end
     end
 
     @testset "normalization" begin


### PR DESCRIPTION
This PR special-cases the return-types of the `adjoint` and `transpose` for `SMatrix` and `MMatrix`. This isn't ideal, but currently Julia doesn't infer the return types of certain recursive calls with changing types, and this PR helps with type-inference in such cases.

An example (using this PR):
```julia
julia> S = SMatrix{3,2,SMatrix{1,2,Int,2},6}(fill(SMatrix{1,2,Int,2}(1:2), 6))
3×2 SMatrix{3, 2, SMatrix{1, 2, Int64, 2}, 6} with indices SOneTo(3)×SOneTo(2):
 [1 2]  [1 2]
 [1 2]  [1 2]
 [1 2]  [1 2]

julia> @inferred adjoint(S)
2×3 SMatrix{2, 3, SMatrix{2, 1, Int64, 2}, 6} with indices SOneTo(2)×SOneTo(3):
 [1; 2;;]  [1; 2;;]  [1; 2;;]
 [1; 2;;]  [1; 2;;]  [1; 2;;]
```
Whereas, on master,
```julia
julia> @inferred adjoint(S)
ERROR: return type SMatrix{2, 3, SMatrix{2, 1, Int64, 2}, 6} does not match inferred return type SMatrix{2, 3, _A, 6} where _A
```