### PR TITLE
Specialize `zeros`/`ones`/`fill` for `SOneTo`

### DIFF
--- a/src/abstractarray.jl
+++ b/src/abstractarray.jl
@@ -293,20 +293,17 @@ function Base.view(S::SArray, I::Union{Colon, Integer, SOneTo, StaticArray{<:Tup
 end
 
 # zeros, ones and fill may return SArrays if all the axes are statically sized
-for (cf, elf) in ((:zeros, :zero), (:ones, :one))
-    _cf = Symbol(:_, cf)
+for (arrf, elf) in ((:zeros, :zero), (:ones, :one))
+    _arrf = Symbol(:_, arrf)
     @eval begin
-        $_cf(::Type{T}, s::Size) where {T} = similar_type(SArray, T, s)(ntuple(_->$elf(T), prod(s)))
-        # fall back to Base if the size is not statically known
-        $_cf(T, sz) = $cf(T, sz)
-        function $cf(::Type{T}, ax::NTuple{N,HeterogeneousShape}) where {T,N}
-            $_cf(T, homogenize_shape(ax))
+        function $arrf(::Type{T}, ax::Tuple{SOneTo,Vararg{SOneTo}}) where {T}
+            sz = homogenize_shape(ax)
+            similar_type(SArray, T, sz)(ntuple(_->$elf(T), prod(sz)))
         end
     end
 end
 
-_fill(v, s::Size) = similar_type(SArray, typeof(v), s)(ntuple(_->v, prod(s)))
-_fill(v, sz) = fill(v, sz)
-function fill(v, ax::NTuple{N,HeterogeneousShape}) where {N}
-    _fill(v, homogenize_shape(ax))
+function fill(v, ax::Tuple{SOneTo,Vararg{SOneTo}})
+    sz = homogenize_shape(ax)
+    similar_type(SArray, typeof(v), sz)(ntuple(_->v, prod(sz)))
 end

--- a/src/abstractarray.jl
+++ b/src/abstractarray.jl
@@ -292,6 +292,7 @@ function Base.view(S::SArray, I::Union{Colon, Integer, SOneTo, StaticArray{<:Tup
     _maybewrapscalar(S, V)
 end
 
+# zeros, ones and fill may return SArrays if all the axes are statically sized
 for (cf, elf) in ((:zeros, :zero), (:ones, :one))
     _cf = Symbol(:_, cf)
     @eval begin

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -418,3 +418,14 @@ end
         @test b isa Vec{0}
     end
 end
+
+@testset "zeros/ones/fill" begin
+    for ax in ((SOneTo(2),), (SOneTo(2),SOneTo(3)))
+        @test fill(:abc, ax...) === fill(:abc, ax)
+        @test fill(:abc, ax) == fill(:abc, length.(ax)) == fill(:abc, Base.OneTo.(length.(ax)))
+        for fz in (zeros, ones)
+            @test fz(Float32, ax...) === fz(Float32, ax)
+            @test fz(Float32, ax) == fz(Float32, length.(ax)) == fz(Float32, Base.OneTo.(length.(ax)))
+        end
+    end
+end

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -421,10 +421,10 @@ end
 
 @testset "zeros/ones/fill" begin
     for ax in ((SOneTo(2),), (SOneTo(2),SOneTo(3)))
-        @test fill(:abc, ax...) === fill(:abc, ax)
+        @test @inferred(fill(:abc, ax...)) === @inferred(fill(:abc, ax))
         @test fill(:abc, ax) == fill(:abc, length.(ax)) == fill(:abc, Base.OneTo.(length.(ax)))
         for fz in (zeros, ones)
-            @test fz(Float32, ax...) === fz(Float32, ax)
+            @test @inferred(fz(Float32, ax...)) === @inferred(fz(Float32, ax))
             @test fz(Float32, ax) == fz(Float32, length.(ax)) == fz(Float32, Base.OneTo.(length.(ax)))
         end
     end


### PR DESCRIPTION
After this,
```julia
julia> zeros(SOneTo(4))
4-element SVector{4, Float64} with indices SOneTo(4):
 0.0
 0.0
 0.0
 0.0
```
and similarly, `ones` and `fill` also return `SArray`s.