### PR TITLE
Remove duplicate tests on v1.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ jobs:
       matrix:
         version:
           - '1.6'
-          - '~1.10.0-0'
           - '1'
           - 'nightly'
         os:


### PR DESCRIPTION
Now that v1 points to v1.10, the explicit tests on v1.10 are redundant