### PR TITLE
Fix p-norm for unitful quantities

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StaticArrays"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "1.9.8"
+version = "1.9.9"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -301,7 +301,7 @@ end
         $(Expr(:meta, :inline))
         scale = maxabs_nested(a)
 
-        scale==0 && return _init_zero(a)
+        iszero(scale) && return _init_zero(a)
         p == 1 && return @inbounds scale * $expr_p1
         return @inbounds scale * ($expr)^(inv(p))
     end
@@ -328,7 +328,7 @@ end
         p == Inf && return mapreduce(norm, max, a)  # no need for scaling
 
         l = p==1 ? @inbounds($expr_p1) : @inbounds(($expr)^(inv(p)))
-        0<l<Inf && return l
+        zero(l) < l && isfinite(l) && return l
         return _norm_scaled(Size(a), a, p)  # p != 0, 2, Inf
     end
 end

--- a/test/unitful.jl
+++ b/test/unitful.jl
@@ -5,4 +5,7 @@ using Unitful
     @test norm(SVector(1.0*u"m")) == 1.0*u"m"
     # issue $1127
     @test norm(SVector(0.0, 0.0)*u"nm") == 0.0*u"nm"
+
+    @test norm(SVector(1.0, 2.0)*u"m", 1) == 3.0*u"m"
+    @test norm(SVector(0.0, 0.0)*u"nm", 1) == 0.0*u"nm"
 end


### PR DESCRIPTION
This is #1125 and #1128 for general p-norms, where $p\neq 0,2,\infty$. Before:
```julia
julia> norm(SVector(1.0, 2.0)*u"m", 1)
ERROR: DimensionError: 0.0 and 3.0 m are not dimensionally compatible.
Stacktrace:
 [1] _lt
   @ ~/.julia/packages/Unitful/dHMk1/src/quantities.jl:250 [inlined]
 [2] <(x::Quantity{Float64, NoDims, Unitful.FreeUnits{…}}, y::Quantity{Float64, 𝐋, Unitful.FreeUnits{…}})
   @ Unitful ~/.julia/packages/Unitful/dHMk1/src/quantities.jl:240
 [3] <(x::Int64, y::Quantity{Float64, 𝐋, Unitful.FreeUnits{(m,), 𝐋, nothing}})
   @ Unitful ~/.julia/packages/Unitful/dHMk1/src/quantities.jl:242
 [4] macro expansion
   @ ~/.julia/dev/StaticArrays/src/linalg.jl:331 [inlined]
 [5] _norm
   @ ~/.julia/dev/StaticArrays/src/linalg.jl:311 [inlined]
 [6] norm(a::SVector{2, Quantity{Float64, 𝐋, Unitful.FreeUnits{(m,), 𝐋, nothing}}}, p::Int64)
   @ StaticArrays ~/.julia/dev/StaticArrays/src/linalg.jl:310
 [7] top-level scope
   @ REPL[27]:1
Some type information was truncated. Use `show(err)` to see complete types.
```

and
```julia
julia> norm(SVector(0.0, 0.0)*u"nm", 1)
NaN nm
```
After this PR:
```julia
julia> norm(SVector(1.0, 2.0)*u"m", 1)
3.0 m
```

and
```julia
julia> norm(SVector(0.0, 0.0)*u"nm", 1)
0.0 nm
```