### PR TITLE
Force specialization of dimension_mismatch_fail() on type argument.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StaticArrays"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "1.9.2"
+version = "1.9.3"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -192,7 +192,7 @@ AbstractArray{T,N}(sa::StaticArray{S,U,N}) where {S,T,U,N} = similar_type(typeof
 # Constructing a Tuple from a StaticArray
 @inline Tuple(a::StaticArray) = unroll_tuple(a, Length(a))
 
-@noinline function dimension_mismatch_fail(SA::Type, a::AbstractArray)
+@noinline function dimension_mismatch_fail(::Type{SA}, a::AbstractArray) where {SA <: StaticArray}
     throw(DimensionMismatch("expected input array of length $(length(SA)), got length $(length(a))"))
 end
 


### PR DESCRIPTION
Following #1244 I just went ahead with this small change.

This should improve GPU-compatibility.
Original discussion: https://discourse.julialang.org/t/problems-with-linearalgebra-functions-within-kernelabstractions-and-cuda/97566/5
