### PR TITLE
Ignore versioned manifest files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.jl.mem
 /.benchmarkci
 /Manifest.toml
+/Manifest-v*.*.toml
 /benchmark/*.json
 /benchmark/Manifest.toml
 /docs/Manifest.toml


### PR DESCRIPTION
Julia v1.11 supports version-specific Manifest files, so it's better to ignore these files as well in `.gitignore`