### PR TITLE
Fix pinv for Symmetric/Hermitian wrapped SMatrix

### DIFF
--- a/src/pinv.jl
+++ b/src/pinv.jl
@@ -7,6 +7,8 @@
     return _pinv(A_S, atol, rtol)
 end
 
+@inline pinv(A::LinearAlgebra.HermOrSym{T,<:StaticMatrix}; kwargs...) where T = pinv(similar_type(A)(A); kwargs...)
+
 @inline function _pinv(A::StaticMatrix{m,n,T}, atol::Real, rtol::Real) where T where m where n
     if m == 0 || n == 0
         return similar_type(A, Size(n,m))()

--- a/src/pinv.jl
+++ b/src/pinv.jl
@@ -7,7 +7,7 @@
     return _pinv(A_S, atol, rtol)
 end
 
-@inline pinv(A::LinearAlgebra.HermOrSym{T,<:StaticMatrix}; kwargs...) where T = pinv(similar_type(A)(A); kwargs...)
+@inline pinv(A::LinearAlgebra.HermOrSym{T,<:StaticMatrix}; kwargs...) where T = pinv(convert(similar_type(A), A); kwargs...)
 
 @inline function _pinv(A::StaticMatrix{m,n,T}, atol::Real, rtol::Real) where T where m where n
     if m == 0 || n == 0

--- a/test/pinv.jl
+++ b/test/pinv.jl
@@ -75,4 +75,11 @@ tol = 1e-13
     @test norm(N10*M10*N10 - N10) < tol
     @test N10 isa StaticMatrix
     @test N10 ≈ pinv(Matrix(M10))
+
+    for wrapper in (Symmetric, Hermitian)
+        M_w = wrapper(@SMatrix [1.0 0.5; 0.5 2.0])
+        N_w = pinv(M_w)
+        @test N_w ≈ pinv(Matrix(M_w))
+        @test N_w isa SMatrix{2,2,Float64}
+    end
 end


### PR DESCRIPTION
\`pinv(Symmetric(smatrix))\` failed because the \`pinv\` codepath tried to construct a \`Symmetric\` from the SVD result, which doesn't work.

Fix: unwrap \`HermOrSym\` to the underlying \`StaticMatrix\` before calling \`_pinv\`.