### PR TITLE
Specialize `map!(f, array)`

### DIFF
--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -110,6 +110,12 @@ enumerate_static(a::StaticArray) = StaticEnumerate(a)
     end
 end
 
+if VERSION >= v"1.12.0-beta3"
+    @inline function map!(f, dest::StaticArray)
+        _map!(f, dest, Size(dest), dest)
+    end
+end
+
 @inline function map!(f, dest::StaticArray, a::StaticArray...)
     _map!(f, dest, same_size(dest, a...), a...)
 end

--- a/test/mapreduce.jl
+++ b/test/mapreduce.jl
@@ -31,6 +31,14 @@ using Statistics: mean
         map!(+, mv3, v1, v2, v3)
         @test mv3 == @MVector [7, 9, 11, 13]
 
+        if VERSION >= v"1.12.0-beta3"
+            @testset "map!(function, array)" begin
+                local mv = MVector(1,2,3)
+                map!(x->x^2, mv)
+                @test mv == SA[1,4,9]
+            end
+        end
+
         # Output eltype for empty cases #528
         @test @inferred(map(/, SVector{0,Int}(), SVector{0,Int}())) === SVector{0,Float64}()
         @test @inferred(map(+, SVector{0,Int}(), SVector{0,Float32}())) === SVector{0,Float32}()


### PR DESCRIPTION
Julia v1.12 introduces the 2-term `map!`, where the source and the destination are identical. Currently, this package errors without a third term, as it can't find the source array. This PR ensures that the method works for `StaticArrays`s.

After this,
```julia
julia> M = MVector(1,3,4)
3-element MVector{3, Int64} with indices SOneTo(3):
 1
 3
 4

julia> map!(x->x^2, M)
3-element MVector{3, Int64} with indices SOneTo(3):
  1
  9
 16

julia> M
3-element MVector{3, Int64} with indices SOneTo(3):
  1
  9
 16
```