### PR TITLE
refactor inv to also work for lu

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StaticArrays"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "1.9.6"
+version = "1.9.7"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/inv.jl
+++ b/src/inv.jl
@@ -76,10 +76,11 @@ end
     if prod(S) ≤ 14*14
         quote
             @_inline_meta
-            LUp = lu(A)
-            LUp.U \ (LUp.L \ typeof(A)(I)[LUp.p,:])
+            inv(lu(A))
         end
     else
         :(@_inline_meta; similar_type(A)(inv(Matrix(A))))
     end
 end
+
+inv(LUp::LU) = LUp.U \ (LUp.L \ typeof(LUp.L.data)(I)[LUp.p,:])

--- a/src/inv.jl
+++ b/src/inv.jl
@@ -83,4 +83,10 @@ end
     end
 end
 
-inv(LUp::LU) = LUp.U \ (LUp.L \ typeof(LUp.L.data)(I)[LUp.p,:])
+function inv(LUp::LU)
+    if !(LUp.L isa LowerTriangular)
+        checksquare(LUp.L)
+        checksquare(LUp.U)
+    end
+    LUp.U \ (LUp.L \ typeof(parent(LUp.L))(I)[LUp.p,:])
+end

--- a/test/inv.jl
+++ b/test/inv.jl
@@ -97,6 +97,12 @@ end
     @test inv(A) ≈ inv(SA)
 end
 
+@testset "LU to inverse" for sz in (5, 8, 15), typ in (Float64, Complex{Float64})
+    A = rand(typ, sz, sz)
+    SA = SMatrix{sz,sz,typ}(A)
+    @test inv(lu(A)) ≈ inv(lu(SA))
+end
+
 #-------------------------------------------------------------------------------
 # More comprehensive but qualitative testing for inv() accuracy
 #=

--- a/test/inv.jl
+++ b/test/inv.jl
@@ -101,6 +101,8 @@ end
     A = rand(typ, sz, sz)
     SA = SMatrix{sz,sz,typ}(A)
     @test inv(lu(A)) ≈ inv(lu(SA))
+    @test_throws DimensionMismatch inv(lu(SMatrix{sz,sz+1,typ}(rand(typ, sz, sz+1))))
+    @test_throws DimensionMismatch inv(lu(SMatrix{sz+1,sz,typ}(rand(typ, sz+1, sz))))
 end
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
This pr refactors the `inv` code so that `inv(::StaticArrays.LU)` behaves like `inv(::LinearAlgebra.LU)`, allowing the construction of the inverse from the LU factorization. I'm not sure if I handled inlining correctly and I would be happy to implement any feedback.