### PR TITLE
Delete some functions already defined in Base

### DIFF
--- a/src/SOneTo.jl
+++ b/src/SOneTo.jl
@@ -24,12 +24,7 @@ Base.length(s::SOneTo{n}) where {n} = n
 # The axes of a Slice'd SOneTo use the SOneTo itself
 Base.axes(S::Base.Slice{<:SOneTo}) = (S.indices,)
 Base.unsafe_indices(S::Base.Slice{<:SOneTo}) = (S.indices,)
-Base.axes1(S::Base.Slice{<:SOneTo}) = S.indices
 
-@propagate_inbounds function Base.getindex(s::SOneTo, i::Int)
-    @boundscheck checkbounds(s, i)
-    return i
-end
 @propagate_inbounds function Base.getindex(s::SOneTo, s2::SOneTo)
     @boundscheck checkbounds(s, s2)
     return s2

--- a/test/matrix_multiply_add.jl
+++ b/test/matrix_multiply_add.jl
@@ -97,8 +97,8 @@ function test_multiply_add(N1,N2,ArrayType=MArray)
     if !(ArrayType <: SizedArray)
         @test_noalloc mul!(c,A,b)
     else
-        mul!(c,A,b)
-        @test_broken(@allocated(mul!(c,A,b)) == 0)
+        mul!(c,A,b) # Precompilation?
+        @test_noalloc mul!(c,A,b)
     end
     expected_transpose_allocs = 0
     bmark = @benchmark mul!($c,$A,$b,$α,$β) samples=10 evals=10


### PR DESCRIPTION
This fixes some invalidations. On Julia 1.12 the number of invalidations go down from 1628 to 1498. As a dependency of CUDA.jl and in combination with https://github.com/JuliaData/SentinelArrays.jl/pull/119 the number of invalidations from loading CUDA go from 11175 to 10432.

One potentially dodgy change is removing the `getindex()` method, but I benchmarked it against the default one in Base and got the same results (~3 ns). When running the tests I also found that one of the `@test_broken` tests was passing so I fixed that too, but it's an allocation test so it may just be a 1.12 thing.