### PR TITLE
Complex multiplication with SHermitianCompact

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StaticArrays"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "1.9.5"
+version = "1.9.6"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/SHermitianCompact.jl
+++ b/src/SHermitianCompact.jl
@@ -151,21 +151,25 @@ LinearAlgebra.issymmetric(a::SHermitianCompact) = true
     end
 end
 
-@inline Base.:*(a::Number, b::SHermitianCompact) = SHermitianCompact(a * b.lowertriangle)
-@inline Base.:*(a::SHermitianCompact, b::Number) = SHermitianCompact(a.lowertriangle * b)
-@inline Base.:*(a::Complex, b::SHermitianCompact) = a * SMatrix(b)
-@inline Base.:*(a::SHermitianCompact, b::Complex) = SMatrix(a) * b
+@inline Base.:*(a::Real, b::SHermitianCompact) = SHermitianCompact(a * b.lowertriangle)
+@inline Base.:*(a::SHermitianCompact, b::Real) = SHermitianCompact(a.lowertriangle * b)
+@inline Base.:*(a::Number, b::SHermitianCompact) = a * SMatrix(b)
+@inline Base.:*(a::SHermitianCompact, b::Number) = SMatrix(a) * b
 
-@inline Base.:/(a::SHermitianCompact, b::Number) = SHermitianCompact(a.lowertriangle / b)
-@inline Base.:\(a::Number, b::SHermitianCompact) = SHermitianCompact(a \ b.lowertriangle)
-@inline Base.:/(a::SHermitianCompact, b::Complex) = SMatrix(a) / b
-@inline Base.:\(a::Complex, b::SHermitianCompact) = a \ SMatrix(b)
+@inline Base.:/(a::SHermitianCompact, b::Real) = SHermitianCompact(a.lowertriangle / b)
+@inline Base.:\(a::Real, b::SHermitianCompact) = SHermitianCompact(a \ b.lowertriangle)
+@inline Base.:/(a::SHermitianCompact, b::Number) = SMatrix(a) / b
+@inline Base.:\(a::Number, b::SHermitianCompact) = a \ SMatrix(b)
 
-@inline Base.muladd(scalar::Complex, a::SHermitianCompact, b::StaticArray) = muladd(scalar, SMatrix(a), b)
-@inline Base.muladd(a::SHermitianCompact, scalar::Complex, b::StaticArray) = muladd(SMatrix(a), scalar, b)
+@inline Base.muladd(scalar::Number, a::SHermitianCompact, b::StaticArray) = muladd(scalar, SMatrix(a), b)
+@inline Base.muladd(a::SHermitianCompact, scalar::Number, b::StaticArray) = muladd(SMatrix(a), scalar, b)
+@inline Base.muladd(scalar::Real, a::SHermitianCompact, b::StaticArray) = map((ai, bi) -> muladd(scalar, ai, bi), a, b)
+@inline Base.muladd(a::SHermitianCompact, scalar::Real, b::StaticArray) = map((ai, bi) -> muladd(ai, scalar, bi), a, b)
 
-@inline Base.FastMath.mul_fast(a::Complex, b::SHermitianCompact) = Base.FastMath.mul_fast(a, SMatrix(b))
-@inline Base.FastMath.mul_fast(a::SHermitianCompact, b::Complex) = Base.FastMath.mul_fast(SMatrix(a), b)
+@inline Base.FastMath.mul_fast(a::Number, b::SHermitianCompact) = Base.FastMath.mul_fast(a, SMatrix(b))
+@inline Base.FastMath.mul_fast(a::SHermitianCompact, b::Number) = Base.FastMath.mul_fast(SMatrix(a), b)
+@inline Base.FastMath.mul_fast(a::Real, b::SHermitianCompact) = map(c -> Base.FastMath.mul_fast(a, c), b)
+@inline Base.FastMath.mul_fast(a::SHermitianCompact, b::Real) = map(c -> Base.FastMath.mul_fast(c, b), a)
 
 @generated function _plus_uniform(::Size{S}, a::SHermitianCompact{N, T, L}, λ) where {S, N, T, L}
     @assert S[1] == N

--- a/src/SHermitianCompact.jl
+++ b/src/SHermitianCompact.jl
@@ -153,9 +153,19 @@ end
 
 @inline Base.:*(a::Number, b::SHermitianCompact) = SHermitianCompact(a * b.lowertriangle)
 @inline Base.:*(a::SHermitianCompact, b::Number) = SHermitianCompact(a.lowertriangle * b)
+@inline Base.:*(a::Complex, b::SHermitianCompact) = a * SMatrix(b)
+@inline Base.:*(a::SHermitianCompact, b::Complex) = SMatrix(a) * b
 
 @inline Base.:/(a::SHermitianCompact, b::Number) = SHermitianCompact(a.lowertriangle / b)
 @inline Base.:\(a::Number, b::SHermitianCompact) = SHermitianCompact(a \ b.lowertriangle)
+@inline Base.:/(a::SHermitianCompact, b::Complex) = SMatrix(a) / b
+@inline Base.:\(a::Complex, b::SHermitianCompact) = a \ SMatrix(b)
+
+@inline Base.muladd(scalar::Complex, a::SHermitianCompact, b::StaticArray) = muladd(scalar, SMatrix(a), b)
+@inline Base.muladd(a::SHermitianCompact, scalar::Complex, b::StaticArray) = muladd(SMatrix(a), scalar, b)
+
+@inline Base.FastMath.mul_fast(a::Complex, b::SHermitianCompact) = Base.FastMath.mul_fast(a, SMatrix(b))
+@inline Base.FastMath.mul_fast(a::SHermitianCompact, b::Complex) = Base.FastMath.mul_fast(SMatrix(a), b)
 
 @generated function _plus_uniform(::Size{S}, a::SHermitianCompact{N, T, L}, λ) where {S, N, T, L}
     @assert S[1] == N

--- a/test/SHermitianCompact.jl
+++ b/test/SHermitianCompact.jl
@@ -185,20 +185,27 @@ fill3(x) = fill(3, x)
 
     @testset "Scalar-array" begin
         x = SHermitianCompact(SVector{6, Int}(1 : 6))
-        y = -5
-        for op in (:*, :/, :\)
-            if op != :\
-                @eval begin
-                    @test $op($x, $y) == $op(SMatrix($x), $y)
-                    @test_noalloc $op($x, $y)
+        for y = (-5, 1.1+4.3im)
+            for op in (:*, :/, :\, :(Base.FastMath.mul_fast))
+                if op != :\
+                    @eval begin
+                        @test $op($x, $y) == $op(SMatrix($x), $y)
+                        @test_noalloc $op($x, $y)
+                    end
+                end
+
+                if op != :/
+                    @eval begin
+                        @test $op($y, $x) == $op($y, SMatrix($x))
+                        @test_noalloc $op($y, $x)
+                    end
                 end
             end
-
-            if op != :/
-                @eval begin
-                    @test $op($y, $x) == $op($y, SMatrix($x))
-                    @test_noalloc $op($y, $x)
-                end
+            @eval begin
+                @test muladd($y, $x, $x) == muladd($y, SMatrix($x), $x)
+                @test_noalloc muladd($y, $x, $x)
+                @test muladd($x, $y, $x) == muladd(SMatrix($x), $y, $x)
+                @test_noalloc muladd($x, $y, $x)
             end
         end
     end


### PR DESCRIPTION
This pr adds some methods to dispatch complex scalar multiplication/division with `SHermitianCompact` to a correct method using `SMatrix`. Tests are also added. For other details see #1263 