### PR TITLE
NamedTuple constructor support for FieldArray subtypes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StaticArrays"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "1.9.2"
+version = "1.9.3"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/FieldArray.jl
+++ b/src/FieldArray.jl
@@ -31,3 +31,7 @@ similar_type(::Type{A}, ::Type{T}, S::Size) where {N, T, A<:FieldArray{N, T}} =
 _fieldarray_similar_type(A, T, NewSize::S, OldSize::S) where {S} = A
 _fieldarray_similar_type(A, T, NewSize, OldSize) =
     default_similar_type(T, NewSize, length_val(NewSize))
+
+# Convenience constructors for NamedTuple types 
+Base.convert(::Type{NamedTuple}, array::FieldArray) = Base.NamedTuple(array)
+Base.NamedTuple(array::FieldArray) = Base.NamedTuple{propertynames(array)}(array)

--- a/src/FieldArray.jl
+++ b/src/FieldArray.jl
@@ -33,5 +33,4 @@ _fieldarray_similar_type(A, T, NewSize, OldSize) =
     default_similar_type(T, NewSize, length_val(NewSize))
 
 # Convenience constructors for NamedTuple types 
-Base.convert(::Type{NamedTuple}, array::FieldArray) = Base.NamedTuple(array)
 Base.NamedTuple(array::FieldArray) = Base.NamedTuple{propertynames(array)}(array)

--- a/test/FieldMatrix.jl
+++ b/test/FieldMatrix.jl
@@ -119,5 +119,6 @@
         end
 
         @test NamedTuple(FieldMatrixNT(1,2,3,4)) isa @NamedTuple{a::Int, b::Int, c::Int, d::Int}
+        @test convert(NamedTuple, FieldMatrixNT(1,2,3,4)) isa @NamedTuple{a::Int, b::Int, c::Int, d::Int}
     end
 end

--- a/test/FieldMatrix.jl
+++ b/test/FieldMatrix.jl
@@ -109,4 +109,15 @@
         @test length(x[1]) == 2
         @test x.x == (1, 2)
     end
+
+    @testset "FieldMatrix to NamedTuple" begin
+        struct FieldMatrixNT{T} <: FieldMatrix{2,2,T}
+            a::T
+            b::T
+            c::T
+            d::T
+        end
+
+        @test NamedTuple(FieldMatrixNT(1,2,3,4)) isa @NamedTuple{a::Int, b::Int, c::Int, d::Int}
+    end
 end

--- a/test/FieldMatrix.jl
+++ b/test/FieldMatrix.jl
@@ -119,6 +119,5 @@
         end
 
         @test NamedTuple(FieldMatrixNT(1,2,3,4)) isa @NamedTuple{a::Int, b::Int, c::Int, d::Int}
-        @test convert(NamedTuple, FieldMatrixNT(1,2,3,4)) isa @NamedTuple{a::Int, b::Int, c::Int, d::Int}
     end
 end

--- a/test/FieldVector.jl
+++ b/test/FieldVector.jl
@@ -148,6 +148,6 @@
             c::T
         end
 
-        @test NamedTuple(FieldVectorNT(1,2,3)) isa @NamedTuple{a::Int64, b::Int64, c::Int64}
+        @test NamedTuple(FieldVectorNT(1,2,3)) isa @NamedTuple{a::Int, b::Int, c::Int}
     end
 end

--- a/test/FieldVector.jl
+++ b/test/FieldVector.jl
@@ -140,4 +140,14 @@
         end
         @test_throws ErrorException("The constructor for Position1088{Float64}(::Float64, ::Float64, ::Float64) is missing!") Position1088((1.,2.,3.))
     end
+
+    @testset "FieldVector to NamedTuple" begin
+        struct FieldVectorNT{T} <: FieldVector{3,T}
+            a::T
+            b::T
+            c::T
+        end
+
+        @test NamedTuple(FieldVectorNT(1,2,3)) isa @NamedTuple{a::Int64, b::Int64, c::Int64}
+    end
 end

--- a/test/FieldVector.jl
+++ b/test/FieldVector.jl
@@ -149,6 +149,5 @@
         end
 
         @test NamedTuple(FieldVectorNT(1,2,3)) isa @NamedTuple{a::Int, b::Int, c::Int}
-        @test convert(NamedTuple, FieldVectorNT(1,2,3,4)) isa @NamedTuple{a::Int, b::Int, c::Int, d::Int}
     end
 end

--- a/test/FieldVector.jl
+++ b/test/FieldVector.jl
@@ -149,5 +149,6 @@
         end
 
         @test NamedTuple(FieldVectorNT(1,2,3)) isa @NamedTuple{a::Int, b::Int, c::Int}
+        @test convert(NamedTuple, FieldVectorNT(1,2,3,4)) isa @NamedTuple{a::Int, b::Int, c::Int, d::Int}
     end
 end


### PR DESCRIPTION
This PR was originally posted to [`StaticArraysCore.jl`](https://github.com/JuliaArrays/StaticArraysCore.jl/pull/25), but was moved to here because `StaticArraysCore` lacks the method definitions necessary to make this `NamedTuple` functionality work. 

I have found `NamedTuple` to be a performant way to initialize `FieldArray` subtypes. See, for example, the following code in [`AstrodynamicalModels.jl`](https://github.com/cadojo/AstrodynamicalModels.jl/blob/8c811923c2d56b7927bf4c62acc2fbfa1bcd91d4/src/AstrodynamicalModels.jl#L107). I think it may also be useful sometimes to go in reverse: convert a `FieldArray` subtype back into a `NamedTuple`. **Do you agree this may be useful, and without undesirable side effects?** I got this idea from `SciML`'s [`Base.NamedTuple` method](https://github.com/SciML/LabelledArrays.jl/blob/d652e95b08b28260d36ca1ce34af1d02fd5506d0/src/LabelledArrays.jl#L59) for `LabelledArrays.jl`. Thanks for reading!

```julia
"""
A mutable vector, with labels, for 6DOF Cartesian states.
"""
Base.@kwdef mutable struct CartesianState{F} <: FieldVector{6,F}
    x::F = 0.0
    y::F = 0.0
    z::F = 0.0
    ẋ::F = 0.0
    ẏ::F = 0.0
    ż::F = 0.0

    CartesianState{F}(::UndefInitializer) where {F} = new{F}()
    CartesianState(::UndefInitializer) = CartesianState{Float64}(undef)

    CartesianState{F}(x, y, z, ẋ, ẏ, ż) where {F} = new{F}(x, y, z, ẋ, ẏ, ż)
    CartesianState(x, y, z, ẋ, ẏ, ż) = new{promote_type(typeof(x), typeof(y), typeof(z), typeof(ẋ), typeof(ẏ), typeof(ż))}(x, y, z, ẋ, ẏ, ż)
    CartesianState{F}(state::NamedTuple) where {F} =
        let
            (; x, y, z, ẋ, ẏ, ż) = merge((; x=zero(F), y=zero(F), z=zero(F), ẋ=zero(F), ẏ=zero(F), ż=zero(F)), state)
            CartesianState{F}(x, y, z, ẋ, ẏ, ż)
        end
    CartesianState(state::NamedTuple) = CartesianState{Float64}(state)
end
```
