### PR TITLE
Generalize broadcasting to `StaticMatrixLike`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StaticArrays"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "1.6.5"
+version = "1.7.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/abstractarray.jl
+++ b/src/abstractarray.jl
@@ -8,13 +8,10 @@ length(a::Type{SA}) where {SA <: StaticArrayLike} = prod(Size(SA))::Int
 end
 @inline size(a::StaticArrayLike) = Tuple(Size(a))
 
-Base.axes(s::StaticArray) = _axes(Size(s))
+Base.axes(s::StaticArrayLike) = _axes(Size(s))
 @pure function _axes(::Size{sizes}) where {sizes}
     map(SOneTo, sizes)
 end
-Base.axes(rv::Adjoint{<:Any,<:StaticVector})   = (SOneTo(1), axes(rv.parent)...)
-Base.axes(rv::Transpose{<:Any,<:StaticVector}) = (SOneTo(1), axes(rv.parent)...)
-Base.axes(d::Diagonal{<:Any,<:StaticVector}) = (ax = axes(d.diag, 1); (ax, ax))
 
 Base.eachindex(::IndexLinear, a::StaticArray) = SOneTo(length(a))
 

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -9,9 +9,7 @@ import Base.Broadcast: _bcs1  # for SOneTo axis information
 using Base.Broadcast: _bcsm
 
 BroadcastStyle(::Type{<:StaticArray{<:Tuple, <:Any, N}}) where {N} = StaticArrayStyle{N}()
-BroadcastStyle(::Type{<:Transpose{<:Any, <:StaticArray}}) = StaticArrayStyle{2}()
-BroadcastStyle(::Type{<:Adjoint{<:Any, <:StaticArray}}) = StaticArrayStyle{2}()
-BroadcastStyle(::Type{<:Diagonal{<:Any, <:StaticArray{<:Tuple, <:Any, 1}}}) = StaticArrayStyle{2}()
+BroadcastStyle(::Type{<:StaticMatrixLike}) = StaticArrayStyle{2}()
 # Precedence rules
 BroadcastStyle(::StaticArrayStyle{M}, ::DefaultArrayStyle{N}) where {M,N} =
     DefaultArrayStyle(Val(max(M, N)))
@@ -104,10 +102,7 @@ function broadcast_getindex(oldsize::Tuple, i::Int, newindex::CartesianIndex)
     return :(a[$i][$ind])
 end
 
-isstatic(::StaticArray) = true
-isstatic(::Transpose{<:Any, <:StaticArray}) = true
-isstatic(::Adjoint{<:Any, <:StaticArray}) = true
-isstatic(::Diagonal{<:Any, <:StaticArray}) = true
+isstatic(::StaticArrayLike) = true
 isstatic(_) = false
 
 @inline first_statictype(x, y...) = isstatic(x) ? typeof(x) : first_statictype(y...)

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -10,6 +10,20 @@ using StaticArrays, Test, LinearAlgebra
         @test eachindex(m) isa SOneTo
     end
 
+    @testset "axes" begin
+        v = @SVector [1, 2, 3]
+        @test @inferred(axes(v)) == (SOneTo(3),)
+        for T in (Adjoint, Transpose)
+            @test @inferred(axes(T(v))) == (SOneTo(1), SOneTo(3))
+        end
+
+        m = @SMatrix [1 2; 3 4]
+        @test @inferred(axes(m)) == (SOneTo(2), SOneTo(2))
+        for T in (Adjoint, Transpose, Diagonal, Symmetric, Hermitian, UpperTriangular, LowerTriangular, UnitUpperTriangular, UnitLowerTriangular)
+            @test @inferred(axes(T(m))) == (SOneTo(2), SOneTo(2))
+        end
+    end
+
     @testset "strides" begin
         m1 = MArray{Tuple{3, 4, 5}}(rand(Int, 3, 4, 5))
         m2 = SizedArray{Tuple{3,4,5}}(rand(Int, 3, 4, 5))


### PR DESCRIPTION
Currently, broadcasting with `StaticMatrixLike`-types does not always return `SMatrix` results:
```julia
julia> using StaticArrays, LinearAlgebra

julia> Symmetric(@SMatrix [1 2; 3 4]) .+ 1
2×2 Matrix{Int64}:
 2  3
 3  5

julia> Symmetric(@SMatrix [1 2; 3 4]) .+ @SVector [5, 6]
2×2 Matrix{Int64}:
 6   7
 8  10

julia> Symmetric(@SMatrix [1 2; 3 4]) .+ @SMatrix [5 6; 7 8]
2×2 SizedMatrix{2, 2, Int64, 2, Matrix{Int64}} with indices SOneTo(2)×SOneTo(2):
 6   8
 9  12
```

The PR fixes this by generalizing definitions of `BroadcastStyle`, `isstatic`, and `axes` to `StaticMatrixLike`:
```julia
julia> using StaticArrays, LinearAlgebra

julia> Symmetric(@SMatrix [1 2; 3 4]) .+ 1
2×2 SMatrix{2, 2, Int64, 4} with indices SOneTo(2)×SOneTo(2):
 2  3
 3  5

julia> Symmetric(@SMatrix [1 2; 3 4]) .+ @SVector [5, 6]
2×2 SMatrix{2, 2, Int64, 4} with indices SOneTo(2)×SOneTo(2):
 6   7
 8  10

julia> Symmetric(@SMatrix [1 2; 3 4]) .+ @SMatrix [5 6; 7 8]
2×2 SMatrix{2, 2, Int64, 4} with indices SOneTo(2)×SOneTo(2):
 6   8
 9  12
```