### PR TITLE
fix: fix n-dimensional `view` into n-dimensional `SArray` with `Any` eltype

### DIFF
--- a/src/abstractarray.jl
+++ b/src/abstractarray.jl
@@ -285,11 +285,11 @@ end
 # SArrays may avoid the SubArray wrapper and consequently an additional level of indirection
 # The output may use the broadcasting machinery defined for StaticArrays (see issue #892)
 # wrap elements in Scalar to be consistent with 0D views
-_maybewrapscalar(S::SArray{<:Any,T}, r::T) where {T} = Scalar{T}(r)
-_maybewrapscalar(S, r) = r
+_maybewrapscalar(::Tuple{}, r::T) where {T} = Scalar{T}(r)
+_maybewrapscalar(_, r) = r
 function Base.view(S::SArray, I::Union{Colon, Integer, SOneTo, StaticArray{<:Tuple, Int}, CartesianIndex}...)
     V = getindex(S, I...)
-    _maybewrapscalar(S, V)
+    _maybewrapscalar(Base.index_dimsum(I...), V)
 end
 
 # zeros, ones and fill may return SArrays if all the axes are statically sized

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -253,4 +253,16 @@ using StaticArrays, Test
         @test lastindex(ind[3]) === 2
         @test size(ind[3]) === (2,)
     end
+
+    @testset "Array view into `Any` eltype `SArray`" begin
+        A = SVector{4, Any}(1,2,3,4)
+        v = @inferred view(A, SA[3, 1])
+        @test v == SVector{2, Any}(3, 1)
+        A = SMatrix{2, 2, Any}(1, 2, 3, 4)
+        v = @inferred view(A, @SArray(fill(1, 1, 1)))
+        @test v == SMatrix{1, 1, Any}(1)
+        A = SArray{Tuple{2, 2, 2}, Any}(1, 2, 3, 4, 5, 6, 7, 8)
+        v = @inferred view(A, @SArray(fill(1, 1, 1, 1)))
+        @test v == SArray{Tuple{1, 1, 1}, Any}(1)
+    end
 end


### PR DESCRIPTION
As of the latest release, trying to `view` into an `SArray` with an eltype of `Any` such that the view also returns an `SArray` would wrap the returned array in a scalar. `_maybewrapscalar` assumes that if the `eltype` of the array matches the type of the view, it must be a scalar view. This assumption breaks down when the `eltype` is `Any`. MWE:

```julia
julia> A = SVector{4, Any}(1,2,3,4)

julia> I = SVector{2}(3, 1)

julia> view(A, I)
Scalar{Any}((Any[3, 1],))

julia> view(A, [3, 1])
2-element view(::SVector{4, Any}, [3, 1]) with eltype Any:
 3
 1
```

I've verified that all the added tests fail on the latest release and pass with this PR.