### PR TITLE
disable precompiles that fail on julia v1.11

### DIFF
--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -21,13 +21,15 @@ function _precompile_()
         end
     end
 
-    # Some expensive generators
-    @assert precompile(Tuple{typeof(which(__broadcast,(Any,Size,Tuple{Vararg{Size}},Vararg{Any},)).generator.gen),Any,Any,Any,Any,Any,Any})
-    @assert precompile(Tuple{typeof(which(_zeros,(Size,Type{<:StaticArray},)).generator.gen),Any,Any,Any,Type,Any})
-    @assert precompile(Tuple{typeof(which(_mapfoldl,(Any,Any,Colon,Any,Size,Vararg{StaticArray},)).generator.gen),Any,Any,Any,Any,Any,Any,Any,Any})
-
+    # TODO: These fail to precompile on v1.11 pre-release
+    if VERSION < v"1.11.0-0"
+        # Some expensive generators
+        @assert precompile(Tuple{typeof(which(__broadcast,(Any,Size,Tuple{Vararg{Size}},Vararg{Any},)).generator.gen),Any,Any,Any,Any,Any,Any})
+        @assert precompile(Tuple{typeof(which(_zeros,(Size,Type{<:StaticArray},)).generator.gen),Any,Any,Any,Type,Any})
+        @assert precompile(Tuple{typeof(which(_mapfoldl,(Any,Any,Colon,Any,Size,Vararg{StaticArray},)).generator.gen),Any,Any,Any,Any,Any,Any,Any,Any})
+    end
     # broadcast_getindex
-    for m = 0:5, n = m:5 
+    for m = 0:5, n = m:5
         @assert precompile(Tuple{typeof(broadcast_getindex),NTuple{m,Int},Int,CartesianIndex{n}})
     end
 end


### PR DESCRIPTION
Fixes #1182 

Just disables these on v1.11.
Someone familiar with the issue should review and fix if appropriate.