### PR TITLE
Specialize `cconvert` instead of `unsafe_convert`

### DIFF
--- a/src/SizedArray.jl
+++ b/src/SizedArray.jl
@@ -94,7 +94,10 @@ end
 
 Base.parent(sa::SizedArray) = sa.data
 
-Base.unsafe_convert(::Type{Ptr{T}}, sa::SizedArray) where {T} = Base.unsafe_convert(Ptr{T}, sa.data)
+Base.cconvert(P::Type{Ptr{T}}, sa::SizedArray) where {T} = Base.cconvert(P, sa.data)
+if VERSION < v"1.11-"
+    Base.unsafe_convert(::Type{Ptr{T}}, sa::SizedArray) where {T} = Base.unsafe_convert(Ptr{T}, sa.data)
+end
 Base.elsize(::Type{SizedArray{S,T,M,N,A}}) where {S,T,M,N,A} = Base.elsize(A)
 
 Base.dataids(sa::SizedArray) = Base.dataids(sa.data)

--- a/test/SizedArray.jl
+++ b/test/SizedArray.jl
@@ -110,6 +110,7 @@
 
     # pointer
     @testset "pointer" begin
+        @test Base.cconvert(Ptr{Int}, sa) === Base.cconvert(Ptr{Int}, sa.data)
         @test pointer(sa) === pointer(sa.data)
 
         A = MMatrix{32,3,Float64}(undef);


### PR DESCRIPTION
These changes should address some of the breakages related to `pointer` on julia nightly that are reported in https://github.com/JuliaLang/julia/issues/51962