### PR TITLE
Fix norm_sqr init for Unitful element types

### DIFF
--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -275,7 +275,8 @@ _inner_eltype(x::Number) = typeof(x)
 @inline _init_zero(v::AbstractArray) = float(norm(zero(_inner_eltype(v))))
 
 @inline function LinearAlgebra.norm_sqr(v::StaticArray)
-    return mapreduce(LinearAlgebra.norm_sqr, +, v; init=_init_zero(v))
+    init = float(LinearAlgebra.norm_sqr(zero(_inner_eltype(v))))
+    return mapreduce(LinearAlgebra.norm_sqr, +, v; init=init)
 end
 
 @inline maxabs_nested(a::Number) = abs(a)

--- a/test/unitful.jl
+++ b/test/unitful.jl
@@ -8,4 +8,6 @@ using Unitful
 
     @test norm(SVector(1.0, 2.0)*u"m", 1) == 3.0*u"m"
     @test norm(SVector(0.0, 0.0)*u"nm", 1) == 0.0*u"nm"
+
+    @test norm([SVector(1.0u"m", 2.0u"m")]) == norm([1.0u"m", 2.0u"m"])
 end

--- a/test/unitful.jl
+++ b/test/unitful.jl
@@ -10,4 +10,5 @@ using Unitful
     @test norm(SVector(0.0, 0.0)*u"nm", 1) == 0.0*u"nm"
 
     @test norm([SVector(1.0u"m", 2.0u"m")]) == norm([1.0u"m", 2.0u"m"])
+    @test isapprox(SVector(1.0u"m", 2.0u"m"), SVector(1.1u"m", 2.1u"m"); atol=0.2u"m")
 end


### PR DESCRIPTION
\`norm_sqr\` used \`_init_zero(v)\` as the mapreduce init, which computes \`float(norm(zero(eltype)))\`. For Unitful quantities this has units of e.g. \`m\`, but \`norm_sqr\` produces values with units of \`m²\` — causing \`DimensionError\` when adding.

Fix: use \`norm_sqr(zero(...))\` instead of \`norm(zero(...))\` for the init, so it has the correct squared units.

This fixes \`norm\` for arrays of Unitful SVectors and \`isapprox\` for Unitful SVectors with explicit \`atol\`.