### PR TITLE
Handle the rrule for SVector{}(....)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StaticArrays"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "1.8.0"
+version = "1.8.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/ext/StaticArraysChainRulesCoreExt.jl
+++ b/ext/StaticArraysChainRulesCoreExt.jl
@@ -29,4 +29,10 @@ function rrule(::Type{T}, x::Tuple) where {T <: SArray}
     return T(x), ∇Array
 end
 
+function rrule(::Type{T}, xs::Number...) where {T <: SVector}
+    project_x = ProjectTo(xs)
+    ∇Array(∂y) = (NoTangent(), project_x(∂y)...)
+    return T(xs...), ∇Array
+end
+
 end

--- a/test/chainrules.jl
+++ b/test/chainrules.jl
@@ -6,5 +6,7 @@ using StaticArrays, ChainRulesCore, ChainRulesTestUtils, Test
         test_rrule(SMatrix{4, 1}, (1.0, 1.0, 1.0, 1.0))
         test_rrule(SMatrix{2, 2}, (1.0, 1.0, 1.0, 1.0))
         test_rrule(SVector{4}, (1.0, 1.0, 1.0, 1.0))
+        test_rrule(SVector{4}, 1.0, 1.0, 1.0, 1.0)
+        test_rrule(SVector{4}, 1.0, 1.0f0, 1.0, 1.0f0)
     end
 end


### PR DESCRIPTION
Based on the comment https://github.com/JuliaArrays/StaticArrays.jl/commit/91f4857cddbdec7fdbe32ea9f4ef7506ed2bc8b0#commitcomment-135109496

@Larbino1 do you have some other tests to try it on?