### PR TITLE
Fix zero() for LinearAlgebra wrappers over StaticArrays

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StaticArrays"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "1.9.17"
+version = "1.9.18"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -155,7 +155,6 @@ end
 for WR in (:UpperTriangular, :LowerTriangular, :UnitUpperTriangular, :UnitLowerTriangular, :Transpose, :Adjoint)
     @eval @inline Base.zero(a::$WR{<:Any,<:StaticArray}) = $WR(zero(parent(a)))
 end
-@inline Base.zero(a::Diagonal{<:Any,<:StaticVector}) = Diagonal(zero(parent(a)))
 
 @inline _construct_sametype(a::Type, elements) = a(elements)
 @inline _construct_sametype(a, elements) = typeof(a)(elements)

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -148,6 +148,15 @@ end
 @inline Base.zero(a::SA) where {SA <: StaticArray} = zeros(SA)
 @inline Base.zero(a::Type{SA}) where {SA <: StaticArray} = zeros(SA)
 
+# Wrappers over StaticArray (see StaticMatrixLike definition)
+for WR in (:Symmetric, :Hermitian)
+    @eval @inline Base.zero(a::$WR{<:Any,<:StaticMatrix}) = $WR(zero(parent(a)), _sym_uplo(a))
+end
+for WR in (:UpperTriangular, :LowerTriangular, :UnitUpperTriangular, :UnitLowerTriangular, :Transpose, :Adjoint)
+    @eval @inline Base.zero(a::$WR{<:Any,<:StaticArray}) = $WR(zero(parent(a)))
+end
+@inline Base.zero(a::Diagonal{<:Any,<:StaticVector}) = Diagonal(zero(parent(a)))
+
 @inline _construct_sametype(a::Type, elements) = a(elements)
 @inline _construct_sametype(a, elements) = typeof(a)(elements)
 

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -231,6 +231,15 @@ end
         @test one(RotMat2) == SA[1 0; 0 1]
         # TODO: See comment in _one.
         @test_broken one(RotMat2) isa SMatrix{2,2,Float64}
+
+        # zero preserves wrapper types over StaticArrays
+        let S = SMatrix{2,2}(1.0, 0.5, 0.5, 2.0), v = SVector(1.0, 2.0)
+            for WR in (Symmetric, Hermitian, UpperTriangular, LowerTriangular,
+                       UnitUpperTriangular, UnitLowerTriangular, Transpose, Adjoint)
+                @test @inferred(zero(WR(S))) === WR(zero(S))
+            end
+            @test @inferred(zero(Diagonal(v))) === Diagonal(zero(v))
+        end
     end
 
     @testset "cross()" begin


### PR DESCRIPTION
\`zero(Symmetric(smatrix))\`, \`zero(Diagonal(svector))\`, etc. failed because \`zero\` was not defined for LinearAlgebra wrapper types over StaticArrays.

Fix: add \`zero\` methods for \`Symmetric\`, \`Hermitian\`, \`UpperTriangular\`, \`LowerTriangular\`, \`UnitUpperTriangular\`, \`UnitLowerTriangular\`, \`Transpose\`, \`Adjoint\`, and \`Diagonal\` wrapping StaticArrays.