### PR TITLE
Test `arithmetic_closure` against concrete types

### DIFF
--- a/test/arraymath.jl
+++ b/test/arraymath.jl
@@ -7,6 +7,10 @@ end
 Random.rand(rng::AbstractRNG, d::Random.SamplerTrivial{TestDie}) = rand(rng, 1:d[].nsides)
 Base.eltype(::Type{TestDie}) = Int
 
+const AbstractFloatSubtypes = [Float16, Float32, Float64, BigFloat]
+const UnsignedSubtypes = [UInt8, UInt16, UInt32, UInt64, UInt128]
+const SignedSubtypes = [Int8, Int16, Int32, Int64, Int128, BigInt]
+
 @testset "Array math" begin
     @testset "zeros() and ones()" begin
         @test @inferred(zeros(SVector{3,Float64})) === @SVector [0.0, 0.0, 0.0]
@@ -336,13 +340,12 @@ Base.eltype(::Type{TestDie}) = Int
         end
     end
 
-    @testset "arithmetic_closure" for T0 in [subtypes(Unsigned);
-                                             subtypes(Signed);
-                                             subtypes(AbstractFloat);
+    @testset "arithmetic_closure" for T0 in [UnsignedSubtypes;
+                                             SignedSubtypes;
+                                             AbstractFloatSubtypes;
                                              Bool;
                                              Complex{Int};
                                              Complex{Float64};
-                                             BigInt
                                              ]
         T = @inferred arithmetic_closure(T0)
         @test arithmetic_closure(T) == T


### PR DESCRIPTION
On Julia nightly,
```julia
julia> subtypes(AbstractFloat)
5-element Vector{Any}:
 BigFloat
 Core.BFloat16
 Float16
 Float32
 Float64
```
and `Core.BFloat16` does not have `one` defined for itself, which was leading to test failures. It's better to be explicit in the types that we test against, which are known to work.