### PR TITLE
union and intersect for SOneTo

### DIFF
--- a/src/SOneTo.jl
+++ b/src/SOneTo.jl
@@ -78,3 +78,6 @@ Base.promote_rule(a::Type{Base.OneTo{T}}, ::Type{SOneTo{n}}) where {T,n} =
 function Base.reduced_indices(inds::Tuple{SOneTo,Vararg{SOneTo}}, d::Int)
     Base.reduced_indices(map(Base.OneTo, inds), d)
 end
+
+Base.intersect(r::SOneTo{n1}, s::SOneTo{n2}) where {n1,n2} = SOneTo(min(n1, n2))
+Base.union(r::SOneTo{n1}, s::SOneTo{n2}) where {n1,n2} = SOneTo(max(n1, n2))

--- a/test/core.jl
+++ b/test/core.jl
@@ -206,7 +206,7 @@
         @test_throws DimensionMismatch StaticArrays.SOneTo{2}(1:3)
         @test_throws DimensionMismatch StaticArrays.SOneTo{2}(1:1)
 
-        @test @inferred(intersect(SOneTo(2), SOneTo(4))) == SOneTo(2)
-        @test @inferred(union(SOneTo(2), SOneTo(4))) == SOneTo(4)
+        @test @inferred(intersect(SOneTo(2), SOneTo(4))) === SOneTo(2)
+        @test @inferred(union(SOneTo(2), SOneTo(4))) === SOneTo(4)
     end
 end

--- a/test/core.jl
+++ b/test/core.jl
@@ -205,5 +205,8 @@
         @test convert(StaticArrays.SOneTo{2}, 1:2) === StaticArrays.SOneTo{2}()
         @test_throws DimensionMismatch StaticArrays.SOneTo{2}(1:3)
         @test_throws DimensionMismatch StaticArrays.SOneTo{2}(1:1)
+
+        @test @inferred(intersect(SOneTo(2), SOneTo(4))) == SOneTo(2)
+        @test @inferred(union(SOneTo(2), SOneTo(4))) == SOneTo(4)
     end
 end


### PR DESCRIPTION
This matches the behavior of `Base.OneTo`. After this,
```julia
julia> intersect(SOneTo(3), SOneTo(5))
SOneTo(3)

julia> union(SOneTo(3), SOneTo(5))
SOneTo(5)
```