### PR TITLE
Remove `eye` from the docs, update around `@SVector` and `@SMatrix` docs

### DIFF
--- a/docs/src/pages/api.md
+++ b/docs/src/pages/api.md
@@ -16,7 +16,7 @@ where you can use native Julia array literals syntax, comprehensions, and the
 macro, and must be made of combinations of literal values, functions, or global
 variables, but is not limited to just simple ranges. Extending this to
 (hopefully statically known by type-inference) local-scope variables is hoped
-for the future. The `zeros()`, `ones()`, `fill()`, `rand()` and `randn()` functions do not have this
+for the future. The `zeros()`, `ones()`, `fill()`, `rand()`, `randn()`, and `randexp()` functions do not have this
 limitation.)
 
 ### `SMatrix`
@@ -28,7 +28,7 @@ convenience constructors are provided, so that `L`, `T` and even `M` are
 unnecessary. At minimum, you can type `SMatrix{2}(1,2,3,4)` to create a 2×2
 matrix (the total number of elements must divide evenly into `N`). A
 convenience macro `@SMatrix [1 2; 3 4]` is provided (which also accepts
-comprehensions and the `zeros()`, `ones()`, `fill()`, `rand()`, `randn()` and `eye()`
+comprehensions and the `zeros()`, `ones()`, `fill()`, `rand()`, `randn()`, and `randexp()`
 functions).
 
 ### `SArray`

--- a/docs/src/pages/quickstart.md
+++ b/docs/src/pages/quickstart.md
@@ -40,7 +40,7 @@ a = @SArray randn(2, 2, 2, 2, 2, 2)
 # Supports all the common operations of AbstractArray
 v7 = v1 + v2
 v8 = sin.(v3)
-v3 == m3 * v3 # recall that m3 = eye(SMatrix{3,3})
+v3 == m3 * v3 # recall that m3 = SMatrix{3,3}(1I)
 # map, reduce, broadcast, map!, broadcast!, etc...
 
 # Indexing can also be done using static arrays of integers


### PR DESCRIPTION
[`eye`](https://docs.julialang.org/en/v0.6/stdlib/arrays/#Base.eye) was removed in Julia v1.0. :wink: