### PR TITLE
force specialization of dims argument type where it may be `Colon`

### DIFF
--- a/ext/StaticArraysStatisticsExt.jl
+++ b/ext/StaticArraysStatisticsExt.jl
@@ -12,10 +12,10 @@ _mean_denom(a, ::Colon) = length(a)
 _mean_denom(a, dims::Int) = size(a, dims)
 _mean_denom(a, ::Val{D}) where {D} = size(a, D)
 
-@inline mean(a::StaticArray; dims=:) = _reduce(+, a, dims) / _mean_denom(a, dims)
-@inline mean(f::Function, a::StaticArray; dims=:) = _mapreduce(f, +, dims, _InitialValue(), Size(a), a) / _mean_denom(a, dims)
+@inline mean(a::StaticArray; dims::D=:) where {D} = _reduce(+, a, dims) / _mean_denom(a, dims)
+@inline mean(f::Function, a::StaticArray; dims::D=:) where {D} = _mapreduce(f, +, dims, _InitialValue(), Size(a), a) / _mean_denom(a, dims)
 
-@inline function median(a::StaticArray; dims = :)
+@inline function median(a::StaticArray; dims::D = :) where {D}
     if dims == Colon()
         median(vec(a))
     else


### PR DESCRIPTION
As discussed in the Performance Tips in the Manual, Julia avoids specializing calls on the type of `Function` arguments by default.

The function `:`, `(:) isa Function`, is often used not as a callable, but as the special value for specifying the "full range" or "all dimensions". However in such cases we often forget to force specialization on the type of `:`. This change fixes that.

See PR JuliaLang/julia#59474, which applies the same kind of change in Julia itself.

NB: I don't have an example where this change helps for StaticArrays, however the eliminated invalidation in the linked JuliaLang/julia PR is proof that it does help in some cases. Finding such examples is difficult because the compiler is often able to achieve good results because of constant propagation. However constprop is often fragile, so it is better to avoid relying on it. For example, constprop through recursion is not even attempted by the Julia compiler.

I believe this change should not cause any real-world compile time regression, as `:` is the only function that is valid as a dims argument.