### PR TITLE
Fix eigen for 3x3 Symmetric{BigFloat} static matrices

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StaticArrays"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "1.9.19"
+version = "1.9.20"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/eigen.jl
+++ b/src/eigen.jl
@@ -286,7 +286,8 @@ end
     b22 = a22
 
     # Givens reflections, B' = G^T * B * G, preserve tridiagonal matrices
-    max_iteration = 2 * (1 + precision(T) - exponent(floatmin(T)))
+    emin = max(exponent(floatmin(T)), -100_000)
+    max_iteration = 2 * (1 + precision(T) - emin)
 
     if abs(b12) <= abs(b01)
         saveB00, saveB01, saveB11 = b00, b01, b11

--- a/src/eigen.jl
+++ b/src/eigen.jl
@@ -286,6 +286,11 @@ end
     b22 = a22
 
     # Givens reflections, B' = G^T * B * G, preserve tridiagonal matrices
+    #
+    # `emin` is clamped because it can overflow for extended-range numbers.  This limit
+    # compiles away for standard fixed-precision types, and does not change `max_iteration`
+    # for them.  It corrects the behavior for `BigFloat`; see
+    # https://github.com/JuliaArrays/StaticArrays.jl/issues/1349
     emin = max(exponent(floatmin(T)), -100_000)
     max_iteration = 2 * (1 + precision(T) - emin)
 

--- a/test/eigen.jl
+++ b/test/eigen.jl
@@ -329,4 +329,21 @@ using StaticArrays, Test, LinearAlgebra
         λ, V = eigen(A)
         @test A * V ≈ V * Diagonal(λ)
     end
+
+    @testset "3×3 BigFloat" begin
+        # The iteration bound used to overflow `Int64` for `BigFloat`, so the QR sweep
+        # never ran and `eigen` returned its un-iterated intermediate (#1349).
+        m = BigFloat[4 1 2; 1 5 3; 2 3 6]
+        A = Symmetric(SMatrix{3,3}(m))
+        λ, V = eigen(A)
+        @test A * V ≈ V * Diagonal(λ)
+        @test λ ≈ eigvals(A)
+        @test λ ≈ eigvals(Symmetric(Float64.(m)))
+        # the overflow happened at every precision, so check a small one too
+        setprecision(BigFloat, 24) do
+            B = Symmetric(SMatrix{3,3}(BigFloat[4 1 2; 1 5 3; 2 3 6]))
+            μ, W = eigen(B)
+            @test B * W ≈ W * Diagonal(μ)
+        end
+    end
 end


### PR DESCRIPTION
Claude did this, including writing the following (I'm on vacation).  But I've reviewed the code and the following text and it looks right to me.  Note that the new lines will compile away for the important cases of `Float*` and probably other fixed-precision types (not `BigFloat`, but I don't think this is a bottleneck for it).

---

Fixes #1349.

The iteration bound in the 3×3 symmetric solver overflows `Int64` for `BigFloat`:

```julia
max_iteration = 2 * (1 + precision(T) - exponent(floatmin(T)))
```

MPFR's minimum exponent is exactly `-2^62`, so `2 * 2^62` is exactly `typemax(Int64) + 1` and the
expression wraps to a large negative number. Both loops that use it (`src/eigen.jl:293` and `:339`)
then run `for iteration in 1:max_iteration` over an empty range, so the QR sweep never executes and
the routine returns its un-iterated intermediate as though it had converged.

Because it clears the limit by only `2 * (1 + precision(T)) + 1`, this happens at *every* `BigFloat`
precision — 515 over at the default 256 bits, and still 7 over at 2 bits — which is why reducing the
precision doesn't avoid it.

The failure is silent, and `eigen` ends up disagreeing with `eigvals` (which uses a different,
closed-form path and is correct):

```julia
julia> setprecision(BigFloat, 64);

julia> A = Symmetric(SMatrix{3,3}(BigFloat[4 1 2; 1 5 3; 2 3 6]));

julia> eigvals(A)               # correct
3-element SVector{3, BigFloat} with indices SOneTo(3):
 2.1943971674224085548
 3.38677015660754922484
 9.41883267597004221992

julia> eigen(A).values          # wrong
3-element SVector{3, BigFloat} with indices SOneTo(3):
 3.38461538461538461527
 5.61538461538461538408
 6.0
```

With this change the two agree, and `norm(A*V - V*Diagonal(λ))` drops from about `5.1` to about
`17 * eps(BigFloat)`, in line with the other element types.

### The fix

```julia
emin = max(exponent(floatmin(T)), -100_000)
max_iteration = 2 * (1 + precision(T) - emin)
```

A few notes on why this is safe:

* **Hardware types are unaffected.** `-100_000` is below the `floatmin` exponent of every hardware
  type and of `Float128` (`-16382`), so their bounds are unchanged: still 52, 302 and 2152 for
  `Float16`, `Float32` and `Float64`.
* **It costs nothing at run time.** For concrete hardware types the expression constant-folds
  exactly as before — `code_typed` returns the literal `2152` for `Float64` both with and without
  the change, and a 3×3 `Float64` `eigen` benchmarks the same (~387 ns, 0 allocations). It doesn't
  fold for `BigFloat`, since `precision(BigFloat)` is a runtime global, but that was already true;
  the change adds one integer `max` to a path that is about to do MPFR arithmetic.
* **The bound is only a safety valve.** The loop exits as soon as it actually converges — about 6
  iterations here, independent of precision — so nothing relies on the larger bound. Raising the cap
  to `10^7` still returns in ~370 µs.

The specific constant is arbitrary.

### Tests

Adds a `3×3 BigFloat` testset covering the reconstruction, agreement with `eigvals`, agreement with
the `Float64` answer, and a reduced precision. All four assertions fail on `master` and pass here.
