### PR TITLE
Fix precision of 2x2 eigenvectors

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StaticArrays"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "1.6.2"
+version = "1.6.3"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/eigen.jl
+++ b/src/eigen.jl
@@ -161,20 +161,22 @@ end
     TA = eltype(A)
     @inbounds a21 = A.uplo == 'U' ? a[3]' : a[2]
     @inbounds if !iszero(a21) # A is not diagonal
+        # TODO: Note!!!
+        # Not sure about use of real here, 
+        # but at least norm kills the complex part 
+        # of the eigenvalues. 
+        # Probably this should not be the case
         t_half = real(a[1] + a[4]) / 2
         diag_avg_diff = (a[1] - a[4])/2
         tmp = norm(SVector(diag_avg_diff, a21))
         vals = SVector(t_half - tmp, t_half + tmp)
-
-        #v11 = vals[1] - a[4]
         v11 = -tmp + diag_avg_diff
-        n1 = sqrt(v11' * v11 + a21 * a[3])
+        n1 = sqrt(v11' * v11 + a21 * a21')
         v11 = v11 / n1
         v12 = a21 / n1
 
-        #v21 = vals[2] - a[4]
         v21 = tmp + diag_avg_diff
-        n2 = sqrt(v21' * v21 + a21 * a[3])
+        n2 = sqrt(v21' * v21 + a21 * a21')
         v21 = v21 / n2
         v22 = a21 / n2
 

--- a/src/eigen.jl
+++ b/src/eigen.jl
@@ -161,11 +161,6 @@ end
     TA = eltype(A)
     @inbounds a21 = A.uplo == 'U' ? a[3]' : a[2]
     @inbounds if !iszero(a21) # A is not diagonal
-        # TODO: Note!!!
-        # Not sure about use of real here, 
-        # but at least norm kills the complex part 
-        # of the eigenvalues. 
-        # Probably this should not be the case
         t_half = real(a[1] + a[4]) / 2
         diag_avg_diff = (a[1] - a[4])/2
         tmp = norm(SVector(diag_avg_diff, a21))

--- a/src/eigen.jl
+++ b/src/eigen.jl
@@ -162,15 +162,18 @@ end
     @inbounds if A.uplo == 'U'
         if !iszero(a[3]) # A is not diagonal
             t_half = real(a[1] + a[4]) / 2
-            tmp = norm(SVector((a[1] - a[4])/2, a[3]'))
+            diag_avg_diff = (a[1] - a[4])/2
+            tmp = norm(SVector(diag_avg_diff, a[3]'))
             vals = SVector(t_half - tmp, t_half + tmp)
 
-            v11 = vals[1] - a[4]
+            #v11 = vals[1] - a[4]
+            v11 = -tmp + diag_avg_diff
             n1 = sqrt(v11' * v11 + a[3]' * a[3])
             v11 = v11 / n1
             v12 = a[3]' / n1
 
-            v21 = vals[2] - a[4]
+            #v21 = vals[2] - a[4]
+            v21 = tmp + diag_avg_diff
             n2 = sqrt(v21' * v21 + a[3]' * a[3])
             v21 = v21 / n2
             v22 = a[3]' / n2

--- a/test/eigen.jl
+++ b/test/eigen.jl
@@ -83,6 +83,25 @@ using StaticArrays, Test, LinearAlgebra
             @test eigvecs(E) * SDiagonal(eigvals(E)) * eigvecs(E)' ≈ A
         end
 
+        # issue #956
+        v1, v2 = let A = SMatrix{2,2}((1.0, 1e-100, 1e-100, 1.0))
+            vecs = eigvecs(eigen(Hermitian(A)))
+            vecs[:,1], vecs[:,2]
+        end
+        @test norm(v1) ≈ 1
+        @test norm(v2) ≈ 1
+        @test acos(v1 ⋅ v2)*2 ≈ π
+
+        # Test that correct value is taken for upper or lower sym 
+        for T in (Float64, Complex{Float64})
+            af = SMatrix{2,2}(rand(T, 4))
+            a = af + af' # Make hermitian
+            au = Hermitian(SMatrix{2,2}((a[1,1], zero(T), a[1,2], a[2,2])), 'U')
+            al = Hermitian(SMatrix{2,2}((a[1,1], a[2,1], zero(T), a[2,2])), 'L')
+            @test eigvals(eigen(a)) ≈ eigvals(eigen(au)) ≈ eigvals(eigen(al))
+            @test eigvals(eigen(a)) ≈ eigvals(eigen(au)) ≈ eigvals(eigen(al))
+        end
+
         m1_a = randn(2,2)
         m1_a = m1_a*m1_a'
         m1 = SMatrix{2,2}(m1_a)

--- a/test/initializers.jl
+++ b/test/initializers.jl
@@ -50,7 +50,11 @@ if VERSION >= v"1.7.0"
     @test SA[1 2;1 2 ;;; 1 2;1 2] === SArray{Tuple{2,2,2}}(Tuple([1 2;1 2 ;;; 1 2;1 2]))
     @test_inlined SA_test_hvncat1(3)
     @test_inlined SA_test_hvncat2(2)
-    @test_throws ArgumentError SA[1;2;;3]
+    if VERSION < v"1.10-DEV"
+        @test_throws ArgumentError SA[1;2;;3]
+    else
+        @test_throws DimensionMismatch SA[1;2;;3]
+    end
 end
 
 # https://github.com/JuliaArrays/StaticArrays.jl/pull/685


### PR DESCRIPTION
Fixes #956 by subtracting mean diagonal (draft because for now only for `A.uplo == 'U'`, see question below)

`a = SMatrix{2,2}((1.0, 1e-100, 1e-100, 1.0))`
Master (fast, but incorrect)
```julia
@btime eigen($a)
9.510 ns (0 allocations: 0 bytes)
eigen(a)
Eigen{Float64, Float64, SMatrix{2, 2, Float64, 4}, SVector{2, Float64}}
values:
2-element SVector{2, Float64} with indices SOneTo(2):
 1.0
 1.0
vectors:
2×2 SMatrix{2, 2, Float64, 4} with indices SOneTo(2)×SOneTo(2):
 0.0  0.0
 1.0  1.0
```

PR (slower, but correct)
```julia
julia> @btime eigen($a)
  11.011 ns (0 allocations: 0 bytes)

julia> eigen(a)
Eigen{Float64, Float64, SMatrix{2, 2, Float64, 4}, SVector{2, Float64}}
values:
2-element SVector{2, Float64} with indices SOneTo(2):
 1.0
 1.0
vectors:
2×2 SMatrix{2, 2, Float64, 4} with indices SOneTo(2)×SOneTo(2):
 -0.707107  0.707107
  0.707107  0.707107
```

# Question
Why is the algorithm split between upper and lower diagonal, should be easier to do 
```julia
a21 = A.uplo == 'U' ? a[3]' : a[2]
```
And then the algorithms are equal. 

For now, I have only changed the algorithm for upper diagonal entry (hence draft), + no tests are added yet. Once I understand this choice, I can finish it up! 