### PR TITLE
Fix any/all invalidation by overriding Base._any/_all

### DIFF
--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -301,11 +301,17 @@ reduce(::typeof(hcat), A::StaticArray{<:Tuple,<:StaticVecOrMatLike}) =
 @inline count(a::StaticArray{<:Tuple,Bool}; dims::D=:, init=0) where {D} = _reduce(+, a, dims, init)
 @inline count(f, a::StaticArray; dims::D=:, init=0) where {D} = _mapreduce(x->f(x)::Bool, +, dims, init, Size(a), a)
 
+# Hook into Base's internal _all/_any dispatch to avoid invalidating
+# the Base.all(::Function, ::AbstractArray) and Base.any(::Function, ::AbstractArray) methods.
+# Base calls _all(f, A, dims) and _any(f, A, dims) internally, so overriding
+# those avoids method table invalidation while still catching all calls.
+@inline Base._all(f, a::StaticArray, ::Colon) = _mapreduce(x->f(x)::Bool, &, :, true, Size(a), a)
+@inline Base._all(f, a::StaticArray, dims) = _mapreduce(x->f(x)::Bool, &, dims, true, Size(a), a)
 @inline all(a::StaticArray{<:Tuple,Bool}; dims::D=:) where {D} = _reduce(&, a, dims, true)  # non-branching versions
-@inline all(f::Function, a::StaticArray; dims::D=:) where {D} = _mapreduce(x->f(x)::Bool, &, dims, true, Size(a), a)
 
+@inline Base._any(f, a::StaticArray, ::Colon) = _mapreduce(x->f(x)::Bool, |, :, false, Size(a), a)
+@inline Base._any(f, a::StaticArray, dims) = _mapreduce(x->f(x)::Bool, |, dims, false, Size(a), a)
 @inline any(a::StaticArray{<:Tuple,Bool}; dims::D=:) where {D} = _reduce(|, a, dims, false) # (benchmarking needed)
-@inline any(f::Function, a::StaticArray; dims::D=:) where {D} = _mapreduce(x->f(x)::Bool, |, dims, false, Size(a), a) # (benchmarking needed)
 
 @inline Base.in(x, a::StaticArray) = _mapreduce(==(x), |, :, false, Size(a), a)
 


### PR DESCRIPTION
## Summary
- `any(f::Function, a::StaticArray; dims)` and `all(f::Function, a::StaticArray; dims)` caused **3,081+ method invalidations** when loading StaticArrays
- Changed to override `Base._any(f, a::StaticArray, dims)` and `Base._all(f, a::StaticArray, dims)` instead, which are the internal dispatch targets
- Non-function versions (`all`/`any` on `StaticArray{Bool}`) kept as direct overrides since they don't cause the same invalidation

## Context
When profiling the TTFX of ModelingToolkit's DAE pipeline, `StaticArrays` was identified as the #3 source of method invalidations. The `any(f::Function, a::StaticArray; dims)` method invalidated `Base.any(f::Function, a::AbstractArray; dims)`, triggering a cascade of recompilations.

## Changes
- `src/mapreduce.jl`: Replaced direct `any`/`all` overrides with `Base._any`/`Base._all` overrides
  - `Base._any(f, a::StaticArray, ::Colon)` and `Base._any(f, a::StaticArray, dims)` for the `any` path
  - `Base._all(f, a::StaticArray, ::Colon)` and `Base._all(f, a::StaticArray, dims)` for the `all` path
  - Kept `all(a::StaticArray{<:Tuple,Bool}; dims)` and `any(a::StaticArray{<:Tuple,Bool}; dims)` as direct overrides

## Design rationale
`Base.any(f, A::AbstractArray; dims)` internally calls `Base._any(f, A, dims)`. By overriding `_any`/`_all` instead of `any`/`all`, we avoid invalidating the entry-point methods while still intercepting all calls that go through the standard `Base.any`/`Base.all` path.

## Test plan
- [x] Full test suite passes locally (all pass, 12 broken (pre-existing))

🤖 Generated with [Claude Code](https://claude.com/claude-code)