### PR TITLE
Remove some uses of `@pure`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StaticArrays"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "1.9.3"
+version = "1.9.4"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/docs/src/pages/api.md
+++ b/docs/src/pages/api.md
@@ -60,7 +60,7 @@ same vector. We can now do this with the `Scalar` type:
 The size of a statically sized array is a static parameter associated with the
 type of the array. The `Size` trait is provided as an abstract representation of
 the dimensions of a static array. An array `sa::SA` of size `(dims...)` is
-associated with `Size{(dims...)}()`. The following are equivalent (`@pure`)
+associated with `Size{(dims...)}()`. The following are equivalent
 constructors:
 ```julia
 Size{(dims...,)}()

--- a/src/SHermitianCompact.jl
+++ b/src/SHermitianCompact.jl
@@ -44,8 +44,10 @@ end
     end
 end
 
-Base.@pure triangularnumber(N::Int) = div(N * (N + 1), 2)
-Base.@pure triangularroot(L::Int) = div(isqrt(8 * L + 1) - 1, 2) # from quadratic formula
+triangularnumber(N::Int) = div(N * (N + 1), 2)
+@generated function triangularroot(::Val{L}) where {L}
+    return div(isqrt(8 * L + 1) - 1, 2) # from quadratic formula
+end
 
 lowertriangletype(::Type{SHermitianCompact{N, T, L}}) where {N, T, L} = SVector{L, T}
 lowertriangletype(::Type{SHermitianCompact{N, T}}) where {N, T} = SVector{triangularnumber(N), T}
@@ -55,7 +57,7 @@ lowertriangletype(::Type{SHermitianCompact{N}}) where {N} = SVector{triangularnu
 @inline SHermitianCompact{N}(lowertriangle::SVector{L, T}) where {N, T, L} = SHermitianCompact{N, T, L}(lowertriangle)
 
 @inline function SHermitianCompact(lowertriangle::SVector{L, T}) where {T, L}
-    N = triangularroot(L)
+    N = triangularroot(Val(L))
     SHermitianCompact{N, T, L}(lowertriangle)
 end
 

--- a/src/SOneTo.jl
+++ b/src/SOneTo.jl
@@ -38,7 +38,7 @@ end
 Base.first(::SOneTo) = 1
 Base.last(::SOneTo{n}) where {n} = n::Int
 
-@pure function Base.iterate(::SOneTo{n}) where {n}
+function Base.iterate(::SOneTo{n}) where {n}
     if n::Int < 1
         return nothing
     else

--- a/src/SUnitRange.jl
+++ b/src/SUnitRange.jl
@@ -6,7 +6,7 @@ struct SUnitRange{Start, L} <: StaticVector{L, Int}
     end
 end
 
-@pure function check_sunitrange_params(L::Int)
+function check_sunitrange_params(L::Int)
     if L < 0
         error("Static unit range length is negative")
     end
@@ -16,9 +16,9 @@ function check_sunitrange_params(L)
     throw(TypeError(:SUnitRange, "type parameters must be `Int`", Tuple{Int,}, Tuple{typeof(L),}))
 end
 
-@pure SUnitRange(a::Int, b::Int) = SUnitRange{a, max(0, b - a + 1)}()
+SUnitRange(a::Int, b::Int) = SUnitRange{a, max(0, b - a + 1)}()
 
-@pure @propagate_inbounds function getindex(x::SUnitRange{Start, L}, i::Int) where {Start, L}
+@propagate_inbounds function getindex(x::SUnitRange{Start, L}, i::Int) where {Start, L}
     @boundscheck if i < 1 || i > L
         throw(BoundsError(x, i))
     end

--- a/src/abstractarray.jl
+++ b/src/abstractarray.jl
@@ -1,7 +1,7 @@
 length(a::StaticArrayLike) = prod(Size(a))::Int
 length(a::Type{SA}) where {SA <: StaticArrayLike} = prod(Size(SA))::Int
 
-@pure size(::Type{SA}) where {SA <: StaticArrayLike} = Tuple(Size(SA))
+size(::Type{SA}) where {SA <: StaticArrayLike} = Tuple(Size(SA))
 @inline function size(t::Type{<:StaticArrayLike}, d::Int)
     S = size(t)
     d > length(S) ? 1 : S[d]
@@ -9,7 +9,7 @@ end
 @inline size(a::StaticArrayLike) = Tuple(Size(a))
 
 Base.axes(s::StaticArrayLike) = _axes(Size(s))
-@pure function _axes(::Size{sizes}) where {sizes}
+@generated function _axes(::Size{sizes}) where {sizes}
     map(SOneTo, sizes)
 end
 
@@ -83,9 +83,9 @@ sizedarray_similar_type(::Type{T},s::Size{S},::Type{Val{D}}) where {T,S,D} = Siz
 # Utility for computing the eltype of an array instance, type, or type
 # constructor.  For type constructors without a definite eltype, the default
 # value is returned.
-Base.@pure _eltype_or(a::AbstractArray, default) = eltype(a)
-Base.@pure _eltype_or(::Type{<:AbstractArray{T}}, default) where {T} = T
-Base.@pure _eltype_or(::Type{<:AbstractArray}, default) = default # eltype not available
+_eltype_or(a::AbstractArray, default) = eltype(a)
+_eltype_or(::Type{<:AbstractArray{T}}, default) where {T} = T
+_eltype_or(::Type{<:AbstractArray}, default) = default # eltype not available
 
 """
     _construct_similar(a, ::Size, elements::NTuple)

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -11,14 +11,14 @@ const BadArgs = Args{<:Tuple{Tuple{<:Tuple}}}
 
 # Some help functions.
 @pure has_ndims(::Type{<:StaticArray{<:Tuple,<:Any,N}}) where {N} = @isdefined N
-@pure has_ndims(::Type{<:StaticArray}) = false
+has_ndims(::Type{<:StaticArray}) = false
 if VERSION < v"1.7"
     Base.ndims(::Type{<:StaticArray{<:Tuple,<:Any,N}}) where {N} = N
 end
 @pure has_eltype(::Type{<:StaticArray{<:Tuple,T}}) where {T} = @isdefined T
-@pure has_eltype(::Type{<:StaticArray}) = false
+has_eltype(::Type{<:StaticArray}) = false
 @pure has_size(::Type{<:StaticArray{S}}) where {S<:Tuple} = @isdefined S
-@pure has_size(::Type{<:StaticArray}) = false
+has_size(::Type{<:StaticArray}) = false
 # workaround for https://github.com/JuliaArrays/StaticArrays.jl/issues/1047
 has_size(::Type{SVector}) = false
 has_size(::Type{MVector}) = false
@@ -28,10 +28,10 @@ has_size(::Type{SMatrix{N}}) where {N} = false
 has_size(::Type{MMatrix{N}}) where {N} = false
 
 @pure has_size1(::Type{<:StaticMatrix{M}}) where {M} = @isdefined M
-@pure has_size1(::Type{<:StaticMatrix}) = false
+has_size1(::Type{<:StaticMatrix}) = false
 _size1(::Type{<:StaticMatrix{M}}) where {M} = M
 @generated function _sqrt(::Length{L}) where {L}
-    N = round(Int, sqrt(L))
+    N = isqrt(L)
     N^2 == L && return :($N)
     throw(DimensionMismatch("Input's length must be perfect square"))
 end

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -71,7 +71,7 @@ end
 ## Indexing utilities  ##
 #########################
 
-@pure unpack_size(::Type{Size{S}}) where {S} = map(Size, S)
+@generated unpack_size(::Type{Size{S}}) where {S} = map(Size, S)
 
 @inline index_size(::Size, ::Int) = Size()
 @inline index_size(::Size, a::StaticArray) = Size(a)

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -36,7 +36,7 @@ Base.show(io::IO, ::Length{L}) where {L} = print(io, "Length(", L, ")")
 
 Length(a::AbstractArray) = Length(Size(a))
 Length(::Type{A}) where {A <: AbstractArray} = Length(Size(A))
-@pure Length(L::Int) = Length{L}()
+Length(L::Int) = Length{L}()
 Length(::Size{S}) where {S} = _Length(S...)
 _Length(S::Int...) = Length{prod(S)}()
 @inline _Length(S...) = Length{Dynamic()}()
@@ -44,7 +44,7 @@ _Length(S::Int...) = Length{prod(S)}()
 # Some convenience functions for `Size`
 (::Type{Tuple})(::Size{S}) where {S} = S
 
-@pure getindex(::Size{S}, i::Int) where {S} = i <= length(S) ? S[i] : 1
+getindex(::Size{S}, i::Int) where {S} = i <= length(S) ? S[i] : 1
 
 length(::Size{S}) where {S} = length(S)
 length_val(::Size{S}) where {S} = Val{length(S)}
@@ -59,8 +59,8 @@ Base.LinearIndices(::Size{S}) where {S} = LinearIndices(S)
 
 size_tuple(::Size{S}) where {S} = Tuple{S...}
 
-# Some @pure convenience functions for `Length`
-@pure (::Type{Int})(::Length{L}) where {L} = Int(L)
+# Some convenience functions for `Length`
+(::Type{Int})(::Length{L}) where {L} = Int(L)
 
 Base.:(==)(::Length{L}, l::Int) where {L} = L == l
 Base.:(==)(l::Int, ::Length{L}) where {L} = l == L


### PR DESCRIPTION
I think it will be much easier to track potential performance regressions when pure removal is split into a few steps. This is the first one.