### PR TITLE
improved definitions of ishermitian/issymmetric

### DIFF
--- a/src/SHermitianCompact.jl
+++ b/src/SHermitianCompact.jl
@@ -1,9 +1,11 @@
 """
     SHermitianCompact{N, T, L} <: StaticMatrix{N, N, T}
 
-A [`StaticArray`](@ref) subtype that represents a Hermitian matrix. Unlike
+A [`StaticArray`](@ref) subtype that can represent a Hermitian matrix. Unlike
 `LinearAlgebra.Hermitian`, `SHermitianCompact` stores only the lower triangle
-of the matrix (as an `SVector`). The lower triangle is stored in column-major order.
+of the matrix (as an `SVector`), and the diagonal may not be real. The lower
+triangle is stored in column-major order and the superdiagonal entries are 
+`adjoint` to the transposed subdiagonal entries. The diagonal is returned as-is.
 For example, for an `SHermitianCompact{3}`, the indices of the stored elements
 can be visualized as follows:
 
@@ -28,6 +30,13 @@ An `SHermitianCompact` may be constructed either:
 
 For the latter two cases, only the lower triangular elements are used; the upper triangular
 elements are ignored.
+
+When its element type is real, then a `SHermitianCompact` is both Hermitian and
+symmetric. Otherwise, to ensure that a `SHermitianCompact` matrix, `a`, is
+Hermitian according to `LinearAlgebra.ishermitian`, take an average with its
+adjoint, i.e. `(a+a')/2`, or take a Hermitian view of the data with
+`LinearAlgebra.Hermitian(a)`. However, the latter case is not specialized to use
+the compact storage.
 """
 struct SHermitianCompact{N, T, L} <: StaticMatrix{N, N, T}
     lowertriangle::SVector{L, T}

--- a/src/SHermitianCompact.jl
+++ b/src/SHermitianCompact.jl
@@ -129,8 +129,10 @@ end
     end
 end
 
-LinearAlgebra.ishermitian(a::SHermitianCompact) = true
-LinearAlgebra.issymmetric(a::SHermitianCompact) = true
+LinearAlgebra.ishermitian(a::SHermitianCompact{<:Any,<:Real}) = true
+LinearAlgebra.ishermitian(a::SHermitianCompact) = a == a'
+LinearAlgebra.issymmetric(a::SHermitianCompact{<:Any,<:Real}) = true
+LinearAlgebra.issymmetric(a::SHermitianCompact) = a == transpose(a)
 
 # TODO: factorize?
 

--- a/test/SHermitianCompact.jl
+++ b/test/SHermitianCompact.jl
@@ -139,13 +139,21 @@ fill3(x) = fill(3, x)
         @test issymmetric(a)
 
         b = rand(SHermitianCompact{5, ComplexF64})
-        @test ishermitian(b)
-        @test issymmetric(b)
+        @test !ishermitian(b)
+        @test !issymmetric(b)
 
         c = b + conj(b)
         @test ishermitian(c)
         @test issymmetric(c)
         @test_noalloc ishermitian(c)
+
+        d = b + b'
+        @test ishermitian(d)
+        @test !issymmetric(d)
+
+        e = rand(SHermitianCompact{5, Float64}) + im*I
+        @test !ishermitian(e)
+        @test issymmetric(e)
     end
 
     @testset "==" begin


### PR DESCRIPTION
As mentioned in #1263, the `SHermitianCompact` type can represent matrices which are neither Hermitian nor symmetric, so this pr fixes the definitions of `ishermitian` and `issymmetric` to capture this and adds tests to verify the logic on some of these unusual cases. I think this would be preferable to making `SHermitianCompact` guarantee that it is in fact Hermitian, i.e. by always returning real values on the diagonal, because the latter would be breaking.