### PR TITLE
`SOneTo` subtypes `AbstractOneTo`

### DIFF
--- a/src/SOneTo.jl
+++ b/src/SOneTo.jl
@@ -6,12 +6,8 @@ a `StaticArray`.
 """
 SOneTo
 
-if isdefined(Base, :AbstractOneTo)
-    struct SOneTo{n} <: Base.AbstractOneTo{Int}
-    end
-else
-    struct SOneTo{n} <: AbstractUnitRange{Int}
-    end
+const SOneToSupertype = isdefined(Base, :AbstractOneTo) ?  Base.AbstractOneTo : AbstractUnitRange
+struct SOneTo{n} <: SOneToSupertype{Int}
 end
 
 SOneTo(n::Int) = SOneTo{n}()

--- a/src/SOneTo.jl
+++ b/src/SOneTo.jl
@@ -4,7 +4,14 @@
 Return a statically-sized `AbstractUnitRange` starting at `1`, functioning as the `axes` of
 a `StaticArray`.
 """
-struct SOneTo{n} <: AbstractUnitRange{Int}
+SOneTo
+
+if isdefined(Base, :AbstractOneTo)
+    struct SOneTo{n} <: Base.AbstractOneTo{Int}
+    end
+else
+    struct SOneTo{n} <: AbstractUnitRange{Int}
+    end
 end
 
 SOneTo(n::Int) = SOneTo{n}()

--- a/src/SOneTo.jl
+++ b/src/SOneTo.jl
@@ -1,12 +1,11 @@
+const SOneToSupertype = isdefined(Base, :AbstractOneTo) ?  Base.AbstractOneTo : AbstractUnitRange
+
 """
     SOneTo(n)
 
 Return a statically-sized `AbstractUnitRange` starting at `1`, functioning as the `axes` of
 a `StaticArray`.
 """
-SOneTo
-
-const SOneToSupertype = isdefined(Base, :AbstractOneTo) ?  Base.AbstractOneTo : AbstractUnitRange
 struct SOneTo{n} <: SOneToSupertype{Int}
 end
 

--- a/src/abstractarray.jl
+++ b/src/abstractarray.jl
@@ -142,8 +142,13 @@ const HeterogeneousBaseShape = Union{Integer, Base.OneTo}
 const HeterogeneousShape = Union{HeterogeneousBaseShape, SOneTo}
 const HeterogeneousShapeTuple = Tuple{Vararg{HeterogeneousShape}}
 
-similar(A::AbstractArray, ::Type{T}, shape::HeterogeneousShapeTuple) where {T} = similar(A, T, homogenize_shape(shape))
-similar(::Type{A}, shape::HeterogeneousShapeTuple) where {A<:AbstractArray} = similar(A, homogenize_shape(shape))
+if isdefined(Base, :AbstractOneTo)
+    similar(A::AbstractArray, ::Type{T}, shape::Tuple{SOneTo, Vararg{SOneTo}}) where {T} = similar(A, T, homogenize_shape(shape))
+    similar(::Type{A}, shape::Tuple{SOneTo, Vararg{SOneTo}}) where {A<:AbstractArray} = similar(A, homogenize_shape(shape))
+else
+    similar(A::AbstractArray, ::Type{T}, shape::HeterogeneousShapeTuple) where {T} = similar(A, T, homogenize_shape(shape))
+    similar(::Type{A}, shape::HeterogeneousShapeTuple) where {A<:AbstractArray} = similar(A, homogenize_shape(shape))
+end
 # Use an Array for StaticArrays if we don't have a statically-known size
 similar(::Type{A}, shape::Tuple{Int, Vararg{Int}}) where {A<:StaticArray} = Array{eltype(A)}(undef, shape)
 

--- a/src/abstractarray.jl
+++ b/src/abstractarray.jl
@@ -142,7 +142,7 @@ const HeterogeneousBaseShape = Union{Integer, Base.OneTo}
 const HeterogeneousShape = Union{HeterogeneousBaseShape, SOneTo}
 const HeterogeneousShapeTuple = Tuple{Vararg{HeterogeneousShape}}
 
-if isdefined(Base, :AbstractOneTo)
+@static if isdefined(Base, :AbstractOneTo)
     similar(A::AbstractArray, ::Type{T}, shape::Tuple{SOneTo, Vararg{SOneTo}}) where {T} = similar(A, T, homogenize_shape(shape))
     similar(::Type{A}, shape::Tuple{SOneTo, Vararg{SOneTo}}) where {A<:AbstractArray} = similar(A, homogenize_shape(shape))
 else


### PR DESCRIPTION
On a recent nightly (v"1.13.0-DEV.347"), `Base` has added `AbstractOneTo` (https://github.com/JuliaLang/julia/pull/56902), and in this PR we change `SOneTo` to subtype `AbstractOneTo` when this is available. This makes combinations of `SOneTo`, `Base.OneTo` and `Integer`s dispatch to `Base` methods, and we don't need to disambiguate these in this package.

Fixes https://github.com/JuliaArrays/StaticArrays.jl/issues/1248. After this, `StaticArrays` only needs to define `similar` methods for `Tuple`s of `SOneTo` as indices.