### PR TITLE
Don't import require_one_based_indexing from StaticArraysCore

### DIFF
--- a/src/StaticArrays.jl
+++ b/src/StaticArrays.jl
@@ -26,7 +26,7 @@ using PrecompileTools
 # from StaticArraysCore to make transitioning definitions to StaticArraysCore easier.
 using StaticArraysCore: StaticArraysCore, StaticArray, StaticScalar, StaticVector,
                         StaticMatrix, StaticVecOrMat, tuple_length, tuple_prod,
-                        tuple_minimum, size_to_tuple, require_one_based_indexing
+                        tuple_minimum, size_to_tuple
 using StaticArraysCore: FieldArray, FieldMatrix, FieldVector
 using StaticArraysCore: StaticArrayStyle
 using StaticArraysCore: Dynamic, StaticDimension


### PR DESCRIPTION
This is not being used anywhere in the package, and `StaticArraysCore` now uses the `Base` function instead of defining their own. This means precompilation is currently broken for this package without removing this import.